### PR TITLE
feat: add per-project AGENTS.md convention for agent onboarding

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -51,4 +51,4 @@ source .agent/scripts/worktree_enter.sh --issue <N>
 - [`WORKFORCE_PROTOCOL.md`](WORKFORCE_PROTOCOL.md) — Multi-agent coordination
 - [`WORKTREE_GUIDE.md`](WORKTREE_GUIDE.md) — Worktree patterns
 - [`../ARCHITECTURE.md`](../ARCHITECTURE.md) — System design
-- Project repo `AGENTS.md` -- Per-repo agent guide: package inventory, code layout, pitfalls (if present)
+- Project repo `.agents/README.md` — Per-repo agent guide: package inventory, code layout, pitfalls (if present)

--- a/.agent/AI_RULES.md
+++ b/.agent/AI_RULES.md
@@ -51,5 +51,5 @@ rules plus framework-specific guidance.
 - [`WORKFORCE_PROTOCOL.md`](WORKFORCE_PROTOCOL.md) — Multi-agent coordination
 - [`WORKTREE_GUIDE.md`](WORKTREE_GUIDE.md) — Detailed worktree patterns
 - [`.agent/knowledge/`](knowledge/) — ROS 2 patterns and CLI best practices
-- Project repo `AGENTS.md` -- Per-repo agent guide: package inventory, code layout, pitfalls (if present)
+- Project repo `.agents/README.md` — Per-repo agent guide: package inventory, code layout, pitfalls (if present)
 - [`.agent/project_knowledge/`](project_knowledge/) — Project-specific conventions and architecture (symlink, may not exist)

--- a/.agent/instructions/gemini-cli.instructions.md
+++ b/.agent/instructions/gemini-cli.instructions.md
@@ -96,6 +96,19 @@ make lint                                        # Lint + hooks (uses venv pre-c
 - Use the verification workflow in [`../knowledge/documentation_verification.md`](../knowledge/documentation_verification.md).
 - Use the documentation template in [`../templates/package_documentation.md`](../templates/package_documentation.md).
 
+## Project-Level Guidance
+
+When working in a project repository (`layers/main/<layer>_ws/src/<project_repo>/`),
+check for `.agents/README.md` at the repo root. If present, read it before making changes —
+it contains the package inventory, code layout, architecture overview, and repo-specific
+pitfalls documented by previous agents.
+
+If no `.agents/README.md` exists, note this gap. To create one, use the template at
+[`../templates/project_agents_guide.md`](../templates/project_agents_guide.md)
+and follow the [documentation verification workflow](../knowledge/documentation_verification.md).
+This should be a dedicated task with its own issue in the project repo, not a side-effect
+of unrelated work.
+
 ## Workspace Cleanliness
 
 - Keep repo root and `layers/*/src/` clean — no temp files, build artifacts, or logs.
@@ -147,6 +160,5 @@ layers/main/
 - [`../AI_IDENTITY_STRATEGY.md`](../AI_IDENTITY_STRATEGY.md) — Multi-framework identity
 - [`../WORKFORCE_PROTOCOL.md`](../WORKFORCE_PROTOCOL.md) — Multi-agent coordination
 - [`../knowledge/`](../knowledge/) — ROS 2 development patterns and CLI best practices
-- Project repo `AGENTS.md` -- Per-repo agent guide: package inventory, code layout, pitfalls (if present)
 - [`../project_knowledge/`](../project_knowledge/) — Project-specific conventions and architecture (symlink, may not exist)
 - [`../templates/`](../templates/) — Issue and test templates

--- a/.agent/knowledge/README.md
+++ b/.agent/knowledge/README.md
@@ -20,7 +20,7 @@ repo does not provide an `agent_context/` directory.
 
 ## Project-Level Agent Guides
 
-Project repositories may contain an `AGENTS.md` at their root with repo-specific
+Project repositories may contain a `.agents/README.md` at their root with repo-specific
 guidance for agents. To create one, use the template at
 [`../templates/project_agents_guide.md`](../templates/project_agents_guide.md).
 

--- a/.agent/templates/project_agents_guide.md
+++ b/.agent/templates/project_agents_guide.md
@@ -32,9 +32,9 @@ Link to `docs/` for details if available.
 
 Prioritized list for agents new to this repo:
 
-1. `path/to/entry_point` -- Main node or launch file
-2. `path/to/config.yaml` -- Default parameters
-3. `path/to/interfaces/` -- Custom message/service/action definitions
+1. `path/to/entry_point` — Main node or launch file
+2. `path/to/config.yaml` — Default parameters
+3. `path/to/interfaces/` — Custom message/service/action definitions
 
 ## Build & Test
 
