### PR TITLE
Add consequence checklist to PR template and post-task verification

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,16 @@ Closes #
 
 -
 
+## Documentation and test impact
+
+<!-- Consider what else needs updating as a consequence of this change. -->
+
+- [ ] No impact (no behavior, API, or interface changes)
+- [ ] Impact considered (check all that apply below):
+  - [ ] Tests added or updated
+  - [ ] Documentation updated (README, package docs, `.agents/README.md`)
+  - [ ] Dependent references updated (callers, message definitions, config files)
+
 ## Architecture impact
 
 - [ ] No architecture impact (routine change within existing patterns)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,7 +183,8 @@ Before marking a task complete or opening a PR:
 
 1. Re-read issue description and work plan
 2. Compare changes against requirements
-3. List any gaps; complete them or explain in PR description
+3. Check consequences: do tests, docs, or dependent references need updating?
+4. List any gaps; complete them or explain in PR description
 
 ## Script Reference
 


### PR DESCRIPTION
## Summary

Completes the remaining scope from #267 — the principle itself was added in #269.

- Adds a **"Documentation and test impact"** checklist section to the PR template, prompting authors to consider whether tests, docs, or dependent references need updating
- Adds a **consequence check step** to the Post-Task Verification section in AGENTS.md

## What changed

- `.github/PULL_REQUEST_TEMPLATE.md` — new section before Architecture impact
- `AGENTS.md` — new step 3 in Post-Task Verification

## Documentation and test impact

- [x] No behavior, API, or interface changes — this is process/template only

## Architecture impact

- [x] No architecture impact (routine change within existing patterns)

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
