### PR TITLE
Fix layer worktree slug to use package repo name

### DIFF
--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -163,10 +163,11 @@ if [ -z "$REPO_SLUG" ]; then
         fi
     fi
 
-    # Fallback: detect from workspace repo remote
+    # Fallback: detect from workspace repo remote (use -C to ensure we
+    # always query the workspace repo, regardless of the caller's cwd)
     if [ -z "$REMOTE_URL" ]; then
-        if git remote get-url origin &>/dev/null; then
-            REMOTE_URL=$(git remote get-url origin)
+        if git -C "$ROOT_DIR" remote get-url origin &>/dev/null; then
+            REMOTE_URL=$(git -C "$ROOT_DIR" remote get-url origin)
         fi
     fi
 


### PR DESCRIPTION
## Summary

- For layer worktrees, auto-detect the repo slug from the first `--packages` entry's git remote instead of always using the workspace repo
- Produces paths like `issue-unh_marine_autonomy-48` instead of `issue-workspace-48`
- Workspace worktrees unchanged (still use workspace repo remote)
- `--repo-slug` override still takes precedence when provided

## How it works

The script now checks `layers/main/{layer}_ws/src/{first_package}` for a git remote before falling back to the workspace remote. Since the issue is typically filed in the same repo as the package being modified, this correctly identifies the issue's source repo.

## Test Plan

- [ ] `--type layer --layer core --packages unh_marine_autonomy` produces `issue-unh_marine_autonomy-{N}`
- [ ] `--type workspace` still produces `issue-workspace-{N}`
- [ ] `--repo-slug custom` overrides auto-detection for both types
- [ ] Fallback to workspace slug if package has no git remote
- [ ] `worktree_enter.sh` and `worktree_remove.sh` find worktrees with new naming (glob pattern `issue-*-{N}`)

Closes #186

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
