### PR TITLE
doc: Enforce 'Closes #ID' in PR Guidelines

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -48,6 +48,7 @@ This configures git in:
 1.  **Check if a GitHub Issue exists** for your current objective.
 2.  If not, **ask the user**: *"Should I open an issue to track this?"*
 3.  Use the issue number in your branch name: `feature/ISSUE-<number>-<description>`.
+4.  **Note**: When you submit the PR, you MUST include `Closes #<issue-number>` in the description.
 
 ## 5. Create a Feature Branch (30 sec)
 

--- a/.agent/PR_GUIDELINES.md
+++ b/.agent/PR_GUIDELINES.md
@@ -11,6 +11,11 @@
 *   You must create a feature branch: \`git checkout -b feature/<issue-number>-<description>\`.
 *   **Reason**: Direct commits to main bypass CI/CD and Code Review, breaking the "stable main" contract.
 
+## Issue Linking (Mandatory)
+Every Pull Request MUST explicitly link to the issue it resolves using GitHub's keyword syntax.
+*   **Requirement**: Include `Closes #<issue-number>` (or `Fixes #...`) in the PR description body.
+*   **Why**: This ensures the issue is automatically closed when the PR is merged, keeping the backlog clean and status accurate.
+
 ## Multi-Agent Concurrency Strategy
 To prevent conflicts when multiple agents/users work in the same repo:
 1.  **Sync First**: Always pull the latest `main` before branching.

--- a/.agent/workflows/dev/submit-pr.md
+++ b/.agent/workflows/dev/submit-pr.md
@@ -28,12 +28,13 @@ Use this workflow when you are ready to submit your changes for review.
     -   **Option A: GitHub MCP (Preferred)**
         -   Use `github.create_pull_request`.
         -   Title: `feat: <description>`
-        -   Body: Description of changes + "Closes #<issue-id>" if applicable.
+        -   Body: Description of changes + "Closes #<issue-id>" (Mandatory).
     -   **Option B: `gh` CLI**
-        -   Run: `gh pr create --fill`
+        -   Run: `gh pr create --title "feat: <description>" --body "Closes #<issue-id> description of changes..."`
     -   **Option C: Manual**
         -   The `git push` command usually outputs a URL to create a PR.
         -   **Action**: Display that URL to the user.
+        -   **Requirement**: Remind user to add "Closes #<issue-id>" to the description.
 
 6.  **Request Review**
     -   If the repo is configured, comment `/copilot review` on the PR (if supported) or assign the relevant reviewers.


### PR DESCRIPTION
This PR updates the Agent Onboarding, PR Guidelines, and Submit PR workflow to explicitly require linking PRs to issues using 'Closes #ID'.

Closes #53