### PR TITLE
fix: use .repos branch for worktree start-point and draft PR base

### DIFF
--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -418,7 +418,7 @@ EOF
                             git fetch --quiet origin "$REPOS_BRANCH" 2>/dev/null || true
                         fi
 
-                        # Prefer the issue branch for this package: local first, then remote, then new
+                        # Prefer the issue branch for this package: local first, then remote, then new from .repos branch, then new from HEAD
                         if git worktree add "$WORKTREE_PKG_PATH" "$BRANCH_NAME" 2>/dev/null; then
                             echo "      ✓ Worktree created from existing local branch: $BRANCH_NAME"
                         elif fetch_remote_branch "$pkg_path" "$BRANCH_NAME" && \


### PR DESCRIPTION
## Summary

- Add `resolve_repos_branch()` helper that queries `lib/workspace.py`'s `find_repo_version()` to determine the `.repos`-configured branch for a package
- When creating a new feature branch via `git worktree add -b`, use `origin/<repos_branch>` as the start-point before falling back to implicit HEAD
- When creating draft PRs via `gh pr create`, pass `--base <repos_branch>` so PRs target the correct upstream branch (e.g. `jazzy`) instead of the GitHub default (e.g. `ros2`)

## Test plan

- [x] `resolve_repos_branch ros2launch_gui` returns `jazzy`
- [x] `resolve_repos_branch nonexistent_pkg` returns empty (no error)
- [x] `bash -n` syntax check passes
- [x] shellcheck passes
- [ ] End-to-end: create a test worktree with `--draft-pr` for a package with a non-default `.repos` branch and verify the PR targets the correct base

Closes #223

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