@@ -62,8 +62,8 @@ Known build issues or special requirements:
 
 ## Instructions for Use
 
-1. Copy this template to `AGENTS.md` at the project repo root.
-2. Fill every section by reading actual source code -- never assume.
+1. Copy this template to `.agents/README.md` at the project repo root.
+2. Fill every section by reading actual source code — never assume.
 3. Follow the verification workflow in
    [`.agent/knowledge/documentation_verification.md`](../../.agent/knowledge/documentation_verification.md).
 4. **Omit** any section that does not apply (e.g., if there are no cross-layer

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,6 +96,19 @@ make lint                                        # Lint + hooks (uses venv pre-c
 - Use the verification workflow in [`../.agent/knowledge/documentation_verification.md`](../.agent/knowledge/documentation_verification.md).
 - Use the documentation template in [`../.agent/templates/package_documentation.md`](../.agent/templates/package_documentation.md).
 
+## Project-Level Guidance
+
+When working in a project repository (`layers/main/<layer>_ws/src/<project_repo>/`),
+check for `.agents/README.md` at the repo root. If present, read it before making changes —
+it contains the package inventory, code layout, architecture overview, and repo-specific
+pitfalls documented by previous agents.
+
+If no `.agents/README.md` exists, note this gap. To create one, use the template at
+[`../.agent/templates/project_agents_guide.md`](../.agent/templates/project_agents_guide.md)
+and follow the [documentation verification workflow](../.agent/knowledge/documentation_verification.md).
+This should be a dedicated task with its own issue in the project repo, not a side-effect
+of unrelated work.
+
 ## Workspace Cleanliness
 
 - Keep repo root and `layers/*/src/` clean — no temp files, build artifacts, or logs.
@@ -148,6 +161,5 @@ layers/main/
 - [`.agent/AI_IDENTITY_STRATEGY.md`](../.agent/AI_IDENTITY_STRATEGY.md) — Multi-framework identity
 - [`.agent/WORKFORCE_PROTOCOL.md`](../.agent/WORKFORCE_PROTOCOL.md) — Multi-agent coordination
 - [`.agent/knowledge/`](../.agent/knowledge/) — ROS 2 development patterns and CLI best practices
-- Project repo `AGENTS.md` -- Per-repo agent guide: package inventory, code layout, pitfalls (if present)
 - [`.agent/project_knowledge/`](../.agent/project_knowledge/) — Project-specific conventions and architecture (symlink, may not exist)
 - [`.agent/templates/`](../.agent/templates/) — Issue and test templates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,11 +119,11 @@ make lint                                        # Lint + hooks (uses venv pre-c
 ## Project-Level Guidance
 
 When working in a project repository (`layers/main/<layer>_ws/src/<project_repo>/`),
-check for an `AGENTS.md` at the repo root. If present, read it before making changes --
+check for `.agents/README.md` at the repo root. If present, read it before making changes —
 it contains the package inventory, code layout, architecture overview, and repo-specific
 pitfalls documented by previous agents.
 
-If no `AGENTS.md` exists, note this gap. To create one, use the template at
+If no `.agents/README.md` exists, note this gap. To create one, use the template at
 [`.agent/templates/project_agents_guide.md`](.agent/templates/project_agents_guide.md)
 and follow the [documentation verification workflow](.agent/knowledge/documentation_verification.md).
 This should be a dedicated task with its own issue in the project repo, not a side-effect


### PR DESCRIPTION
## Summary

- Add `.agent/templates/project_agents_guide.md` template for per-project `AGENTS.md` files with package inventory, code layout, architecture overview, and repo-specific pitfalls
- Update all five instruction files (CLAUDE.md, copilot-instructions.md, gemini-cli.instructions.md, AI_RULES.md, AGENT_ONBOARDING.md) to reference `AGENTS.md` when entering a project repo
- Add "Project-Level Agent Guides" subsection to `.agent/knowledge/README.md`

## Test plan

- [x] `make lint` passes
- [ ] Verify template follows same conventions as `package_documentation.md` (verification checklist, omit-empty-sections rule)
- [ ] Verify all five instruction files reference `AGENTS.md`
- [ ] Verify `knowledge/README.md` links the template
- [ ] Verify new CLAUDE.md section is between "Documentation Accuracy" and "Workspace Cleanliness"

Closes #219

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
