### PR TITLE
Fix `make sync`: Update path from workspaces/ to layers/main/

### DIFF
--- a/.agent/scripts/sync_repos.py
+++ b/.agent/scripts/sync_repos.py
@@ -131,7 +131,7 @@ def main():
     for repo in repos:
         # Determine workspace directory from source file (e.g. core.repos -> core_ws)
         ws_name = repo['source_file'].replace('.repos', '_ws')
-        candidate_path = root_dir / "workspaces" / ws_name / "src" / repo['name']
+        candidate_path = root_dir / "layers" / "main" / ws_name / "src" / repo['name']
 
         repo_path = None
         tried_paths = [str(candidate_path)]


### PR DESCRIPTION
## Summary

Fixes #138 - `make sync` was broken and skipping all overlay repositories.

## Problem

The `sync_repos.py` script was looking for repositories in the old `workspaces/` directory structure, but the actual workspace layout uses `layers/main/*_ws/`. This caused all 21 overlay repositories to be skipped with "could not resolve repository path" errors.

## Solution

Updated line 134 in `.agent/scripts/sync_repos.py`:
```python
# FROM
candidate_path = root_dir / "workspaces" / ws_name / "src" / repo['name']

# TO
candidate_path = root_dir / "layers" / "main" / ws_name / "src" / repo['name']
```

## Testing

Tested in main workspace (worktrees don't have `layers/` since it's gitignored):
- Before: All repos skipped
- After: All repos sync successfully

## Impact

- ✅ Fixes broken core functionality
- ✅ No breaking changes
- ✅ Minimal code change (1 line)

---
**🤖 Authored-By**: `Copilot CLI Agent` (Claude Sonnet 4.5)