### PR TITLE
Fix agent script ROOT_DIR when invoked via scripts/ symlink

### DIFF
--- a/.agent/scripts/agent
+++ b/.agent/scripts/agent
@@ -15,7 +15,7 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 export ROOT_DIR
 


### PR DESCRIPTION
## Summary

- Fix `SCRIPT_DIR` resolution in `.agent/scripts/agent` to use `readlink -f` before computing the directory, so `ROOT_DIR` resolves correctly when invoked via the `scripts/` symlink (e.g., `./scripts/agent launch 250`)

## Test plan

- [ ] Run `./scripts/agent launch <issue>` and verify it creates/finds the worktree correctly
- [ ] Run `.agent/scripts/agent launch <issue>` and verify it still works via the direct path

Closes #410

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
