### PR TITLE
docs: add guiding principles for workspace development

### DIFF
--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -39,7 +39,13 @@ regressions which matter — sensor failures, timing issues, degraded conditions
 Don't chase coverage targets; focus on the failure modes that are hard to
 find in the field.
 
-## 7. Workspace improvements cascade to projects
+## 7. Improve incrementally
+
+Deliver small, reviewed changes rather than large rework efforts. Each change
+should leave the workspace better than it found it without requiring a
+comprehensive redesign.
+
+## 8. Workspace improvements cascade to projects
 
 When we invest in improving workflow quality — PR templates, CI patterns, hooks,
 documentation standards — the benefit shouldn't stop at the workspace repo boundary.


### PR DESCRIPTION
## Summary

Adds `docs/PRINCIPLES.md` — seven guiding principles for workspace development, extracted from [issue #249](https://github.com/rolker/ros2_agent_workspace/issues/249) discussion.

## Related issue

Part of [#249: Workspace rework](https://github.com/rolker/ros2_agent_workspace/issues/249)

## What changed

New file `docs/PRINCIPLES.md` capturing principles that were previously only in issue comments. Intended to be referenced by PR templates, agent instructions, and review processes.

## Test plan

- [ ] Review principles for completeness, clarity, and applicability as review criteria

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
