### PR TITLE
docs: fix CLAUDE.md worktree docs for project repos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,11 +23,11 @@ source .agent/scripts/set_git_identity_env.sh "Claude Code Agent" "roland+claude
 
 Every task must use an isolated worktree — never work in the main tree or default branches.
 
-**Project repos**: Directories under `layers/main/*_ws/src/` are independent git repos
-(e.g., `unh_marine_autonomy`), each containing one or more ROS 2 packages. Layer
+**Project repos**: Directories under `layers/main/*_ws/src/` are typically independent git
+repos (e.g., `unh_marine_autonomy`), each containing one or more ROS 2 packages. Layer
 worktrees create git worktrees *inside* these project repos — you commit and push to the
-project repo, not the workspace repo. The `--packages` flag takes these directory names
-(not individual ROS package names).
+project repo, not the workspace repo. Non-git directories are symlinked instead.
+The `--packages` flag takes these directory names (not individual ROS package names).
 
 ```bash
 # Workspace infrastructure work (docs, .agent/, configs)
@@ -60,8 +60,9 @@ and reference it in PRs with `Closes #<N>`.
 Issues and PRs live in whichever repo owns the code being changed — check the project
 repo (e.g., `rolker/unh_marine_autonomy`), not just the workspace repo.
 
-**Trivial fixes** (typos, minor doc corrections) don't need a new issue but must still
-use an existing worktree — never commit directly to default branches.
+**Trivial fixes** (typos, minor doc corrections) don't need a dedicated issue — use the
+current task's worktree or create a quick issue for a new one.
+Never commit directly to default branches.
 
 ## AI Signature (Required on all GitHub Issues/PRs/Comments)
 


### PR DESCRIPTION
## Summary

Fixes CLAUDE.md so agents working on project repos (under `layers/`) use the worktree scripts correctly instead of bypassing them with raw `git worktree` commands.

- **Worktree Workflow**: Added "Project repos" concept, fixed broken layer example (added required `--packages` flag), added `cd` guidance showing where to work/commit, multi-package example, and link to WORKTREE_GUIDE.md
- **Issue-First Policy**: Added guidance that issues/PRs live in project repos; closed loophole allowing direct commits to default branches
- **Layered Architecture**: Made generic (not UNH-specific) and surfaced the project repo concept with `src/` explanation

## Root cause

A fresh agent on PR #58 in `unh_marine_autonomy` bypassed worktree scripts entirely because CLAUDE.md didn't explain that layer worktrees work with project repos, had an invalid example (missing `--packages`), and never mentioned "project repos."

## Test plan

- [x] All pre-commit hooks pass
- [x] Every layer worktree example includes `--packages`
- [x] "Project repos" is defined before the agent needs to use the concept
- [x] No exceptions allow working on default branches
- [x] Example commands validated against `worktree_create.sh --help`

Closes #196

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
