### PR TITLE
fix: simplify .gitignore to ignore entire layers/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,7 @@
-# Ignore ROS2 layers because they are managed by vcs and .repos files
-# Main builds live in layers/main/
-layers/main/*/src/
-layers/main/*/build/
-layers/main/*/install/
-layers/main/*/log/
-
-# Ignore layer worktrees (created dynamically for task isolation)
-# Each worktree contains target layer + symlinks to main
-layers/worktrees/
+# Ignore entire layers directory (managed by vcstool)
+# All ROS2 code is pulled via vcstool from .repos files
+# Nothing in layers/ is tracked by git
+layers/
 
 # Ignore workspace worktrees (for infrastructure work)
 .workspace-worktrees/


### PR DESCRIPTION
Fixes worktree removal false positive warning.

## Problem
`worktree_remove.sh` warns about "uncommitted changes" even when workspace worktrees are clean, requiring unnecessary `--force` flag.

**Root Cause**: Workspace worktrees create `layers/` symlink pointing back to main. Git sees this as untracked file (`?? layers/`).

## Solution
Simplify `.gitignore` to ignore entire `layers/` directory (replacing 6 granular rules with 1 simple rule).

**Validation**: Nothing in `layers/` is tracked by git—all ROS2 code managed by vcstool.

## Testing
```bash
# Before: layers/ shown as untracked in worktrees
$ git status --porcelain
?? layers/

# After: clean status
$ git status --porcelain
# (empty)
```

Closes #127

---
**🤖 Created-By**: Copilot CLI Agent (Claude Sonnet 4.5)