### PR TITLE
Auto-symlink layers/ in workspace worktrees

### DIFF
--- a/.agent/hooks/README.md
+++ b/.agent/hooks/README.md
@@ -18,9 +18,11 @@ This directory contains custom git hooks for the ROS2 Agent Workspace.
 
 **Exit codes**:
 - `0` - Success or skipped (not a workspace worktree)
-- `1` - Error creating symlink
+- `1` - Error: `../../layers` directory missing or failed to create symlink
 
-**Installation**: Symlinked from `.git/hooks/post-checkout` to `.agent/hooks/post-checkout`
+**Installation**:
+- Make the hook executable: `chmod +x .agent/hooks/post-checkout`
+- Symlink into your local repo: `ln -s ../../.agent/hooks/post-checkout .git/hooks/post-checkout`
 
 **Related**: Issue #142, WORKTREE_GUIDE.md
 

--- a/.agent/hooks/post-checkout
+++ b/.agent/hooks/post-checkout
@@ -61,12 +61,12 @@ fi
 if [[ ! -d "../../layers" ]]; then
     echo "⚠️  Warning: Cannot find ../../layers directory"
     echo "   Skipping auto-symlink."
-    exit 1
+    exit 0
 fi
 
 # Create the symlink
 echo "🔗 Auto-symlinking layers/ directory for workspace worktree..."
-if ln -s ../../layers layers 2>/dev/null; then
+if ln -s ../../layers layers; then
     echo "   ✅ Created: layers -> ../../layers"
     echo ""
     echo "   This worktree now has access to all ROS2 workspace layers."


### PR DESCRIPTION
Fixes #142

## Summary
Implements automatic symlinking of `layers/` directory to workspace worktrees via git `post-checkout` hook.

## Changes
- **New**: `.agent/hooks/post-checkout` - Git hook script that auto-creates symlinks
- **Updated**: `.agent/hooks/README.md` - Documentation for the new hook

## How It Works
1. Hook triggers after `git worktree add .workspace-worktrees/issue-N/`
2. Detects workspace worktree by path pattern
3. Automatically creates `layers -> ../../layers` symlink
4. Enables full workspace functionality (`make sync`, `make build`, etc.)

## Installation
Once merged, the hook will be active for all new workspace worktrees.

**Note**: The hook symlink (`.git/hooks/post-checkout`) should be created manually or via a setup script. For now, run:
```bash
cd .git/hooks && ln -s ../../.agent/hooks/post-checkout post-checkout
```

## Testing
After merge, test by creating a new workspace worktree:
```bash
git worktree add .workspace-worktrees/test-hook -b test/hook-verification
cd .workspace-worktrees/test-hook
ls -la layers  # Should show: layers -> ../../layers
```

## Benefits
- ✅ Eliminates manual `ln -s` step after creating worktrees
- ✅ Prevents "layers not found" errors
- ✅ Improves developer experience
- ✅ Enables smooth multi-agent workflows

---
**AI Signature**  
Agent: Copilot CLI Agent  
Model: Unknown Model  
Issue: #142