### PR TITLE
docs: add first-mention GitHub link rule for agent summaries

### DIFF
--- a/.agent/AI_RULES.md
+++ b/.agent/AI_RULES.md
@@ -36,10 +36,13 @@ rules plus framework-specific guidance.
 10. **Never document from assumptions** — verify every parameter, topic, service, and message type by reading source code. See [`knowledge/documentation_verification.md`](knowledge/documentation_verification.md).
 11. **Link GitHub references on every mention** — in summaries/reports, include a clickable URL for each issue, PR, commit, or repository. Use markdown links where supported; otherwise include the full URL inline or on the next line. This is a link rule only, not a required summary template.
 
+Workspace repo: `rolker/ros2_agent_workspace`. For project repos, derive
+the slug from the git remote (`git remote get-url origin`).
+
 Examples:
 - `[Issue #129: Clickable GitHub references](https://github.com/rolker/ros2_agent_workspace/issues/129)`
 - `PR #68: https://github.com/rolker/unh_marine_autonomy/pull/68`
-- `[e8c32bc](https://github.com/rolker/unh_marine_autonomy/commit/e8c32bc)`
+- `[e8c32bc](https://github.com/rolker/unh_marine_autonomy/commit/<full-sha>)`
 
 ## Key Scripts
 

--- a/.agent/instructions/gemini-cli.instructions.md
+++ b/.agent/instructions/gemini-cli.instructions.md
@@ -80,12 +80,14 @@ rm "$BODY_FILE"
 
 - When referencing any GitHub issue, PR, commit, or repository in summaries/reports, include a clickable URL on every mention.
 - Use markdown links where supported; in plain terminal output include a full URL inline or on the next line.
+- Workspace repo: `rolker/ros2_agent_workspace`. For project repos, derive
+  the slug from the git remote (`git remote get-url origin`).
 - This is a link rule only; summary structure remains flexible.
 
 Examples:
 - `[Issue #129: Clickable GitHub references](https://github.com/rolker/ros2_agent_workspace/issues/129)`
 - `PR #68: https://github.com/rolker/unh_marine_autonomy/pull/68`
-- `[e8c32bc](https://github.com/rolker/unh_marine_autonomy/commit/e8c32bc)`
+- `[e8c32bc](https://github.com/rolker/unh_marine_autonomy/commit/<full-sha>)`
 
 ## Build & Test
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,12 +80,14 @@ rm "$BODY_FILE"
 
 - When referencing any GitHub issue, PR, commit, or repository in summaries/reports, include a clickable URL on every mention.
 - Use markdown links where supported; in plain terminal output include a full URL inline or on the next line.
+- Workspace repo: `rolker/ros2_agent_workspace`. For project repos, derive
+  the slug from the git remote (`git remote get-url origin`).
 - This is a link rule only; summary structure remains flexible.
 
 Examples:
 - `[Issue #129: Clickable GitHub references](https://github.com/rolker/ros2_agent_workspace/issues/129)`
 - `PR #68: https://github.com/rolker/unh_marine_autonomy/pull/68`
-- `[e8c32bc](https://github.com/rolker/unh_marine_autonomy/commit/e8c32bc)`
+- `[e8c32bc](https://github.com/rolker/unh_marine_autonomy/commit/<full-sha>)`
 
 ## Build & Test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,9 @@ rm "$BODY_FILE"
 - This is a link rule only; summary structure remains flexible.
 
 Examples:
-- `[Issue #129](https://github.com/rolker/ros2_agent_workspace/issues/129)`
-- `[PR #68](https://github.com/rolker/unh_marine_autonomy/pull/68)`
-- `[e8c32bc](https://github.com/rolker/unh_marine_autonomy/commit/e8c32bc)`
+- `[Issue #129: Clickable GitHub references](https://github.com/rolker/ros2_agent_workspace/issues/129)`
+- `[PR #68: Example pull request](https://github.com/rolker/unh_marine_autonomy/pull/68)`
+- `[e8c32bc](https://github.com/rolker/unh_marine_autonomy/commit/<full-sha>)`
 
 ## Build & Test
 


### PR DESCRIPTION
## Summary

Add a lightweight rule across agent instruction files: on first mention of any GitHub issue, PR, commit, or repository in summaries/reports, include a clickable URL.

- Adds rule text to universal fallback rules and framework-specific instruction files
- Includes markdown-link and plain-URL examples
- Explicitly keeps summary structure flexible (no rigid template)

Closes #129

---
**Authored-By**: `Copilot CLI Agent`
**Model**: `gpt-5.3-codex (high)`
