### PR TITLE
Add --skip-existing to vcs import for SSH remote compat

### DIFF
--- a/.agent/scripts/setup_layers.sh
+++ b/.agent/scripts/setup_layers.sh
@@ -240,7 +240,7 @@ mkdir -p "$LAYER_DIR/src"
 
 if command -v vcs &> /dev/null; then
     echo "Importing repositories into $LAYER_DIR/src..."
-    vcs import "$LAYER_DIR/src" < "$CONFIG_FILE"
+    vcs import --skip-existing "$LAYER_DIR/src" < "$CONFIG_FILE"
 else
     echo "Warning: 'vcs' command not found. Skipping repository import."
     echo "To install all necessary dependencies, run:"


### PR DESCRIPTION
## Summary

- Add `--skip-existing` flag to `vcs import` in `setup_layers.sh` so repos with changed remotes (e.g., HTTPS → SSH) are skipped instead of causing a build failure

## Test plan

- [ ] Run `make build` on a workspace where some repos have SSH remotes — should succeed
- [ ] Run `make build` on a fresh clone — repos should still be cloned via HTTPS manifest
- [ ] Verify existing repos with matching URLs still get fetched

Closes #361

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
