### PR TITLE
Add human control and completeness principles, reorder all

### DIFF
--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -3,51 +3,64 @@
 These principles inform every change to the workspace — not just the current effort.
 They serve as review criteria for PRs and design decisions.
 
-## 1. Workspace vs. project separation
+## Human control and transparency
 
-Workspace infrastructure is generic ROS 2 tooling; project-specific content belongs in
-project repos. The workspace should be useful to any ROS 2 project, not coupled to a
-single one.
+The user must be able to understand what an agent is doing, how it is doing it, and
+why it chose that approach. This transparency is the foundation for trust — and trust
+is what earns agents greater autonomy. Design controls to be configurable: tight by
+default, relaxable as confidence grows.
 
-## 2. Primary framework first, portability where free
-
-Use the full capabilities of the active framework (currently Claude Code). Where rules
-are naturally framework-agnostic — build commands, coding conventions, architecture —
-express them portably. Don't hobble the primary tool for the sake of frameworks that
-aren't in use.
-
-## 3. Capture decisions, not just implementations
-
-Use ADRs or equivalent so future agents and humans know *why*, not just *what*. Design
-decisions buried in issue comments or commit history get accidentally reverted.
-
-## 4. Enforcement over documentation
+## Enforcement over documentation
 
 Rules that matter must be enforced mechanically — CI, hooks, branch protection — not
 just written down. Documentation tells you what to do; enforcement ensures it happens.
 
-## 5. Radical simplicity
+## Capture decisions, not just implementations
+
+Use ADRs or equivalent so future agents and humans know *why*, not just *what*. Design
+decisions buried in issue comments or commit history get accidentally reverted.
+
+## A change includes its consequences
+
+Modifying code, configuration, or interfaces isn't done until tests, documentation,
+and dependent references reflect the change. Stale docs and broken tests fail quietly —
+treat them as part of the same work, not a follow-up task.
+
+## Radical simplicity
 
 Resist adding process, files, or tools unless the pain they solve is concrete and
 demonstrated. The right amount of complexity is the minimum needed for the current
 situation.
 
-## 6. Test what breaks
+## Improve incrementally
+
+Deliver small, reviewed changes rather than large rework efforts. Each change
+should leave the workspace better than it found it without requiring a
+comprehensive redesign.
+
+## Test what breaks
 
 Test logic and interfaces, not framework glue. Prioritize tests that catch
 regressions which matter — sensor failures, timing issues, degraded conditions.
 Don't chase coverage targets; focus on the failure modes that are hard to
 find in the field.
 
-## 7. Improve incrementally
+## Workspace vs. project separation
 
-Deliver small, reviewed changes rather than large rework efforts. Each change
-should leave the workspace better than it found it without requiring a
-comprehensive redesign.
+Workspace infrastructure is generic ROS 2 tooling; project-specific content belongs in
+project repos. The workspace should be useful to any ROS 2 project, not coupled to a
+single one.
 
-## 8. Workspace improvements cascade to projects
+## Workspace improvements cascade to projects
 
 When we invest in improving workflow quality — PR templates, CI patterns, hooks,
 documentation standards — the benefit shouldn't stop at the workspace repo boundary.
 Design improvements to be portable across repos from the start; the workspace serves
 as the reference implementation, project repos adopt what fits.
+
+## Primary framework first, portability where free
+
+Use the full capabilities of the active framework (currently Claude Code). Where rules
+are naturally framework-agnostic — build commands, coding conventions, architecture —
+express them portably. Don't hobble the primary tool for the sake of frameworks that
+aren't in use.


### PR DESCRIPTION
## Summary

- Adds **"Human control and transparency"** as a new guiding principle — transparency enables trust, trust earns autonomy, controls should be configurable
- Adds **"A change includes its consequences"** — completeness principle for tests, docs, and dependent references
- Removes numbering from all principles (ordering is intentional but not hierarchical)
- Reorders principles from foundational to operational to structural

Closes #267
Closes #268

## Ordering rationale

1. **Foundational** — human relationship and reliability: control/transparency, enforcement, decisions, completeness
2. **Operational** — how we work: simplicity, incrementalism, testing
3. **Structural** — architecture boundaries: workspace/project separation, cascading, framework choice

## Test plan

- [ ] Review principle text for clarity and accuracy
- [ ] Confirm no other files referenced principles by number
- [ ] Verify ordering feels natural when read top-to-bottom

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
