### PR TITLE
feat: Auto-fetch remotes in status_report [TASK-021]

### DIFF
--- a/.agent/scripts/status_report.sh
+++ b/.agent/scripts/status_report.sh
@@ -27,6 +27,7 @@ echo "## Root Repository"
 cd "$ROOT_DIR"
 if command -v git &> /dev/null; then
     # Check for modifications
+    git fetch -q
     if [ -n "$(git status --porcelain)" ]; then
         echo "- **Status**: ⚠️ Modified"
         echo "- **Branch**: $(git branch --show-current)"
@@ -65,6 +66,9 @@ for ws_dir in "$WORKSPACES_DIR"/*; do
         #  M file
         # ?? file
         
+        # Fetch updates
+        vcs custom --git --args fetch -q > /dev/null
+
         raw_output=$(vcs custom --git --args status --porcelain -b)
         
         clean_count=0


### PR DESCRIPTION
## Description
Updates the `status_report.sh` script to automatically fetch remote changes for both the root repository and all overlay repositories before checking their status.

## Rationale
Ensures the status report accurately reflects "Ahead/Behind" metrics relative to the current state of the remote, rather than the cached local state.

## Verification
- Verified by running the workflow locally.
- Confirmed that `project11` status updated from "Behind 2" (cached) to "Behind 8" (actual) after the script ran.