### PR TITLE
fix: include underlay repos in workspace validation

### DIFF
--- a/.agent/scripts/validate_workspace.py
+++ b/.agent/scripts/validate_workspace.py
@@ -141,7 +141,7 @@ def validate_workspace(verbose=False):
     root = get_workspace_root()
 
     # Get configured repos using shared library
-    configured_list = get_overlay_repos(include_underlay=False)
+    configured_list = get_overlay_repos(include_underlay=True)
     # Convert list to dict for easy lookup
     config_repos = {item["name"]: item for item in configured_list}
 


### PR DESCRIPTION
## Summary

- Include underlay repositories in `validate_workspace.py` by changing `include_underlay=False` to `True`
- This was an AI-introduced regression from PR #115 where the agent incorrectly excluded underlay repos during a refactor

Closes #243

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
