### PR TITLE
fix: stop creating workspace git worktree for layer type

### DIFF
--- a/.agent/scripts/_worktree_helpers.sh
+++ b/.agent/scripts/_worktree_helpers.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# .agent/scripts/_worktree_helpers.sh
+# Shared helper functions for worktree scripts
+#
+# Source this file from other worktree scripts:
+#   source "$SCRIPT_DIR/_worktree_helpers.sh"
+
+# Get branch name from the first inner package git worktree in a layer worktree.
+# Returns empty string if no inner git worktree is found.
+# Usage: branch=$(wt_layer_branch "$worktree_dir")
+wt_layer_branch() {
+    local worktree_dir="$1"
+
+    for ws_dir in "$worktree_dir"/*_ws; do
+        [ -d "$ws_dir" ] || continue
+        [ -L "$ws_dir" ] && continue  # skip symlinked layers
+
+        local src_dir="$ws_dir/src"
+        [ -d "$src_dir" ] || continue
+
+        for pkg_dir in "$src_dir"/*; do
+            [ -d "$pkg_dir" ] || continue
+            [ -L "$pkg_dir" ] && continue  # skip symlinked packages
+
+            if git -C "$pkg_dir" rev-parse --git-dir &>/dev/null; then
+                local branch
+                branch=$(git -C "$pkg_dir" branch --show-current 2>/dev/null)
+                if [ -n "$branch" ]; then
+                    echo "$branch"
+                    return 0
+                fi
+            fi
+        done
+    done
+
+    return 1
+}
+
+# Check if a layer worktree has uncommitted changes in any inner package git worktree.
+# Ignores symlinked layers/packages and infrastructure directories.
+# Returns 0 (true) if dirty, 1 (false) if clean.
+# Usage: if wt_layer_is_dirty "$worktree_dir"; then ...
+wt_layer_is_dirty() {
+    local worktree_dir="$1"
+
+    for ws_dir in "$worktree_dir"/*_ws; do
+        [ -d "$ws_dir" ] || continue
+        [ -L "$ws_dir" ] && continue  # skip symlinked layers
+
+        local src_dir="$ws_dir/src"
+        [ -d "$src_dir" ] || continue
+
+        for pkg_dir in "$src_dir"/*; do
+            [ -d "$pkg_dir" ] || continue
+            [ -L "$pkg_dir" ] && continue  # skip symlinked packages
+
+            if git -C "$pkg_dir" rev-parse --git-dir &>/dev/null; then
+                if [ -n "$(git -C "$pkg_dir" status --porcelain 2>/dev/null)" ]; then
+                    return 0  # dirty
+                fi
+            fi
+        done
+    done
+
+    return 1  # clean
+}

--- a/.agent/scripts/agent
+++ b/.agent/scripts/agent
@@ -36,6 +36,8 @@ OPTIONS:
     --layer <name>        Specify layer for ROS package work
                           (core, platforms, sensors, simulation, ui, underlay)
                           Omit for infrastructure/workspace work
+    --packages <pkg,...>  Package(s) to modify (required with --layer)
+                          Comma-separated list for multiple packages
     --help, -h            Show this help message
 
 EXAMPLES:
@@ -43,7 +45,7 @@ EXAMPLES:
     agent start-task 125
 
     # ROS package development
-    agent start-task 42 --layer core
+    agent start-task 42 --layer core --packages unh_marine_autonomy
 
 ENFORCEMENT:
     This wrapper is the ONLY approved way for agents to start work.
@@ -62,12 +64,17 @@ start_task() {
     shift
 
     local layer=""
+    local packages=""
 
     # Parse options
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --layer)
                 layer="$2"
+                shift 2
+                ;;
+            --packages)
+                packages="$2"
                 shift 2
                 ;;
             *)
@@ -101,7 +108,11 @@ start_task() {
         echo ""
 
         # Create layer worktree
-        "$SCRIPT_DIR/worktree_create.sh" --issue "$issue_num" --type layer --layer "$layer"
+        local pkg_args=()
+        if [ -n "$packages" ]; then
+            pkg_args=(--packages "$packages")
+        fi
+        "$SCRIPT_DIR/worktree_create.sh" --issue "$issue_num" --type layer --layer "$layer" "${pkg_args[@]}"
     else
         echo "Type:  Workspace worktree (infrastructure)"
         echo ""
@@ -119,12 +130,7 @@ start_task() {
     echo "  1. Enter worktree:"
     echo "     source .agent/scripts/worktree_enter.sh --issue $issue_num"
     echo ""
-    echo "  2. Or manually:"
-    if [ -n "$layer" ]; then
-        echo "     cd layers/worktrees/issue-$issue_num"
-    else
-        echo "     cd .workspace-worktrees/issue-$issue_num"
-    fi
+    echo "  2. Or use worktree_enter.sh (recommended — it also sources the environment)"
     echo ""
     echo "  3. When done:"
     echo "     .agent/scripts/worktree_remove.sh --issue $issue_num"

--- a/.agent/scripts/worktree_enter.sh
+++ b/.agent/scripts/worktree_enter.sh
@@ -18,6 +18,8 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
+source "$SCRIPT_DIR/_worktree_helpers.sh"
+
 ISSUE_NUM=""
 REPO_SLUG=""
 
@@ -188,7 +190,11 @@ if [ "$WORKTREE_TYPE" == "layer" ]; then
 fi
 
 # Show current branch
-CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+if [ "$WORKTREE_TYPE" == "layer" ]; then
+    CURRENT_BRANCH=$(wt_layer_branch "$WORKTREE_DIR" 2>/dev/null || echo "")
+else
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+fi
 echo ""
 echo "✅ Now in worktree for issue #$ISSUE_NUM"
 echo "   Branch: $CURRENT_BRANCH"


### PR DESCRIPTION
## Summary

- **Fixes the core bug**: `worktree_create.sh --type layer` no longer creates a workspace-level git worktree. Layer worktrees are now plain directories containing per-package git worktrees, eliminating the spurious branch conflict reported in #193.
- **Updates all 4 companion scripts** to handle the new layout: `worktree_list.sh` (directory scan discovery), `worktree_remove.sh` (`rm -rf` instead of `git worktree remove`), `worktree_enter.sh` (branch from inner package), and the `agent` wrapper (`--packages` forwarding).
- **Adds `_worktree_helpers.sh`** shared library with `wt_layer_branch()` and `wt_layer_is_dirty()` used by list/remove/enter scripts.

## Changes

| File | Change |
|------|--------|
| `worktree_create.sh` | Wrap `git worktree add` in workspace-only block; use `mkdir -p` for layer type; move branch check inside workspace block |
| `worktree_list.sh` | Add directory scan of `layers/worktrees/` for layer worktrees; use helpers for branch/status |
| `worktree_remove.sh` | Use `wt_layer_branch` for branch detection; remove Phase 2 workspace-level git status check; use `rm -rf` for layer type |
| `worktree_enter.sh` | Use `wt_layer_branch` for branch display |
| `agent` | Accept and forward `--packages` option; fix misleading manual cd path |
| `_worktree_helpers.sh` | **New** — shared `wt_layer_branch()` and `wt_layer_is_dirty()` |

## Test plan

- [x] Create layer worktree — confirms no workspace-level git worktree, inner package worktree exists
- [x] List worktrees — layer worktree appears with correct branch and status
- [x] Enter worktree — shows correct branch
- [x] Remove worktree — clean removal, no errors
- [x] Workspace worktree regression — create/list/enter/remove still work
- [x] `agent` wrapper — `--packages` forwarded correctly
- [x] All pre-commit hooks pass (including shellcheck)

Closes #193

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
