### PR TITLE
Add plan-task skill

### DIFF
--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -19,7 +19,7 @@ planning system. Use EnterPlanMode for general codebase exploration and
 approach design; use this skill to ensure the plan accounts for workspace
 principles, ADR compliance, and downstream consequences.
 
-**Lifecycle position**: `review-issue → **plan-task** → implement → review-pr`
+**Lifecycle position**: review-issue → **plan-task** → implement → review-pr
 
 ## Steps
 
@@ -56,7 +56,7 @@ Write a plan to `.agent/work-plans/PLAN_ISSUE-<N>.md`:
 
 ## Issue
 
-<link to issue>
+<issue URL from: gh issue view <N> --json url --jq '.url'>
 
 ## Context
 
@@ -117,8 +117,12 @@ Push the branch and create a draft PR with the plan as the body. This
 allows Copilot and humans to review the plan before implementation.
 
 ```bash
-git push -u origin feature/issue-<N>
-gh pr create --draft --title "<issue-title>" --body-file .agent/work-plans/PLAN_ISSUE-<N>.md
+# Push current branch (name may vary: feature/issue-<N> or feature/ISSUE-<N>-<desc>)
+git push -u origin HEAD
+
+# Create draft PR (use --body-file for title safety)
+ISSUE_TITLE=$(gh issue view <N> --json title --jq '.title')
+gh pr create --draft --title "$ISSUE_TITLE" --body-file .agent/work-plans/PLAN_ISSUE-<N>.md
 ```
 
 ### 7. Report to user


### PR DESCRIPTION
## Summary

- Add `plan-task` skill — generates a principles-aware work plan for an issue
- Saves to `.agent/work-plans/PLAN_ISSUE-<N>.md`, commits as first step on feature branch, creates draft PR
- Complements EnterPlanMode by adding governance awareness (principles, ADRs, consequences)

## Design

The skill fits in the lifecycle: `review-issue → **plan-task** → implement → review-pr`

Plan output includes:
- Step-by-step approach
- Files to change
- Principles self-check table
- ADR compliance check
- Consequences map (if we change X, also update Y)
- Open questions for human input
- Scope estimate

## Test plan

- [ ] Invoke `/plan-task` against an issue and verify plan is generated
- [ ] Verify plan is saved to `.agent/work-plans/`
- [ ] Verify draft PR is created with plan as body

Closes #278

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
