### PR TITLE
Add --json flag to worktree_list.sh

### DIFF
--- a/.agent/scripts/worktree_list.sh
+++ b/.agent/scripts/worktree_list.sh
@@ -248,14 +248,9 @@ if [ -d "$LAYER_WT_DIR" ]; then
         # Get branch from inner package worktree
         local_branch=$(wt_layer_branch "$layer_wt" 2>/dev/null || echo "")
 
-        # Check dirty status
+        # Check dirty status and count changed files in a single pass
+        # (avoids running git status twice per repo)
         local_status="clean"
-        if wt_layer_is_dirty "$layer_wt"; then
-            local_status="dirty"
-            ((DIRTY_COUNT++)) || true
-        fi
-
-        # Count changed files across all inner package worktrees
         local_changed=0
         if [ "$VERBOSE" = true ] || [ "$JSON_OUTPUT" = true ]; then
             for ws_dir in "$layer_wt"/*_ws; do
@@ -272,6 +267,16 @@ if [ -d "$LAYER_WT_DIR" ]; then
                     fi
                 done
             done
+            if [ "$local_changed" -gt 0 ]; then
+                local_status="dirty"
+                ((DIRTY_COUNT++)) || true
+            fi
+        else
+            # Text mode without --verbose: just check dirty, skip counting
+            if wt_layer_is_dirty "$layer_wt"; then
+                local_status="dirty"
+                ((DIRTY_COUNT++)) || true
+            fi
         fi
 
         # Determine layer name from the non-symlinked *_ws directory


### PR DESCRIPTION
Closes #399

## Summary

Adds a `--json` flag to `worktree_list.sh` that outputs structured JSON
instead of human-readable text. This is a prerequisite for the agent
dashboard (#398, #400) and enables any tool to programmatically consume
worktree data.

## Changes

- New `--json` flag outputs all worktree data as a single JSON object
- Existing text output (default, no flag) is unchanged
- JSON always includes `files_changed` count (text mode still requires `--verbose`)
- Handles all worktree types: main, workspace, layer, skill
- Handles legacy (`issue-N`) and new (`issue-REPO-N`) naming formats

## Example

```bash
$ worktree_list.sh --json | jq '.worktrees[] | {issue, type, status}'
{"issue": 26, "type": "layer", "status": "clean"}
{"issue": 391, "type": "workspace", "status": "dirty"}
```

## Test plan

- [x] `worktree_list.sh --json` produces valid JSON (`python3 -m json.tool`)
- [x] `worktree_list.sh --json | jq '.worktrees[].issue'` extracts issue numbers
- [x] `worktree_list.sh` (no flag) output is unchanged
- [x] All hooks pass (shellcheck, pre-commit)

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
