### PR TITLE
Sync workspace repos to a secondary git server

### DIFF
--- a/.agent/scripts/add_remote.py
+++ b/.agent/scripts/add_remote.py
@@ -14,41 +14,25 @@ After setup, use push_remote.py / pull_remote.py for ongoing sync.
 """
 
 import argparse
-import subprocess
 import sys
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
-from workspace import extract_github_owner_repo, get_overlay_repos
-
-
-def run_git(repo_path, args, dry_run=False):
-    """Run a git command in the given repo. Returns (success, stdout)."""
-    cmd = ["git"] + args
-    if dry_run:
-        print(f"  [DRY-RUN] {' '.join(cmd)}")
-        return True, ""
-    try:
-        result = subprocess.run(cmd, cwd=str(repo_path), capture_output=True, text=True, check=True)
-        return True, result.stdout.strip()
-    except subprocess.CalledProcessError as e:
-        return False, e.stderr.strip()
+from remote_utils import (
+    add_common_args,
+    remote_exists,
+    run_git,
+    run_script,
+)
+from workspace import extract_github_owner_repo
 
 
 def get_origin_url(repo_path):
     """Get the origin remote URL for a repo."""
-    success, url = run_git(repo_path, ["remote", "get-url", "origin"])
+    success, url, _ = run_git(repo_path, ["remote", "get-url", "origin"])
     return url if success else None
-
-
-def remote_exists(repo_path, remote_name):
-    """Check if a remote already exists."""
-    success, output = run_git(repo_path, ["remote"])
-    if not success:
-        return False
-    return remote_name in output.splitlines()
 
 
 def derive_repo_name(origin_url):
@@ -63,97 +47,47 @@ def derive_repo_name(origin_url):
     return path.rsplit("/", 1)[-1] if "/" in path else None
 
 
-def resolve_repo_path(root_dir, repo):
-    """Resolve the local path for a repo entry. Returns Path or None."""
-    ws_name = repo["source_file"].replace(".repos", "_ws")
-    candidate = root_dir / "layers" / "main" / ws_name / "src" / repo["name"]
-    if candidate.exists():
-        return candidate
-    return None
-
-
-def add_remote_to_repo(repo_path, repo_label, remote_name, url_prefix, dry_run):
+def process_repo(repo_path, repo_name, version, args):
     """Add a named remote to a single repo. Returns (status, message)."""
-    if remote_exists(repo_path, remote_name):
-        return "skip", f"remote '{remote_name}' already exists"
+    if remote_exists(repo_path, args.remote):
+        return "skip", f"remote '{args.remote}' already exists"
 
     origin_url = get_origin_url(repo_path)
     if not origin_url:
         return "error", "could not read origin URL"
 
-    repo_name = derive_repo_name(origin_url)
-    if not repo_name:
+    derived_name = derive_repo_name(origin_url)
+    if not derived_name:
         return "error", f"could not derive repo name from: {origin_url}"
 
-    remote_url = f"{url_prefix}{repo_name}.git"
-    success, output = run_git(repo_path, ["remote", "add", remote_name, remote_url], dry_run)
+    remote_url = f"{args.url_prefix}{derived_name}.git"
+    success, _, err = run_git(repo_path, ["remote", "add", args.remote, remote_url], args.dry_run)
     if success:
         return "added", remote_url
-    return "error", output
+    return "error", err
 
 
 def main():
     parser = argparse.ArgumentParser(
         description="Add a named remote to all workspace repositories."
     )
-    parser.add_argument("--remote", required=True, help="Remote name (e.g., gitcloud)")
+    add_common_args(parser)
     parser.add_argument(
         "--url-prefix",
         required=True,
         help="URL prefix (e.g., git@gitcloud:field/)",
     )
-    parser.add_argument(
-        "--manifest",
-        help="Filter by manifest name(s), comma-separated (e.g., core,platforms)",
-    )
-    parser.add_argument(
-        "--include-underlay",
-        action="store_true",
-        help="Include underlay repositories",
-    )
-    parser.add_argument("--dry-run", action="store_true", help="Show what would be done")
-    args = parser.parse_args()
-
-    root_dir = SCRIPT_DIR.parent.parent
-    manifest_filter = (
-        set(f"{m.strip()}.repos" for m in args.manifest.split(",")) if args.manifest else None
-    )
-
-    repos = get_overlay_repos(include_underlay=args.include_underlay)
-    if manifest_filter:
-        repos = [r for r in repos if r["source_file"] in manifest_filter]
-
-    results = {"added": 0, "skip": 0, "error": 0, "missing": 0}
-
-    # Workspace repo itself
-    print("ros2_agent_workspace (workspace root)")
-    status, msg = add_remote_to_repo(
-        root_dir, "ros2_agent_workspace", args.remote, args.url_prefix, args.dry_run
-    )
-    print(f"  {status}: {msg}")
-    results[status] = results.get(status, 0) + 1
-
-    for repo in repos:
-        repo_path = resolve_repo_path(root_dir, repo)
-        if repo_path is None:
-            print(f"{repo['name']}")
-            print("  missing: could not find local checkout")
-            results["missing"] += 1
-            continue
-
-        print(f"{repo['name']}")
-        status, msg = add_remote_to_repo(
-            repo_path, repo["name"], args.remote, args.url_prefix, args.dry_run
-        )
-        print(f"  {status}: {msg}")
-        results[status] = results.get(status, 0) + 1
-
-    # Summary
-    total = sum(results.values())
-    print(
-        f"\nSummary: {total} repos — "
-        f"{results['added']} added, {results['skip']} already existed, "
-        f"{results['error']} errors, {results['missing']} missing"
+    run_script(
+        SCRIPT_DIR,
+        parser.parse_args(),
+        process_repo,
+        {"added": 0, "skip": 0, "error": 0, "missing": 0},
+        [
+            ("added", "added"),
+            ("skip", "already existed"),
+            ("error", "errors"),
+            ("missing", "missing"),
+        ],
     )
 
 

--- a/.agent/scripts/add_remote.py
+++ b/.agent/scripts/add_remote.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Add a named remote to all workspace repositories.
+
+One-time setup for secondary git server sync. Derives the target repo name
+from each repo's origin URL, then constructs the remote URL as:
+  <url-prefix><repo-name>.git
+
+Usage:
+    python3 add_remote.py --remote gitcloud --url-prefix git@gitcloud:field/
+    python3 add_remote.py --remote gitcloud --url-prefix git@gitcloud:field/ --dry-run
+
+After setup, use push_remote.py / pull_remote.py for ongoing sync.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from workspace import extract_github_owner_repo, get_overlay_repos
+
+
+def run_git(repo_path, args, dry_run=False):
+    """Run a git command in the given repo. Returns (success, stdout)."""
+    cmd = ["git"] + args
+    if dry_run:
+        print(f"  [DRY-RUN] {' '.join(cmd)}")
+        return True, ""
+    try:
+        result = subprocess.run(cmd, cwd=str(repo_path), capture_output=True, text=True, check=True)
+        return True, result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        return False, e.stderr.strip()
+
+
+def get_origin_url(repo_path):
+    """Get the origin remote URL for a repo."""
+    success, url = run_git(repo_path, ["remote", "get-url", "origin"])
+    return url if success else None
+
+
+def remote_exists(repo_path, remote_name):
+    """Check if a remote already exists."""
+    success, output = run_git(repo_path, ["remote"])
+    if not success:
+        return False
+    return remote_name in output.splitlines()
+
+
+def derive_repo_name(origin_url):
+    """Derive the repository name from the origin URL."""
+    _, repo_name = extract_github_owner_repo(origin_url)
+    if repo_name:
+        return repo_name
+    # Fallback: parse the last path component from any git URL
+    path = origin_url.rstrip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+    return path.rsplit("/", 1)[-1] if "/" in path else None
+
+
+def resolve_repo_path(root_dir, repo):
+    """Resolve the local path for a repo entry. Returns Path or None."""
+    ws_name = repo["source_file"].replace(".repos", "_ws")
+    candidate = root_dir / "layers" / "main" / ws_name / "src" / repo["name"]
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def add_remote_to_repo(repo_path, repo_label, remote_name, url_prefix, dry_run):
+    """Add a named remote to a single repo. Returns (status, message)."""
+    if remote_exists(repo_path, remote_name):
+        return "skip", f"remote '{remote_name}' already exists"
+
+    origin_url = get_origin_url(repo_path)
+    if not origin_url:
+        return "error", "could not read origin URL"
+
+    repo_name = derive_repo_name(origin_url)
+    if not repo_name:
+        return "error", f"could not derive repo name from: {origin_url}"
+
+    remote_url = f"{url_prefix}{repo_name}.git"
+    success, output = run_git(repo_path, ["remote", "add", remote_name, remote_url], dry_run)
+    if success:
+        return "added", remote_url
+    return "error", output
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Add a named remote to all workspace repositories."
+    )
+    parser.add_argument("--remote", required=True, help="Remote name (e.g., gitcloud)")
+    parser.add_argument(
+        "--url-prefix",
+        required=True,
+        help="URL prefix (e.g., git@gitcloud:field/)",
+    )
+    parser.add_argument(
+        "--manifest",
+        help="Filter by manifest name(s), comma-separated (e.g., core,platforms)",
+    )
+    parser.add_argument(
+        "--include-underlay",
+        action="store_true",
+        help="Include underlay repositories",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done")
+    args = parser.parse_args()
+
+    root_dir = SCRIPT_DIR.parent.parent
+    manifest_filter = (
+        set(f"{m.strip()}.repos" for m in args.manifest.split(",")) if args.manifest else None
+    )
+
+    repos = get_overlay_repos(include_underlay=args.include_underlay)
+    if manifest_filter:
+        repos = [r for r in repos if r["source_file"] in manifest_filter]
+
+    results = {"added": 0, "skip": 0, "error": 0, "missing": 0}
+
+    # Workspace repo itself
+    print("ros2_agent_workspace (workspace root)")
+    status, msg = add_remote_to_repo(
+        root_dir, "ros2_agent_workspace", args.remote, args.url_prefix, args.dry_run
+    )
+    print(f"  {status}: {msg}")
+    results[status] = results.get(status, 0) + 1
+
+    for repo in repos:
+        repo_path = resolve_repo_path(root_dir, repo)
+        if repo_path is None:
+            print(f"{repo['name']}")
+            print("  missing: could not find local checkout")
+            results["missing"] += 1
+            continue
+
+        print(f"{repo['name']}")
+        status, msg = add_remote_to_repo(
+            repo_path, repo["name"], args.remote, args.url_prefix, args.dry_run
+        )
+        print(f"  {status}: {msg}")
+        results[status] = results.get(status, 0) + 1
+
+    # Summary
+    total = sum(results.values())
+    print(
+        f"\nSummary: {total} repos — "
+        f"{results['added']} added, {results['skip']} already existed, "
+        f"{results['error']} errors, {results['missing']} missing"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.agent/scripts/add_remote.py
+++ b/.agent/scripts/add_remote.py
@@ -77,9 +77,13 @@ def main():
         required=True,
         help="URL prefix (e.g., git@gitcloud:field/)",
     )
+    args = parser.parse_args()
+    if not args.url_prefix.endswith(("/", ":")):
+        parser.error("--url-prefix must end with '/' or ':' (e.g., git@host:org/)")
+
     run_script(
         SCRIPT_DIR,
-        parser.parse_args(),
+        args,
         process_repo,
         {"added": 0, "skip": 0, "error": 0, "missing": 0},
         [

--- a/.agent/scripts/lib/remote_utils.py
+++ b/.agent/scripts/lib/remote_utils.py
@@ -32,7 +32,11 @@ def remote_exists(repo_path, remote_name):
 
 
 def resolve_repo_path(root_dir, repo):
-    """Resolve the local path for a repo entry. Returns Path or None."""
+    """Resolve the local path for a repo entry. Returns Path or None.
+
+    Only checks the main layer tree (layers/main/). These scripts operate
+    on the primary workspace checkout, not worktrees.
+    """
     ws_name = repo["source_file"].replace(".repos", "_ws")
     candidate = root_dir / "layers" / "main" / ws_name / "src" / repo["name"]
     if candidate.exists():
@@ -92,9 +96,10 @@ def iter_repos(script_dir, args, process_fn, initial_results):
     repos = get_repos(args)
     results = dict(initial_results)
 
-    # Workspace repo itself
+    # Workspace repo itself — detect its default branch rather than hard-coding
+    ws_version = get_default_branch(root_dir, None)
     print("ros2_agent_workspace (workspace root)")
-    status, msg = process_fn(root_dir, "ros2_agent_workspace", "main", args)
+    status, msg = process_fn(root_dir, "ros2_agent_workspace", ws_version, args)
     print(f"  {status}: {msg}")
     results[status] = results.get(status, 0) + 1
 

--- a/.agent/scripts/lib/remote_utils.py
+++ b/.agent/scripts/lib/remote_utils.py
@@ -47,13 +47,28 @@ def resolve_repo_path(root_dir, repo):
 def get_default_branch(repo_path, version):
     """Get the default branch for a repo.
 
-    Uses the manifest-declared version if available, otherwise detects
-    from origin/HEAD, falling back to 'main'.
+    Uses the manifest-declared version if it resolves to a branch,
+    otherwise detects from origin/HEAD, falling back to 'main'.
+    Tags and commit SHAs are not usable as branch targets for push/pull.
     """
     if version and version != "unknown":
-        return version
+        # Only use the manifest version if it's actually a branch ref
+        for ref in [f"refs/heads/{version}", f"refs/remotes/origin/{version}"]:
+            success, _, _ = run_git(repo_path, ["rev-parse", "--verify", ref])
+            if success:
+                return version
+
+    # Detect from origin/HEAD
     success, out, _ = run_git(repo_path, ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
-    return out.replace("origin/", "") if success and out else "main"
+    if success and out:
+        return out.replace("origin/", "")
+
+    # Fall back to current branch
+    success, out, _ = run_git(repo_path, ["symbolic-ref", "HEAD", "--short"])
+    if success and out:
+        return out
+
+    return "main"
 
 
 def add_common_args(parser):

--- a/.agent/scripts/lib/remote_utils.py
+++ b/.agent/scripts/lib/remote_utils.py
@@ -59,12 +59,14 @@ def get_default_branch(repo_path, version):
                 return version
 
     # Detect from origin/HEAD
-    success, out, _ = run_git(repo_path, ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
+    success, out, _ = run_git(
+        repo_path, ["symbolic-ref", "-q", "--short", "refs/remotes/origin/HEAD"]
+    )
     if success and out:
         return out.replace("origin/", "")
 
     # Fall back to current branch
-    success, out, _ = run_git(repo_path, ["symbolic-ref", "HEAD", "--short"])
+    success, out, _ = run_git(repo_path, ["symbolic-ref", "-q", "--short", "HEAD"])
     if success and out:
         return out
 

--- a/.agent/scripts/lib/remote_utils.py
+++ b/.agent/scripts/lib/remote_utils.py
@@ -1,0 +1,134 @@
+"""
+Shared utilities for secondary remote management scripts.
+
+Used by add_remote.py, push_remote.py, and pull_remote.py.
+"""
+
+import subprocess
+import sys
+
+from workspace import get_overlay_repos
+
+
+def run_git(repo_path, args, dry_run=False):
+    """Run a git command in the given repo. Returns (success, stdout, stderr)."""
+    cmd = ["git"] + args
+    if dry_run:
+        print(f"  [DRY-RUN] {' '.join(cmd)}")
+        return True, "", ""
+    try:
+        result = subprocess.run(cmd, cwd=str(repo_path), capture_output=True, text=True, check=True)
+        return True, result.stdout.strip(), result.stderr.strip()
+    except subprocess.CalledProcessError as e:
+        return False, e.stdout.strip(), e.stderr.strip()
+
+
+def remote_exists(repo_path, remote_name):
+    """Check if a named remote exists in the repo."""
+    success, output, _ = run_git(repo_path, ["remote"])
+    if not success:
+        return False
+    return remote_name in output.splitlines()
+
+
+def resolve_repo_path(root_dir, repo):
+    """Resolve the local path for a repo entry. Returns Path or None."""
+    ws_name = repo["source_file"].replace(".repos", "_ws")
+    candidate = root_dir / "layers" / "main" / ws_name / "src" / repo["name"]
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def get_default_branch(repo_path, version):
+    """Get the default branch for a repo.
+
+    Uses the manifest-declared version if available, otherwise detects
+    from origin/HEAD, falling back to 'main'.
+    """
+    if version and version != "unknown":
+        return version
+    success, out, _ = run_git(repo_path, ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
+    return out.replace("origin/", "") if success and out else "main"
+
+
+def add_common_args(parser):
+    """Add the common --remote, --manifest, --include-underlay, --dry-run args."""
+    parser.add_argument("--remote", required=True, help="Remote name (e.g., gitcloud)")
+    parser.add_argument(
+        "--manifest",
+        help="Filter by manifest name(s), comma-separated (e.g., core,platforms)",
+    )
+    parser.add_argument(
+        "--include-underlay",
+        action="store_true",
+        help="Include underlay repositories",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done")
+
+
+def get_repos(args):
+    """Get the filtered repo list based on parsed args."""
+    repos = get_overlay_repos(include_underlay=args.include_underlay)
+    if args.manifest:
+        manifest_filter = set(f"{m.strip()}.repos" for m in args.manifest.split(","))
+        repos = [r for r in repos if r["source_file"] in manifest_filter]
+    return repos
+
+
+def iter_repos(script_dir, args, process_fn, initial_results):
+    """Iterate over all workspace repos, calling process_fn for each.
+
+    Args:
+        script_dir: Path to the script's directory (for resolving workspace root).
+        args: Parsed argparse namespace (must include common args).
+        process_fn: Callable(repo_path, repo_name, version, args) -> (status, message).
+        initial_results: Dict of status -> count to accumulate into.
+
+    Returns:
+        The results dict with updated counts. Exits non-zero if errors occurred.
+    """
+    root_dir = script_dir.parent.parent
+    repos = get_repos(args)
+    results = dict(initial_results)
+
+    # Workspace repo itself
+    print("ros2_agent_workspace (workspace root)")
+    status, msg = process_fn(root_dir, "ros2_agent_workspace", "main", args)
+    print(f"  {status}: {msg}")
+    results[status] = results.get(status, 0) + 1
+
+    for repo in repos:
+        repo_path = resolve_repo_path(root_dir, repo)
+        if repo_path is None:
+            print(f"{repo['name']}")
+            print("  missing: could not find local checkout")
+            results["missing"] += 1
+            continue
+
+        print(f"{repo['name']}")
+        status, msg = process_fn(repo_path, repo["name"], repo["version"], args)
+        print(f"  {status}: {msg}")
+        results[status] = results.get(status, 0) + 1
+
+    return results
+
+
+def print_summary_and_exit(results, labels):
+    """Print a summary line and exit non-zero if there were errors.
+
+    Args:
+        results: Dict of status -> count.
+        labels: List of (status_key, label_text) pairs for the summary.
+    """
+    total = sum(results.values())
+    parts = [f"{results.get(key, 0)} {label}" for key, label in labels]
+    print(f"\nSummary: {total} repos — {', '.join(parts)}")
+    if results.get("error", 0) > 0:
+        sys.exit(1)
+
+
+def run_script(script_dir, args, process_fn, initial_results, labels):
+    """Run iter_repos then print_summary_and_exit. Typical main() body."""
+    results = iter_repos(script_dir, args, process_fn, initial_results)
+    print_summary_and_exit(results, labels)

--- a/.agent/scripts/pull_remote.py
+++ b/.agent/scripts/pull_remote.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""
+Fetch/pull from a named remote for all workspace repositories.
+
+Default mode: fetch and report which repos have new commits, listing them.
+With --pull: merge remote changes into the current local branch.
+With --branch: pull remote changes into a named local branch.
+
+Usage:
+    python3 pull_remote.py --remote gitcloud                    # fetch + report
+    python3 pull_remote.py --remote gitcloud --pull             # fetch + merge
+    python3 pull_remote.py --remote gitcloud --branch sync/gc   # fetch into branch
+
+Prerequisites:
+    Remotes must already exist in each repo. Use add_remote.py for one-time setup.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from workspace import get_overlay_repos
+
+
+def run_git(repo_path, args, dry_run=False):
+    """Run a git command in the given repo. Returns (success, stdout, stderr)."""
+    cmd = ["git"] + args
+    if dry_run:
+        print(f"  [DRY-RUN] {' '.join(cmd)}")
+        return True, "", ""
+    try:
+        result = subprocess.run(cmd, cwd=str(repo_path), capture_output=True, text=True, check=True)
+        return True, result.stdout.strip(), result.stderr.strip()
+    except subprocess.CalledProcessError as e:
+        return False, e.stdout.strip(), e.stderr.strip()
+
+
+def remote_exists(repo_path, remote_name):
+    """Check if a remote exists in the repo."""
+    success, output, _ = run_git(repo_path, ["remote"])
+    if not success:
+        return False
+    return remote_name in output.splitlines()
+
+
+def is_dirty(repo_path):
+    """Check if the repo has uncommitted changes."""
+    success, output, _ = run_git(repo_path, ["status", "--porcelain"])
+    return success and bool(output)
+
+
+def get_current_branch(repo_path):
+    """Get the current branch name."""
+    success, output, _ = run_git(repo_path, ["branch", "--show-current"])
+    return output if success and output else None
+
+
+def resolve_repo_path(root_dir, repo):
+    """Resolve the local path for a repo entry. Returns Path or None."""
+    ws_name = repo["source_file"].replace(".repos", "_ws")
+    candidate = root_dir / "layers" / "main" / ws_name / "src" / repo["name"]
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def get_default_branch(repo_path, version):
+    """Get the default branch for comparison."""
+    if version and version != "unknown":
+        return version
+    success, out, _ = run_git(repo_path, ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
+    return out.replace("origin/", "") if success and out else "main"
+
+
+def fetch_and_report(
+    repo_path, remote_name, version, dry_run
+):  # pylint: disable=too-many-return-statements
+    """Fetch from remote and report new commits. Returns (status, message)."""
+    if not remote_exists(repo_path, remote_name):
+        return "skip", f"remote '{remote_name}' not found"
+
+    # Fetch
+    success, _, err = run_git(repo_path, ["fetch", remote_name], dry_run)
+    if not success:
+        return "error", f"fetch failed: {err}"
+    if dry_run:
+        return "ok", "fetched (dry run)"
+
+    # Compare local default branch with remote's
+    branch = get_default_branch(repo_path, version)
+    remote_ref = f"{remote_name}/{branch}"
+
+    # Check if the remote ref exists
+    success, _, _ = run_git(repo_path, ["rev-parse", "--verify", remote_ref])
+    if not success:
+        return "ok", f"fetched (no {remote_ref} on remote)"
+
+    # Check if local branch exists
+    success, _, _ = run_git(repo_path, ["rev-parse", "--verify", branch])
+    if not success:
+        return "ok", f"fetched (local branch {branch} not found)"
+
+    # Count commits ahead/behind
+    success, output, _ = run_git(
+        repo_path, ["rev-list", "--left-right", "--count", f"{branch}...{remote_ref}"]
+    )
+    if not success or not output:
+        return "ok", "fetched"
+
+    parts = output.split()
+    if len(parts) != 2:
+        return "ok", "fetched"
+
+    ahead, behind = int(parts[0]), int(parts[1])
+
+    if ahead == 0 and behind == 0:
+        return "ok", "up to date"
+
+    lines = []
+    if behind > 0:
+        lines.append(f"local is {behind} commit(s) behind {remote_ref}")
+    if ahead > 0:
+        lines.append(f"local is {ahead} commit(s) ahead of {remote_ref}")
+
+    # List new commits from the remote
+    if behind > 0:
+        success, log_output, _ = run_git(
+            repo_path,
+            ["log", "--oneline", f"{branch}..{remote_ref}", "--max-count=20"],
+        )
+        if success and log_output:
+            lines.append("  new remote commits:")
+            for line in log_output.splitlines():
+                lines.append(f"    {line}")
+            if behind > 20:
+                lines.append(f"    ... and {behind - 20} more")
+
+    return "changes", "\n  ".join(lines)
+
+
+def fetch_and_pull(
+    repo_path, remote_name, version, dry_run
+):  # pylint: disable=too-many-return-statements
+    """Fetch and merge from remote. Returns (status, message)."""
+    if not remote_exists(repo_path, remote_name):
+        return "skip", f"remote '{remote_name}' not found"
+
+    if not dry_run and is_dirty(repo_path):
+        return "skip", "uncommitted changes — skipping merge"
+
+    branch = get_default_branch(repo_path, version)
+    current = get_current_branch(repo_path)
+    if not dry_run and current != branch:
+        return "skip", f"not on default branch (on '{current}', expected '{branch}')"
+
+    # Fetch
+    success, _, err = run_git(repo_path, ["fetch", remote_name], dry_run)
+    if not success:
+        return "error", f"fetch failed: {err}"
+
+    # Merge
+    remote_ref = f"{remote_name}/{branch}"
+    success, out, err = run_git(repo_path, ["merge", remote_ref, "--ff-only"], dry_run)
+    if not success:
+        return "error", f"merge failed (non-fast-forward?): {err}"
+
+    if dry_run:
+        return "ok", "merged (dry run)"
+    if "Already up to date" in out:
+        return "ok", "already up to date"
+    return "ok", f"merged from {remote_ref}"
+
+
+def fetch_into_branch(repo_path, remote_name, version, target_branch, dry_run):
+    """Fetch and update a local branch from the remote. Returns (status, message)."""
+    if not remote_exists(repo_path, remote_name):
+        return "skip", f"remote '{remote_name}' not found"
+
+    branch = get_default_branch(repo_path, version)
+
+    # Fetch
+    success, _, err = run_git(repo_path, ["fetch", remote_name], dry_run)
+    if not success:
+        return "error", f"fetch failed: {err}"
+
+    remote_ref = f"{remote_name}/{branch}"
+
+    # Check if remote ref exists
+    if not dry_run:
+        success, _, _ = run_git(repo_path, ["rev-parse", "--verify", remote_ref])
+        if not success:
+            return "ok", f"fetched (no {remote_ref} on remote)"
+
+    # Create or update the target branch to point at the remote ref
+    success, _, err = run_git(repo_path, ["branch", "-f", target_branch, remote_ref], dry_run)
+    if not success:
+        return "error", f"branch update failed: {err}"
+
+    return "ok", f"branch '{target_branch}' updated to {remote_ref}"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch/pull from a named remote for all workspace repositories."
+    )
+    parser.add_argument("--remote", required=True, help="Remote name (e.g., gitcloud)")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--pull",
+        action="store_true",
+        help="Merge remote changes into current branch (fast-forward only)",
+    )
+    mode.add_argument(
+        "--branch",
+        help="Create/update a local branch with remote changes (e.g., sync/gitcloud)",
+    )
+    parser.add_argument(
+        "--manifest",
+        help="Filter by manifest name(s), comma-separated (e.g., core,platforms)",
+    )
+    parser.add_argument(
+        "--include-underlay",
+        action="store_true",
+        help="Include underlay repositories",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done")
+    args = parser.parse_args()
+
+    root_dir = SCRIPT_DIR.parent.parent
+    manifest_filter = (
+        set(f"{m.strip()}.repos" for m in args.manifest.split(",")) if args.manifest else None
+    )
+
+    repos = get_overlay_repos(include_underlay=args.include_underlay)
+    if manifest_filter:
+        repos = [r for r in repos if r["source_file"] in manifest_filter]
+
+    results = {"ok": 0, "changes": 0, "skip": 0, "error": 0, "missing": 0}
+
+    def process_repo(repo_path, repo_name, version):
+        print(f"{repo_name}")
+        if args.pull:
+            status, msg = fetch_and_pull(repo_path, args.remote, version, args.dry_run)
+        elif args.branch:
+            status, msg = fetch_into_branch(
+                repo_path, args.remote, version, args.branch, args.dry_run
+            )
+        else:
+            status, msg = fetch_and_report(repo_path, args.remote, version, args.dry_run)
+        print(f"  {status}: {msg}")
+        results[status] = results.get(status, 0) + 1
+
+    # Workspace repo itself
+    process_repo(root_dir, "ros2_agent_workspace (workspace root)", "main")
+
+    for repo in repos:
+        repo_path = resolve_repo_path(root_dir, repo)
+        if repo_path is None:
+            print(f"{repo['name']}")
+            print("  missing: could not find local checkout")
+            results["missing"] += 1
+            continue
+
+        process_repo(repo_path, repo["name"], repo["version"])
+
+    # Summary
+    total = sum(results.values())
+    if args.pull or args.branch:
+        print(
+            f"\nSummary: {total} repos — "
+            f"{results['ok']} updated, {results['skip']} skipped, "
+            f"{results['error']} errors, {results['missing']} missing"
+        )
+    else:
+        print(
+            f"\nSummary: {total} repos — "
+            f"{results['ok']} up to date, {results['changes']} with changes, "
+            f"{results['skip']} skipped, {results['error']} errors, "
+            f"{results['missing']} missing"
+        )
+
+    if results["error"] > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agent/scripts/pull_remote.py
+++ b/.agent/scripts/pull_remote.py
@@ -102,21 +102,21 @@ def _fetch_and_report(repo_path, remote_name, version, dry_run):
     return _compare_branches(repo_path, branch, remote_ref)
 
 
-def _check_pull_preconditions(repo_path, version, dry_run):
+def _check_pull_preconditions(repo_path, version):
     """Check if repo is ready for a merge. Returns (branch, skip_reason)."""
-    if not dry_run and is_dirty(repo_path):
+    if is_dirty(repo_path):
         return None, "uncommitted changes — skipping merge"
 
     branch = get_default_branch(repo_path, version)
     current = get_current_branch(repo_path)
-    if not dry_run and current != branch:
+    if current != branch:
         return None, f"not on default branch (on '{current}', expected '{branch}')"
     return branch, None
 
 
 def _fetch_and_pull(repo_path, remote_name, version, dry_run):
     """Fetch and merge from remote. Returns (status, message)."""
-    branch, skip_reason = _check_pull_preconditions(repo_path, version, dry_run)
+    branch, skip_reason = _check_pull_preconditions(repo_path, version)
     if skip_reason:
         return "skip", skip_reason
 
@@ -141,7 +141,7 @@ def _fetch_into_branch(repo_path, remote_name, version, target_branch, dry_run):
     """Fetch and update a local branch from the remote. Returns (status, message)."""
     # git branch -f fails if the target branch is currently checked out
     current = get_current_branch(repo_path)
-    if not dry_run and current == target_branch:
+    if current == target_branch:
         return "skip", (
             f"branch '{target_branch}' is currently checked out — "
             "cannot force-update; use --pull instead"

--- a/.agent/scripts/pull_remote.py
+++ b/.agent/scripts/pull_remote.py
@@ -16,35 +16,19 @@ Prerequisites:
 """
 
 import argparse
-import subprocess
 import sys
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
-from workspace import get_overlay_repos
-
-
-def run_git(repo_path, args, dry_run=False):
-    """Run a git command in the given repo. Returns (success, stdout, stderr)."""
-    cmd = ["git"] + args
-    if dry_run:
-        print(f"  [DRY-RUN] {' '.join(cmd)}")
-        return True, "", ""
-    try:
-        result = subprocess.run(cmd, cwd=str(repo_path), capture_output=True, text=True, check=True)
-        return True, result.stdout.strip(), result.stderr.strip()
-    except subprocess.CalledProcessError as e:
-        return False, e.stdout.strip(), e.stderr.strip()
-
-
-def remote_exists(repo_path, remote_name):
-    """Check if a remote exists in the repo."""
-    success, output, _ = run_git(repo_path, ["remote"])
-    if not success:
-        return False
-    return remote_name in output.splitlines()
+from remote_utils import (
+    add_common_args,
+    get_default_branch,
+    remote_exists,
+    run_git,
+    run_script,
+)
 
 
 def is_dirty(repo_path):
@@ -59,54 +43,18 @@ def get_current_branch(repo_path):
     return output if success and output else None
 
 
-def resolve_repo_path(root_dir, repo):
-    """Resolve the local path for a repo entry. Returns Path or None."""
-    ws_name = repo["source_file"].replace(".repos", "_ws")
-    candidate = root_dir / "layers" / "main" / ws_name / "src" / repo["name"]
-    if candidate.exists():
-        return candidate
-    return None
-
-
-def get_default_branch(repo_path, version):
-    """Get the default branch for comparison."""
-    if version and version != "unknown":
-        return version
-    success, out, _ = run_git(repo_path, ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
-    return out.replace("origin/", "") if success and out else "main"
-
-
-def fetch_and_report(
-    repo_path, remote_name, version, dry_run
-):  # pylint: disable=too-many-return-statements
-    """Fetch from remote and report new commits. Returns (status, message)."""
-    if not remote_exists(repo_path, remote_name):
-        return "skip", f"remote '{remote_name}' not found"
-
-    # Fetch
-    success, _, err = run_git(repo_path, ["fetch", remote_name], dry_run)
-    if not success:
-        return "error", f"fetch failed: {err}"
-    if dry_run:
-        return "ok", "fetched (dry run)"
-
-    # Compare local default branch with remote's
-    branch = get_default_branch(repo_path, version)
-    remote_ref = f"{remote_name}/{branch}"
-
-    # Check if the remote ref exists
-    success, _, _ = run_git(repo_path, ["rev-parse", "--verify", remote_ref])
-    if not success:
-        return "ok", f"fetched (no {remote_ref} on remote)"
-
-    # Check if local branch exists
-    success, _, _ = run_git(repo_path, ["rev-parse", "--verify", branch])
-    if not success:
-        return "ok", f"fetched (local branch {branch} not found)"
+def _compare_branches(repo_path, branch, remote_ref):
+    """Compare local and remote branches. Returns (status, message) or None if not comparable."""
+    # Verify both refs exist
+    for ref, label in [(remote_ref, "remote"), (branch, "local branch")]:
+        success, _, _ = run_git(repo_path, ["rev-parse", "--verify", ref])
+        if not success:
+            return "ok", f"fetched (no {ref} on {label})"
 
     # Count commits ahead/behind
     success, output, _ = run_git(
-        repo_path, ["rev-list", "--left-right", "--count", f"{branch}...{remote_ref}"]
+        repo_path,
+        ["rev-list", "--left-right", "--count", f"{branch}...{remote_ref}"],
     )
     if not success or not output:
         return "ok", "fetched"
@@ -116,7 +64,6 @@ def fetch_and_report(
         return "ok", "fetched"
 
     ahead, behind = int(parts[0]), int(parts[1])
-
     if ahead == 0 and behind == 0:
         return "ok", "up to date"
 
@@ -142,20 +89,36 @@ def fetch_and_report(
     return "changes", "\n  ".join(lines)
 
 
-def fetch_and_pull(
-    repo_path, remote_name, version, dry_run
-):  # pylint: disable=too-many-return-statements
-    """Fetch and merge from remote. Returns (status, message)."""
-    if not remote_exists(repo_path, remote_name):
-        return "skip", f"remote '{remote_name}' not found"
+def _fetch_and_report(repo_path, remote_name, version, dry_run):
+    """Fetch from remote and report new commits. Returns (status, message)."""
+    success, _, err = run_git(repo_path, ["fetch", remote_name], dry_run)
+    if not success:
+        return "error", f"fetch failed: {err}"
+    if dry_run:
+        return "ok", "fetched (dry run)"
 
+    branch = get_default_branch(repo_path, version)
+    remote_ref = f"{remote_name}/{branch}"
+    return _compare_branches(repo_path, branch, remote_ref)
+
+
+def _check_pull_preconditions(repo_path, version, dry_run):
+    """Check if repo is ready for a merge. Returns (branch, skip_reason)."""
     if not dry_run and is_dirty(repo_path):
-        return "skip", "uncommitted changes — skipping merge"
+        return None, "uncommitted changes — skipping merge"
 
     branch = get_default_branch(repo_path, version)
     current = get_current_branch(repo_path)
     if not dry_run and current != branch:
-        return "skip", f"not on default branch (on '{current}', expected '{branch}')"
+        return None, f"not on default branch (on '{current}', expected '{branch}')"
+    return branch, None
+
+
+def _fetch_and_pull(repo_path, remote_name, version, dry_run):
+    """Fetch and merge from remote. Returns (status, message)."""
+    branch, skip_reason = _check_pull_preconditions(repo_path, version, dry_run)
+    if skip_reason:
+        return "skip", skip_reason
 
     # Fetch
     success, _, err = run_git(repo_path, ["fetch", remote_name], dry_run)
@@ -167,7 +130,6 @@ def fetch_and_pull(
     success, out, err = run_git(repo_path, ["merge", remote_ref, "--ff-only"], dry_run)
     if not success:
         return "error", f"merge failed (non-fast-forward?): {err}"
-
     if dry_run:
         return "ok", "merged (dry run)"
     if "Already up to date" in out:
@@ -175,11 +137,8 @@ def fetch_and_pull(
     return "ok", f"merged from {remote_ref}"
 
 
-def fetch_into_branch(repo_path, remote_name, version, target_branch, dry_run):
+def _fetch_into_branch(repo_path, remote_name, version, target_branch, dry_run):
     """Fetch and update a local branch from the remote. Returns (status, message)."""
-    if not remote_exists(repo_path, remote_name):
-        return "skip", f"remote '{remote_name}' not found"
-
     branch = get_default_branch(repo_path, version)
 
     # Fetch
@@ -203,11 +162,23 @@ def fetch_into_branch(repo_path, remote_name, version, target_branch, dry_run):
     return "ok", f"branch '{target_branch}' updated to {remote_ref}"
 
 
+def process_repo(repo_path, repo_name, version, args):
+    """Dispatch to the appropriate pull mode. Returns (status, message)."""
+    if not remote_exists(repo_path, args.remote):
+        return "skip", f"remote '{args.remote}' not found"
+
+    if args.pull:
+        return _fetch_and_pull(repo_path, args.remote, version, args.dry_run)
+    if args.branch:
+        return _fetch_into_branch(repo_path, args.remote, version, args.branch, args.dry_run)
+    return _fetch_and_report(repo_path, args.remote, version, args.dry_run)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Fetch/pull from a named remote for all workspace repositories."
     )
-    parser.add_argument("--remote", required=True, help="Remote name (e.g., gitcloud)")
+    add_common_args(parser)
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument(
         "--pull",
@@ -218,73 +189,31 @@ def main():
         "--branch",
         help="Create/update a local branch with remote changes (e.g., sync/gitcloud)",
     )
-    parser.add_argument(
-        "--manifest",
-        help="Filter by manifest name(s), comma-separated (e.g., core,platforms)",
-    )
-    parser.add_argument(
-        "--include-underlay",
-        action="store_true",
-        help="Include underlay repositories",
-    )
-    parser.add_argument("--dry-run", action="store_true", help="Show what would be done")
     args = parser.parse_args()
 
-    root_dir = SCRIPT_DIR.parent.parent
-    manifest_filter = (
-        set(f"{m.strip()}.repos" for m in args.manifest.split(",")) if args.manifest else None
-    )
-
-    repos = get_overlay_repos(include_underlay=args.include_underlay)
-    if manifest_filter:
-        repos = [r for r in repos if r["source_file"] in manifest_filter]
-
-    results = {"ok": 0, "changes": 0, "skip": 0, "error": 0, "missing": 0}
-
-    def process_repo(repo_path, repo_name, version):
-        print(f"{repo_name}")
-        if args.pull:
-            status, msg = fetch_and_pull(repo_path, args.remote, version, args.dry_run)
-        elif args.branch:
-            status, msg = fetch_into_branch(
-                repo_path, args.remote, version, args.branch, args.dry_run
-            )
-        else:
-            status, msg = fetch_and_report(repo_path, args.remote, version, args.dry_run)
-        print(f"  {status}: {msg}")
-        results[status] = results.get(status, 0) + 1
-
-    # Workspace repo itself
-    process_repo(root_dir, "ros2_agent_workspace (workspace root)", "main")
-
-    for repo in repos:
-        repo_path = resolve_repo_path(root_dir, repo)
-        if repo_path is None:
-            print(f"{repo['name']}")
-            print("  missing: could not find local checkout")
-            results["missing"] += 1
-            continue
-
-        process_repo(repo_path, repo["name"], repo["version"])
-
-    # Summary
-    total = sum(results.values())
     if args.pull or args.branch:
-        print(
-            f"\nSummary: {total} repos — "
-            f"{results['ok']} updated, {results['skip']} skipped, "
-            f"{results['error']} errors, {results['missing']} missing"
-        )
+        labels = [
+            ("ok", "updated"),
+            ("skip", "skipped"),
+            ("error", "errors"),
+            ("missing", "missing"),
+        ]
     else:
-        print(
-            f"\nSummary: {total} repos — "
-            f"{results['ok']} up to date, {results['changes']} with changes, "
-            f"{results['skip']} skipped, {results['error']} errors, "
-            f"{results['missing']} missing"
-        )
+        labels = [
+            ("ok", "up to date"),
+            ("changes", "with changes"),
+            ("skip", "skipped"),
+            ("error", "errors"),
+            ("missing", "missing"),
+        ]
 
-    if results["error"] > 0:
-        sys.exit(1)
+    run_script(
+        SCRIPT_DIR,
+        args,
+        process_repo,
+        {"ok": 0, "changes": 0, "skip": 0, "error": 0, "missing": 0},
+        labels,
+    )
 
 
 if __name__ == "__main__":

--- a/.agent/scripts/pull_remote.py
+++ b/.agent/scripts/pull_remote.py
@@ -139,6 +139,14 @@ def _fetch_and_pull(repo_path, remote_name, version, dry_run):
 
 def _fetch_into_branch(repo_path, remote_name, version, target_branch, dry_run):
     """Fetch and update a local branch from the remote. Returns (status, message)."""
+    # git branch -f fails if the target branch is currently checked out
+    current = get_current_branch(repo_path)
+    if not dry_run and current == target_branch:
+        return "skip", (
+            f"branch '{target_branch}' is currently checked out — "
+            "cannot force-update; use --pull instead"
+        )
+
     branch = get_default_branch(repo_path, version)
 
     # Fetch

--- a/.agent/scripts/pull_remote.py
+++ b/.agent/scripts/pull_remote.py
@@ -44,7 +44,7 @@ def get_current_branch(repo_path):
 
 
 def _compare_branches(repo_path, branch, remote_ref):
-    """Compare local and remote branches. Returns (status, message) or None if not comparable."""
+    """Compare local and remote branches. Returns (status, message)."""
     # Verify both refs exist
     for ref, label in [(remote_ref, "remote"), (branch, "local branch")]:
         success, _, _ = run_git(repo_path, ["rev-parse", "--verify", ref])
@@ -109,6 +109,8 @@ def _check_pull_preconditions(repo_path, version):
 
     branch = get_default_branch(repo_path, version)
     current = get_current_branch(repo_path)
+    if current is None:
+        return None, "detached HEAD — skipping merge"
     if current != branch:
         return None, f"not on default branch (on '{current}', expected '{branch}')"
     return branch, None

--- a/.agent/scripts/pull_remote.py
+++ b/.agent/scripts/pull_remote.py
@@ -49,7 +49,7 @@ def _compare_branches(repo_path, branch, remote_ref):
     for ref, label in [(remote_ref, "remote"), (branch, "local branch")]:
         success, _, _ = run_git(repo_path, ["rev-parse", "--verify", ref])
         if not success:
-            return "ok", f"fetched (no {ref} on {label})"
+            return "skip", f"fetched (no {ref} on {label})"
 
     # Count commits ahead/behind
     success, output, _ = run_git(

--- a/.agent/scripts/push_remote.py
+++ b/.agent/scripts/push_remote.py
@@ -15,76 +15,40 @@ Prerequisites:
 """
 
 import argparse
-import subprocess
 import sys
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
-from workspace import get_overlay_repos
+from remote_utils import (
+    add_common_args,
+    get_default_branch,
+    remote_exists,
+    run_git,
+    run_script,
+)
 
 
-def run_git(repo_path, args, dry_run=False):
-    """Run a git command in the given repo. Returns (success, stdout, stderr)."""
-    cmd = ["git"] + args
-    if dry_run:
-        print(f"  [DRY-RUN] {' '.join(cmd)}")
-        return True, "", ""
-    try:
-        result = subprocess.run(cmd, cwd=str(repo_path), capture_output=True, text=True, check=True)
-        return True, result.stdout.strip(), result.stderr.strip()
-    except subprocess.CalledProcessError as e:
-        return False, e.stdout.strip(), e.stderr.strip()
-
-
-def remote_exists(repo_path, remote_name):
-    """Check if a remote exists in the repo."""
-    success, output, _ = run_git(repo_path, ["remote"])
-    if not success:
-        return False
-    return remote_name in output.splitlines()
-
-
-def resolve_repo_path(root_dir, repo):
-    """Resolve the local path for a repo entry. Returns Path or None."""
-    ws_name = repo["source_file"].replace(".repos", "_ws")
-    candidate = root_dir / "layers" / "main" / ws_name / "src" / repo["name"]
-    if candidate.exists():
-        return candidate
-    return None
-
-
-def push_repo(
-    repo_path, repo_name, remote_name, version, all_branches, dry_run
-):  # pylint: disable=too-many-arguments
+def process_repo(repo_path, repo_name, version, args):
     """Push a single repo to the named remote. Returns (status, message)."""
-    if not remote_exists(repo_path, remote_name):
-        return "skip", f"remote '{remote_name}' not found"
+    if not remote_exists(repo_path, args.remote):
+        return "skip", f"remote '{args.remote}' not found"
 
     errors = []
 
-    if all_branches:
-        # Push all branches
-        success, out, err = run_git(repo_path, ["push", remote_name, "--all"], dry_run)
+    if args.all_branches:
+        success, _, err = run_git(repo_path, ["push", args.remote, "--all"], args.dry_run)
         if not success:
             errors.append(f"push --all failed: {err}")
     else:
-        # Push only the manifest-declared branch
-        branch = version if version and version != "unknown" else None
-        if not branch:
-            # Try to detect default branch
-            success, out, _ = run_git(
-                repo_path, ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"]
-            )
-            branch = out.replace("origin/", "") if success and out else "main"
-
-        success, out, err = run_git(repo_path, ["push", remote_name, branch], dry_run)
+        branch = get_default_branch(repo_path, version)
+        success, _, err = run_git(repo_path, ["push", args.remote, branch], args.dry_run)
         if not success:
             errors.append(f"push {branch} failed: {err}")
 
     # Always push tags
-    success, out, err = run_git(repo_path, ["push", remote_name, "--tags"], dry_run)
+    success, _, err = run_git(repo_path, ["push", args.remote, "--tags"], args.dry_run)
     if not success:
         errors.append(f"push --tags failed: {err}")
 
@@ -95,78 +59,19 @@ def push_repo(
 
 def main():
     parser = argparse.ArgumentParser(description="Push workspace repositories to a named remote.")
-    parser.add_argument("--remote", required=True, help="Remote name (e.g., gitcloud)")
+    add_common_args(parser)
     parser.add_argument(
         "--all-branches",
         action="store_true",
         help="Push all branches (default: push only manifest-declared branch)",
     )
-    parser.add_argument(
-        "--manifest",
-        help="Filter by manifest name(s), comma-separated (e.g., core,platforms)",
+    run_script(
+        SCRIPT_DIR,
+        parser.parse_args(),
+        process_repo,
+        {"ok": 0, "skip": 0, "error": 0, "missing": 0},
+        [("ok", "pushed"), ("skip", "skipped"), ("error", "errors"), ("missing", "missing")],
     )
-    parser.add_argument(
-        "--include-underlay",
-        action="store_true",
-        help="Include underlay repositories",
-    )
-    parser.add_argument("--dry-run", action="store_true", help="Show what would be done")
-    args = parser.parse_args()
-
-    root_dir = SCRIPT_DIR.parent.parent
-    manifest_filter = (
-        set(f"{m.strip()}.repos" for m in args.manifest.split(",")) if args.manifest else None
-    )
-
-    repos = get_overlay_repos(include_underlay=args.include_underlay)
-    if manifest_filter:
-        repos = [r for r in repos if r["source_file"] in manifest_filter]
-
-    results = {"ok": 0, "skip": 0, "error": 0, "missing": 0}
-
-    # Workspace repo itself
-    print("ros2_agent_workspace (workspace root)")
-    status, msg = push_repo(
-        root_dir,
-        "ros2_agent_workspace",
-        args.remote,
-        "main",
-        args.all_branches,
-        args.dry_run,
-    )
-    print(f"  {status}: {msg}")
-    results[status] = results.get(status, 0) + 1
-
-    for repo in repos:
-        repo_path = resolve_repo_path(root_dir, repo)
-        if repo_path is None:
-            print(f"{repo['name']}")
-            print("  missing: could not find local checkout")
-            results["missing"] += 1
-            continue
-
-        print(f"{repo['name']}")
-        status, msg = push_repo(
-            repo_path,
-            repo["name"],
-            args.remote,
-            repo["version"],
-            args.all_branches,
-            args.dry_run,
-        )
-        print(f"  {status}: {msg}")
-        results[status] = results.get(status, 0) + 1
-
-    # Summary
-    total = sum(results.values())
-    print(
-        f"\nSummary: {total} repos — "
-        f"{results['ok']} pushed, {results['skip']} skipped, "
-        f"{results['error']} errors, {results['missing']} missing"
-    )
-
-    if results["error"] > 0:
-        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/.agent/scripts/push_remote.py
+++ b/.agent/scripts/push_remote.py
@@ -8,6 +8,7 @@ plus tags to the named remote. Skips repos where the remote doesn't exist.
 Usage:
     python3 push_remote.py --remote gitcloud
     python3 push_remote.py --remote gitcloud --all-branches
+    python3 push_remote.py --remote gitcloud --set-default-branch
     python3 push_remote.py --remote gitcloud --manifest core,platforms --dry-run
 
 Prerequisites:
@@ -15,6 +16,8 @@ Prerequisites:
 """
 
 import argparse
+import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -30,19 +33,97 @@ from remote_utils import (
 )
 
 
+def parse_remote_url(repo_path, remote_name):
+    """Parse a remote URL into (scheme, host, owner, repo_name).
+
+    Supports SSH (git@host:owner/repo.git) and HTTPS (https://host/owner/repo.git).
+    Returns (None, None, None, None) if unparseable.
+    """
+    success, url, _ = run_git(repo_path, ["remote", "get-url", remote_name])
+    if not success or not url:
+        return None, None, None, None
+
+    # SSH: git@host:owner/repo.git
+    if url.startswith("git@"):
+        try:
+            host_part, path_part = url[4:].split(":", 1)
+            path_part = path_part.rstrip("/")
+            if path_part.endswith(".git"):
+                path_part = path_part[:-4]
+            parts = path_part.split("/")
+            if len(parts) >= 2:
+                return "ssh", host_part, parts[0], parts[1]
+        except ValueError:
+            pass
+
+    # HTTPS: https://host/owner/repo.git
+    if url.startswith("https://") or url.startswith("http://"):
+        scheme = url.split("://")[0]
+        path = url.split("://", 1)[1].rstrip("/")
+        if path.endswith(".git"):
+            path = path[:-4]
+        parts = path.split("/")
+        if len(parts) >= 3:
+            return scheme, parts[0], parts[1], parts[2]
+
+    return None, None, None, None
+
+
+def set_forgejo_default_branch(repo_path, remote_name, branch, dry_run):
+    """Set the default branch on a Forgejo/Gitea server via API.
+
+    Returns a message string describing the result.
+    """
+    scheme, host, owner, repo_name = parse_remote_url(repo_path, remote_name)
+    if not host:
+        return "could not parse remote URL for API call"
+
+    api_scheme = "https" if scheme == "ssh" else scheme
+    api_url = f"{api_scheme}://{host}/api/v1/repos/{owner}/{repo_name}"
+    payload = json.dumps({"default_branch": branch})
+
+    if dry_run:
+        print(f"  [DRY-RUN] PATCH {api_url} {payload}")
+        return "default branch set (dry run)"
+
+    try:
+        subprocess.run(
+            [
+                "curl",
+                "-sf",
+                "-X",
+                "PATCH",
+                api_url,
+                "-H",
+                "Content-Type: application/json",
+                "-d",
+                payload,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=15,
+        )
+        return f"default branch set to '{branch}'"
+    except subprocess.CalledProcessError:
+        return f"API call failed (is {host} a Forgejo/Gitea server?)"
+    except subprocess.TimeoutExpired:
+        return f"API call timed out ({host})"
+
+
 def process_repo(repo_path, repo_name, version, args):
     """Push a single repo to the named remote. Returns (status, message)."""
     if not remote_exists(repo_path, args.remote):
         return "skip", f"remote '{args.remote}' not found"
 
     errors = []
+    branch = get_default_branch(repo_path, version)
 
     if args.all_branches:
         success, _, err = run_git(repo_path, ["push", args.remote, "--all"], args.dry_run)
         if not success:
             errors.append(f"push --all failed: {err}")
     else:
-        branch = get_default_branch(repo_path, version)
         success, _, err = run_git(repo_path, ["push", args.remote, branch], args.dry_run)
         if not success:
             errors.append(f"push {branch} failed: {err}")
@@ -51,6 +132,11 @@ def process_repo(repo_path, repo_name, version, args):
     success, _, err = run_git(repo_path, ["push", args.remote, "--tags"], args.dry_run)
     if not success:
         errors.append(f"push --tags failed: {err}")
+
+    # Optionally set the default branch on the remote server
+    if args.set_default_branch:
+        msg = set_forgejo_default_branch(repo_path, args.remote, branch, args.dry_run)
+        print(f"  {msg}")
 
     if errors:
         return "error", "; ".join(errors)
@@ -64,6 +150,11 @@ def main():
         "--all-branches",
         action="store_true",
         help="Push all branches (default: push only manifest-declared branch)",
+    )
+    parser.add_argument(
+        "--set-default-branch",
+        action="store_true",
+        help="Set default branch on Forgejo/Gitea to match manifest version",
     )
     run_script(
         SCRIPT_DIR,

--- a/.agent/scripts/push_remote.py
+++ b/.agent/scripts/push_remote.py
@@ -13,10 +13,14 @@ Usage:
 
 Prerequisites:
     Remotes must already exist in each repo. Use add_remote.py for one-time setup.
+
+Environment variables:
+    FORGEJO_TOKEN   API token for Forgejo/Gitea (required for --set-default-branch).
 """
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -69,22 +73,34 @@ def parse_remote_url(repo_path, remote_name):
     return None, None, None, None
 
 
+def _build_forgejo_api_url(repo_path, remote_name):
+    """Build the Forgejo API URL for a repo. Returns (url, error_msg)."""
+    scheme, host, owner, repo_name = parse_remote_url(repo_path, remote_name)
+    if not host:
+        return None, "could not parse remote URL for API call"
+    api_scheme = "https" if scheme == "ssh" else scheme
+    return f"{api_scheme}://{host}/api/v1/repos/{owner}/{repo_name}", None
+
+
 def set_forgejo_default_branch(repo_path, remote_name, branch, dry_run):
     """Set the default branch on a Forgejo/Gitea server via API.
 
-    Returns a message string describing the result.
+    Uses the FORGEJO_TOKEN environment variable for authentication.
+    Returns (success: bool, message: str).
     """
-    scheme, host, owner, repo_name = parse_remote_url(repo_path, remote_name)
-    if not host:
-        return "could not parse remote URL for API call"
+    api_url, err = _build_forgejo_api_url(repo_path, remote_name)
+    if err:
+        return False, err
 
-    api_scheme = "https" if scheme == "ssh" else scheme
-    api_url = f"{api_scheme}://{host}/api/v1/repos/{owner}/{repo_name}"
+    token = os.environ.get("FORGEJO_TOKEN", "")
+    if not token:
+        return False, "FORGEJO_TOKEN not set — required for API calls"
+
     payload = json.dumps({"default_branch": branch})
 
     if dry_run:
         print(f"  [DRY-RUN] PATCH {api_url} {payload}")
-        return "default branch set (dry run)"
+        return True, "default branch set (dry run)"
 
     try:
         subprocess.run(
@@ -96,6 +112,8 @@ def set_forgejo_default_branch(repo_path, remote_name, branch, dry_run):
                 api_url,
                 "-H",
                 "Content-Type: application/json",
+                "-H",
+                f"Authorization: token {token}",
                 "-d",
                 payload,
             ],
@@ -104,13 +122,9 @@ def set_forgejo_default_branch(repo_path, remote_name, branch, dry_run):
             check=True,
             timeout=15,
         )
-        return f"default branch set to '{branch}'"
-    except FileNotFoundError:
-        return "curl not found — install curl for Forgejo API support"
-    except subprocess.CalledProcessError:
-        return f"API call failed (is {host} a Forgejo/Gitea server?)"
-    except subprocess.TimeoutExpired:
-        return f"API call timed out ({host})"
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        return False, f"API call failed: {exc}"
+    return True, f"default branch set to '{branch}'"
 
 
 def process_repo(repo_path, repo_name, version, args):
@@ -137,8 +151,10 @@ def process_repo(repo_path, repo_name, version, args):
 
     # Optionally set the default branch on the remote server
     if args.set_default_branch:
-        msg = set_forgejo_default_branch(repo_path, args.remote, branch, args.dry_run)
+        ok, msg = set_forgejo_default_branch(repo_path, args.remote, branch, args.dry_run)
         print(f"  {msg}")
+        if not ok:
+            errors.append(f"set-default-branch failed: {msg}")
 
     if errors:
         return "error", "; ".join(errors)
@@ -156,7 +172,8 @@ def main():
     parser.add_argument(
         "--set-default-branch",
         action="store_true",
-        help="Set default branch on Forgejo/Gitea to match manifest version",
+        help="Set default branch on Forgejo/Gitea to match manifest "
+        "version (requires FORGEJO_TOKEN)",
     )
     run_script(
         SCRIPT_DIR,

--- a/.agent/scripts/push_remote.py
+++ b/.agent/scripts/push_remote.py
@@ -133,7 +133,14 @@ def process_repo(repo_path, repo_name, version, args):
         if not success:
             errors.append(f"push --all failed: {err}")
     else:
-        success, _, err = run_git(repo_path, ["push", args.remote, branch], args.dry_run)
+        # Use explicit refspec — the branch may only exist as a remote tracking
+        # ref (refs/remotes/origin/<branch>) with no local branch.
+        local_exists, _, _ = run_git(repo_path, ["rev-parse", "--verify", f"refs/heads/{branch}"])
+        if local_exists:
+            refspec = branch
+        else:
+            refspec = f"origin/{branch}:{branch}"
+        success, _, err = run_git(repo_path, ["push", args.remote, refspec], args.dry_run)
         if not success:
             errors.append(f"push {branch} failed: {err}")
 
@@ -168,9 +175,13 @@ def main():
         help="Set default branch on Forgejo/Gitea to match manifest "
         "version (requires FORGEJO_TOKEN)",
     )
+    args = parser.parse_args()
+    if args.set_default_branch and not os.environ.get("FORGEJO_TOKEN"):
+        parser.error("--set-default-branch requires FORGEJO_TOKEN environment variable")
+
     run_script(
         SCRIPT_DIR,
-        parser.parse_args(),
+        args,
         process_repo,
         {"ok": 0, "skip": 0, "error": 0, "missing": 0},
         [("ok", "pushed"), ("skip", "skipped"), ("error", "errors"), ("missing", "missing")],

--- a/.agent/scripts/push_remote.py
+++ b/.agent/scripts/push_remote.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Push workspace repositories to a named remote.
+
+Iterates all workspace repos and pushes the manifest-declared default branch
+plus tags to the named remote. Skips repos where the remote doesn't exist.
+
+Usage:
+    python3 push_remote.py --remote gitcloud
+    python3 push_remote.py --remote gitcloud --all-branches
+    python3 push_remote.py --remote gitcloud --manifest core,platforms --dry-run
+
+Prerequisites:
+    Remotes must already exist in each repo. Use add_remote.py for one-time setup.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from workspace import get_overlay_repos
+
+
+def run_git(repo_path, args, dry_run=False):
+    """Run a git command in the given repo. Returns (success, stdout, stderr)."""
+    cmd = ["git"] + args
+    if dry_run:
+        print(f"  [DRY-RUN] {' '.join(cmd)}")
+        return True, "", ""
+    try:
+        result = subprocess.run(cmd, cwd=str(repo_path), capture_output=True, text=True, check=True)
+        return True, result.stdout.strip(), result.stderr.strip()
+    except subprocess.CalledProcessError as e:
+        return False, e.stdout.strip(), e.stderr.strip()
+
+
+def remote_exists(repo_path, remote_name):
+    """Check if a remote exists in the repo."""
+    success, output, _ = run_git(repo_path, ["remote"])
+    if not success:
+        return False
+    return remote_name in output.splitlines()
+
+
+def resolve_repo_path(root_dir, repo):
+    """Resolve the local path for a repo entry. Returns Path or None."""
+    ws_name = repo["source_file"].replace(".repos", "_ws")
+    candidate = root_dir / "layers" / "main" / ws_name / "src" / repo["name"]
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def push_repo(
+    repo_path, repo_name, remote_name, version, all_branches, dry_run
+):  # pylint: disable=too-many-arguments
+    """Push a single repo to the named remote. Returns (status, message)."""
+    if not remote_exists(repo_path, remote_name):
+        return "skip", f"remote '{remote_name}' not found"
+
+    errors = []
+
+    if all_branches:
+        # Push all branches
+        success, out, err = run_git(repo_path, ["push", remote_name, "--all"], dry_run)
+        if not success:
+            errors.append(f"push --all failed: {err}")
+    else:
+        # Push only the manifest-declared branch
+        branch = version if version and version != "unknown" else None
+        if not branch:
+            # Try to detect default branch
+            success, out, _ = run_git(
+                repo_path, ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"]
+            )
+            branch = out.replace("origin/", "") if success and out else "main"
+
+        success, out, err = run_git(repo_path, ["push", remote_name, branch], dry_run)
+        if not success:
+            errors.append(f"push {branch} failed: {err}")
+
+    # Always push tags
+    success, out, err = run_git(repo_path, ["push", remote_name, "--tags"], dry_run)
+    if not success:
+        errors.append(f"push --tags failed: {err}")
+
+    if errors:
+        return "error", "; ".join(errors)
+    return "ok", "pushed"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Push workspace repositories to a named remote.")
+    parser.add_argument("--remote", required=True, help="Remote name (e.g., gitcloud)")
+    parser.add_argument(
+        "--all-branches",
+        action="store_true",
+        help="Push all branches (default: push only manifest-declared branch)",
+    )
+    parser.add_argument(
+        "--manifest",
+        help="Filter by manifest name(s), comma-separated (e.g., core,platforms)",
+    )
+    parser.add_argument(
+        "--include-underlay",
+        action="store_true",
+        help="Include underlay repositories",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done")
+    args = parser.parse_args()
+
+    root_dir = SCRIPT_DIR.parent.parent
+    manifest_filter = (
+        set(f"{m.strip()}.repos" for m in args.manifest.split(",")) if args.manifest else None
+    )
+
+    repos = get_overlay_repos(include_underlay=args.include_underlay)
+    if manifest_filter:
+        repos = [r for r in repos if r["source_file"] in manifest_filter]
+
+    results = {"ok": 0, "skip": 0, "error": 0, "missing": 0}
+
+    # Workspace repo itself
+    print("ros2_agent_workspace (workspace root)")
+    status, msg = push_repo(
+        root_dir,
+        "ros2_agent_workspace",
+        args.remote,
+        "main",
+        args.all_branches,
+        args.dry_run,
+    )
+    print(f"  {status}: {msg}")
+    results[status] = results.get(status, 0) + 1
+
+    for repo in repos:
+        repo_path = resolve_repo_path(root_dir, repo)
+        if repo_path is None:
+            print(f"{repo['name']}")
+            print("  missing: could not find local checkout")
+            results["missing"] += 1
+            continue
+
+        print(f"{repo['name']}")
+        status, msg = push_repo(
+            repo_path,
+            repo["name"],
+            args.remote,
+            repo["version"],
+            args.all_branches,
+            args.dry_run,
+        )
+        print(f"  {status}: {msg}")
+        results[status] = results.get(status, 0) + 1
+
+    # Summary
+    total = sum(results.values())
+    print(
+        f"\nSummary: {total} repos — "
+        f"{results['ok']} pushed, {results['skip']} skipped, "
+        f"{results['error']} errors, {results['missing']} missing"
+    )
+
+    if results["error"] > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agent/scripts/push_remote.py
+++ b/.agent/scripts/push_remote.py
@@ -21,8 +21,9 @@ Environment variables:
 import argparse
 import json
 import os
-import subprocess
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
@@ -102,28 +103,20 @@ def set_forgejo_default_branch(repo_path, remote_name, branch, dry_run):
         print(f"  [DRY-RUN] PATCH {api_url} {payload}")
         return True, "default branch set (dry run)"
 
+    req = urllib.request.Request(
+        api_url,
+        data=payload.encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"token {token}",
+        },
+        method="PATCH",
+    )
     try:
-        subprocess.run(
-            [
-                "curl",
-                "-sf",
-                "-X",
-                "PATCH",
-                api_url,
-                "-H",
-                "Content-Type: application/json",
-                "-H",
-                f"Authorization: token {token}",
-                "-d",
-                payload,
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=15,
-        )
-    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-        return False, f"API call failed: {exc}"
+        with urllib.request.urlopen(req, timeout=15):
+            pass
+    except urllib.error.URLError as exc:
+        return False, f"API call failed: {exc.reason}"
     return True, f"default branch set to '{branch}'"
 
 

--- a/.agent/scripts/push_remote.py
+++ b/.agent/scripts/push_remote.py
@@ -105,6 +105,8 @@ def set_forgejo_default_branch(repo_path, remote_name, branch, dry_run):
             timeout=15,
         )
         return f"default branch set to '{branch}'"
+    except FileNotFoundError:
+        return "curl not found — install curl for Forgejo API support"
     except subprocess.CalledProcessError:
         return f"API call failed (is {host} a Forgejo/Gitea server?)"
     except subprocess.TimeoutExpired:

--- a/.agent/work-plans/PLAN_ISSUE-422.md
+++ b/.agent/work-plans/PLAN_ISSUE-422.md
@@ -1,0 +1,77 @@
+# Plan: Sync workspace repos to a secondary git server
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/422
+
+## Context
+
+The workspace has 37 repos across 7 layers, all with `origin` pointing at GitHub.
+Field robots pull from a private Forgejo instance. We manually proved the workflow:
+add a named remote per repo, `git push <remote> --all`. Now we need a script to
+automate this as a single command with parameterized remote name and URL prefix.
+
+The existing `sync_repos.py` (pull from origin) and `workspace.py` library
+(`get_overlay_repos`) already solve the repo-discovery problem. The new script
+should reuse `workspace.py` for repo enumeration and follow the same patterns.
+
+## Approach
+
+1. **Create `push_repos.py`** in `.agent/scripts/` — a new script (not extending
+   `sync_repos.py`, which is pull-oriented). It will:
+   - Accept required args: `--remote-name` (e.g., `gitcloud`) and `--url-prefix`
+     (e.g., `git@gitcloud:field/`)
+   - Accept optional args: `--manifest` to filter by `.repos` file name(s)
+     (e.g., `--manifest core,platforms`), `--include-underlay` flag, `--dry-run`
+   - Always include the workspace repo itself (like `sync_repos.py` does)
+   - For each repo: add the named remote if it doesn't exist, then `git push <remote> --all`
+   - Report success/failure per repo with a summary at the end
+
+2. **Add a Makefile target** — `make push-repos` that invokes the script.
+   Require `REMOTE_NAME` and `URL_PREFIX` as make variables so the command
+   is self-documenting: `make push-repos REMOTE_NAME=gitcloud URL_PREFIX=git@gitcloud:field/`
+
+3. **Document usage** in the script's docstring and Makefile help target.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/push_repos.py` | New script — remote management and push logic |
+| `Makefile` | Add `push-repos` phony target |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Workspace vs. project separation | Script is generic infrastructure — no project-specific content. Remote name and URL are parameters, not hardcoded. |
+| Only what's needed | Single script + Makefile target. No config files, no new dependencies. |
+| Enforcement over documentation | Makefile target makes the command discoverable; required args prevent misconfiguration. |
+| A change includes its consequences | Makefile help text updated; script docstring serves as docs. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0003 (project-agnostic) | Yes | Remote name and URL prefix are parameters, not hardcoded to any server. The script works for any secondary git server. |
+| ADR-0007 (retain Make) | Yes | Adding a Makefile target follows the established pattern. |
+| ADR-0009 (Python packages) | No | Only uses stdlib + PyYAML (already a workspace dependency via workspace.py). |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Add Makefile target | `make help` output | Yes — .PHONY + help text |
+| Add new script | Script reference in AGENTS.md | Yes — add to table |
+
+## Open Questions
+
+- Should `--all` (push all branches) be default, or should we default to pushing
+  only the manifest-declared branch (e.g., `jazzy`) and require `--all-branches`
+  to push everything? Pushing all branches is what we did manually and matches
+  a full-mirror use case, but for field robots only the default branch may matter.
+- Should we also push tags? (`git push <remote> --tags`)
+
+## Estimated Scope
+
+Single PR.

--- a/.agent/work-plans/PLAN_ISSUE-422.md
+++ b/.agent/work-plans/PLAN_ISSUE-422.md
@@ -163,10 +163,60 @@ make pull-remote REMOTE=gitcloud              # fetch + report
 | `Makefile` | Add `push-remote` and `pull-remote` targets |
 | `AGENTS.md` | Add scripts to reference table |
 
-### Open Questions (Revised)
+### Resolved Questions
 
-- Should the one-time `add_remote.py` helper be included in this PR or deferred?
-  For 37 repos, manual setup is tedious. But keeping this PR focused on push/pull
-  is cleaner.
-- For `pull_remote.py`, should it suggest the next step per repo (e.g., "run
-  `git merge gitcloud/jazzy`" or "create a PR")? Or keep output minimal?
+- **`add_remote.py` helper**: Include in this PR. Manual setup for 37 repos is
+  too tedious. Derives target repo name from origin URL via `extract_github_owner_repo`.
+- **`pull_remote.py` output and actions**: Default mode fetches and reports, listing
+  individual commits when the remote has new ones. Two action modes available:
+  - `--pull`: merge remote changes directly into the current branch
+  - `--branch <name>`: pull remote changes into a named branch (for PR workflows)
+
+### Additional Script: `add_remote.py`
+
+```
+add_remote.py --remote <name> --url-prefix <prefix>
+              [--manifest <name,...>] [--include-underlay] [--dry-run]
+```
+
+- Iterates all workspace repos (via `list_overlay_repos` + workspace root)
+- Derives repo name from origin URL (e.g., `https://github.com/rolker/foo.git` → `foo`)
+- Adds remote `<name>` pointing to `<prefix><repo_name>.git`
+- Skips repos where the remote already exists
+- One-time setup; subsequent push/pull just use `--remote <name>`
+
+### Revised `pull_remote.py`
+
+```
+pull_remote.py --remote <name> [--pull] [--branch <name>]
+               [--manifest <name,...>] [--include-underlay] [--dry-run]
+```
+
+- **Default (no flags)**: fetch + report. For repos with new remote commits,
+  list them (short hash + subject line).
+- **`--pull`**: fetch, then merge the remote's branch into the current local branch.
+  Skip repos with dirty working directories.
+- **`--branch <name>`**: fetch, then create/update a local branch with the remote's
+  changes. Useful for repos that require PRs — push the branch and open a PR.
+- `--pull` and `--branch` are mutually exclusive.
+
+### Revised Makefile Targets
+
+```makefile
+make add-remote REMOTE=gitcloud URL_PREFIX=git@gitcloud:field/   # one-time setup
+make push-remote REMOTE=gitcloud              # push default branches + tags
+make push-remote REMOTE=gitcloud ALL=1        # push all branches + tags
+make pull-remote REMOTE=gitcloud              # fetch + report with commit listing
+make pull-remote REMOTE=gitcloud PULL=1       # fetch + merge
+make pull-remote REMOTE=gitcloud BRANCH=sync/gitcloud  # fetch into branch
+```
+
+### Revised Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/add_remote.py` | New — one-time remote setup for all repos |
+| `.agent/scripts/push_remote.py` | New — push to named remote |
+| `.agent/scripts/pull_remote.py` | New — fetch/report/pull from named remote |
+| `Makefile` | Add `add-remote`, `push-remote`, and `pull-remote` targets |
+| `AGENTS.md` | Add scripts to reference table |

--- a/.agent/work-plans/PLAN_ISSUE-422.md
+++ b/.agent/work-plans/PLAN_ISSUE-422.md
@@ -75,3 +75,98 @@ should reuse `workspace.py` for repo enumeration and follow the same patterns.
 ## Estimated Scope
 
 Single PR.
+
+---
+
+## Revised Approach (2026-03-27)
+
+After discussion, the design has changed significantly from the original approach above.
+
+### Key Design Decisions
+
+1. **No config file, no URL prefix argument for routine use.** Remotes are assumed
+   to already exist in each repo (added once manually or via a one-time helper).
+   The scripts just take `--remote <name>` and operate on repos where that remote
+   exists, skipping others with a warning.
+
+2. **Two separate scripts** (leave `sync_repos.py` unchanged):
+   - **`push_remote.py --remote <name>`** — Push to a named remote
+   - **`pull_remote.py --remote <name>`** — Pull/fetch from a named remote
+
+3. **Push default branch + tags by default.** The manifest-declared branch
+   (e.g., `jazzy`) is pushed, plus all tags. `--all-branches` opt-in for full mirror.
+
+4. **Pull = fetch + report.** Fetch from the named remote and report which repos
+   have new commits. Don't merge or create branches automatically — some repos
+   require PRs on GitHub, so the user decides how to integrate changes. Branch
+   creation or PR automation can be added later once patterns are clear.
+
+### Revised Script Designs
+
+#### `push_remote.py`
+
+```
+push_remote.py --remote <name> [--all-branches] [--manifest <name,...>]
+                               [--include-underlay] [--dry-run]
+```
+
+- Iterates all workspace repos (via `list_overlay_repos` + workspace root)
+- For each repo: if the named remote exists, push the manifest-declared branch + tags
+- If `--all-branches`: push all branches instead of just the default
+- Skip repos where the remote doesn't exist (warn)
+- Report per-repo success/failure with summary
+
+#### `pull_remote.py`
+
+```
+pull_remote.py --remote <name> [--manifest <name,...>]
+                               [--include-underlay] [--dry-run]
+```
+
+- Iterates all workspace repos
+- For each repo: if the named remote exists, `git fetch <remote>`
+- Compare the remote's default branch against the local default branch
+- Report repos with new commits (ahead/behind counts)
+- No automatic merge — user decides how to integrate (manual merge, PR, etc.)
+
+### Remote Setup (One-Time)
+
+Remotes are added manually or via a future `add_remote.py` helper:
+
+```bash
+# Manual (per repo)
+cd layers/main/core_ws/src/some_repo
+git remote add gitcloud git@gitcloud:field/some_repo.git
+
+# Future helper (all repos at once — not in this PR)
+# add_remote.py --remote gitcloud --url-prefix git@gitcloud:field/
+```
+
+The URL prefix helper could be a follow-up PR if the manual approach proves too
+tedious for 37 repos. It would derive the repo name from the origin URL
+(via `extract_github_owner_repo`) rather than the directory name.
+
+### Makefile Targets
+
+```makefile
+make push-remote REMOTE=gitcloud              # push default branches + tags
+make push-remote REMOTE=gitcloud ALL=1        # push all branches + tags
+make pull-remote REMOTE=gitcloud              # fetch + report
+```
+
+### Files to Change (Revised)
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/push_remote.py` | New — push to named remote |
+| `.agent/scripts/pull_remote.py` | New — fetch from named remote + report |
+| `Makefile` | Add `push-remote` and `pull-remote` targets |
+| `AGENTS.md` | Add scripts to reference table |
+
+### Open Questions (Revised)
+
+- Should the one-time `add_remote.py` helper be included in this PR or deferred?
+  For 37 repos, manual setup is tedious. But keeping this PR focused on push/pull
+  is cleaner.
+- For `pull_remote.py`, should it suggest the next step per repo (e.g., "run
+  `git merge gitcloud/jazzy`" or "create a PR")? Or keep output minimal?

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
       - id: pylint
         args:
           - '--max-line-length=100'
-          - '--disable=C0114,C0115,C0116,E0401,C0413,C0411,R0914,R0912,R0915,W0718,W1514,W0613,W0123,R1705,W1510,R0801'
+          - '--disable=C0114,C0115,C0116,E0401,C0413,C0411,R0914,R0912,R0915,W0718,W1514,W0613,W0123,R1705,W1510'
         files: ^.agent/scripts/.*\.py$
 
   - repo: https://github.com/adrienverge/yamllint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
       - id: pylint
         args:
           - '--max-line-length=100'
-          - '--disable=C0114,C0115,C0116,E0401,C0413,C0411,R0914,R0912,R0915,W0718,W1514,W0613,W0123,R1705,W1510'
+          - '--disable=C0114,C0115,C0116,E0401,C0413,C0411,R0914,R0912,R0915,W0718,W1514,W0613,W0123,R1705,W1510,R0801'
         files: ^.agent/scripts/.*\.py$
 
   - repo: https://github.com/adrienverge/yamllint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,9 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/git_bug_setup.sh` | Configure git-bug identity + GitHub bridge |
 | `.agent/scripts/revert_feature.sh` | Revert all commits for an issue |
 | `.agent/scripts/sync_repos.py` | Sync all workspace repositories (includes git-bug) |
+| `.agent/scripts/add_remote.py` | Add a named remote to all repos (one-time setup) |
+| `.agent/scripts/push_remote.py` | Push to a named remote across all repos |
+| `.agent/scripts/pull_remote.py` | Fetch/pull from a named remote across all repos |
 | `.agent/scripts/validate_workspace.py` | Validate repos match .repos config |
 | `.agent/scripts/detect_agent_identity.sh` | Auto-detect agent framework + model |
 | `.agent/scripts/fetch_pr_reviews.sh` | Fetch all PR reviews and CI status |

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ help:
 	@echo ""
 	@echo "Remote sync:"
 	@echo "  add-remote REMOTE=<name> URL_PREFIX=<prefix> - Add remote to all repos"
-	@echo "  push-remote REMOTE=<name> [ALL=1]            - Push to named remote"
+	@echo "  push-remote REMOTE=<name> [ALL=1] [SET_DEFAULT=1] - Push to named remote"
 	@echo "  pull-remote REMOTE=<name> [PULL=1|BRANCH=<b>] - Fetch/pull from remote"
 	@echo ""
 	@echo "Maintenance:"
@@ -214,10 +214,10 @@ add-remote:
 push-remote:
 	@if [ -z "$(REMOTE)" ]; then \
 		echo "Error: REMOTE parameter required"; \
-		echo "Usage: make push-remote REMOTE=gitcloud [ALL=1]"; \
+		echo "Usage: make push-remote REMOTE=gitcloud [ALL=1] [SET_DEFAULT=1]"; \
 		exit 1; \
 	fi
-	@python3 ./.agent/scripts/push_remote.py --remote $(REMOTE) $(if $(ALL),--all-branches,)
+	@python3 ./.agent/scripts/push_remote.py --remote $(REMOTE) $(if $(ALL),--all-branches,) $(if $(SET_DEFAULT),--set-default-branch,)
 
 pull-remote:
 	@if [ -z "$(REMOTE)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 LAYER_STAMPS := $(patsubst %,$(STAMP)/layer-%.done,$(LAYERS))
 
 # --- Phony targets ---
-.PHONY: help build test lint clean setup-all dashboard dashboard-ui test-dashboard validate sync lock unlock revert-feature pr-triage generate-skills skip-bootstrap skip-git-bug agent-build agent-run agent-shell push-gateway
+.PHONY: help build test lint clean setup-all dashboard dashboard-ui test-dashboard validate sync lock unlock revert-feature pr-triage generate-skills skip-bootstrap skip-git-bug agent-build agent-run agent-shell push-gateway add-remote push-remote pull-remote
 
 # =============================================================================
 # Tier 2 — Developer workflow
@@ -62,6 +62,11 @@ help:
 	@echo "  dashboard-ui  - Start web-based dashboard (http://localhost:3000)"
 	@echo "  test-dashboard - Run dashboard unit/integration tests (ephemeral port)"
 	@echo "  validate      - Validate workspace config (CI-oriented, pass/fail)"
+	@echo ""
+	@echo "Remote sync:"
+	@echo "  add-remote REMOTE=<name> URL_PREFIX=<prefix> - Add remote to all repos"
+	@echo "  push-remote REMOTE=<name> [ALL=1]            - Push to named remote"
+	@echo "  pull-remote REMOTE=<name> [PULL=1|BRANCH=<b>] - Fetch/pull from remote"
 	@echo ""
 	@echo "Maintenance:"
 	@echo "  sync          - Safely sync all workspace repositories"
@@ -197,6 +202,30 @@ skip-git-bug:
 
 sync:
 	@python3 ./.agent/scripts/sync_repos.py
+
+add-remote:
+	@if [ -z "$(REMOTE)" ] || [ -z "$(URL_PREFIX)" ]; then \
+		echo "Error: REMOTE and URL_PREFIX required"; \
+		echo "Usage: make add-remote REMOTE=gitcloud URL_PREFIX=git@gitcloud:field/"; \
+		exit 1; \
+	fi
+	@python3 ./.agent/scripts/add_remote.py --remote $(REMOTE) --url-prefix "$(URL_PREFIX)"
+
+push-remote:
+	@if [ -z "$(REMOTE)" ]; then \
+		echo "Error: REMOTE parameter required"; \
+		echo "Usage: make push-remote REMOTE=gitcloud [ALL=1]"; \
+		exit 1; \
+	fi
+	@python3 ./.agent/scripts/push_remote.py --remote $(REMOTE) $(if $(ALL),--all-branches,)
+
+pull-remote:
+	@if [ -z "$(REMOTE)" ]; then \
+		echo "Error: REMOTE parameter required"; \
+		echo "Usage: make pull-remote REMOTE=gitcloud [PULL=1] [BRANCH=<name>]"; \
+		exit 1; \
+	fi
+	@python3 ./.agent/scripts/pull_remote.py --remote $(REMOTE) $(if $(PULL),--pull,) $(if $(BRANCH),--branch $(BRANCH),)
 
 lock:
 	@./.agent/scripts/lock.sh "Manual lock via Makefile"

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ push-remote:
 		echo "Usage: make push-remote REMOTE=gitcloud [ALL=1] [SET_DEFAULT=1]"; \
 		exit 1; \
 	fi
-	@python3 ./.agent/scripts/push_remote.py --remote $(REMOTE) $(if $(ALL),--all-branches,) $(if $(SET_DEFAULT),--set-default-branch,)
+	@python3 ./.agent/scripts/push_remote.py --remote $(REMOTE) $(if $(filter 1,$(ALL)),--all-branches,) $(if $(filter 1,$(SET_DEFAULT)),--set-default-branch,)
 
 pull-remote:
 	@if [ -z "$(REMOTE)" ]; then \
@@ -225,7 +225,7 @@ pull-remote:
 		echo "Usage: make pull-remote REMOTE=gitcloud [PULL=1] [BRANCH=<name>]"; \
 		exit 1; \
 	fi
-	@python3 ./.agent/scripts/pull_remote.py --remote $(REMOTE) $(if $(PULL),--pull,) $(if $(BRANCH),--branch $(BRANCH),)
+	@python3 ./.agent/scripts/pull_remote.py --remote $(REMOTE) $(if $(filter 1,$(PULL)),--pull,) $(if $(BRANCH),--branch $(BRANCH),)
 
 lock:
 	@./.agent/scripts/lock.sh "Manual lock via Makefile"


### PR DESCRIPTION
Closes #422

# Plan: Sync workspace repos to a secondary git server

## Issue

https://github.com/rolker/ros2_agent_workspace/issues/422

## Context

The workspace has 37 repos across 7 layers, all with `origin` pointing at GitHub.
Field robots pull from a private Forgejo instance. We manually proved the workflow:
add a named remote per repo, `git push <remote> --all`. Now we need a script to
automate this as a single command with parameterized remote name and URL prefix.

The existing `sync_repos.py` (pull from origin) and `workspace.py` library
(`get_overlay_repos`) already solve the repo-discovery problem. The new script
should reuse `workspace.py` for repo enumeration and follow the same patterns.

## Approach

1. **Create `push_repos.py`** in `.agent/scripts/` — a new script (not extending
   `sync_repos.py`, which is pull-oriented). It will:
   - Accept required args: `--remote-name` (e.g., `gitcloud`) and `--url-prefix`
     (e.g., `git@gitcloud:field/`)
   - Accept optional args: `--manifest` to filter by `.repos` file name(s)
     (e.g., `--manifest core,platforms`), `--include-underlay` flag, `--dry-run`
   - Always include the workspace repo itself (like `sync_repos.py` does)
   - For each repo: add the named remote if it doesn't exist, then `git push <remote> --all`
   - Report success/failure per repo with a summary at the end

2. **Add a Makefile target** — `make push-repos` that invokes the script.
   Require `REMOTE_NAME` and `URL_PREFIX` as make variables so the command
   is self-documenting: `make push-repos REMOTE_NAME=gitcloud URL_PREFIX=git@gitcloud:field/`

3. **Document usage** in the script's docstring and Makefile help target.

## Files to Change

| File | Change |
|------|--------|
| `.agent/scripts/push_repos.py` | New script — remote management and push logic |
| `Makefile` | Add `push-repos` phony target |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Workspace vs. project separation | Script is generic infrastructure — no project-specific content. Remote name and URL are parameters, not hardcoded. |
| Only what's needed | Single script + Makefile target. No config files, no new dependencies. |
| Enforcement over documentation | Makefile target makes the command discoverable; required args prevent misconfiguration. |
| A change includes its consequences | Makefile help text updated; script docstring serves as docs. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| ADR-0003 (project-agnostic) | Yes | Remote name and URL prefix are parameters, not hardcoded to any server. The script works for any secondary git server. |
| ADR-0007 (retain Make) | Yes | Adding a Makefile target follows the established pattern. |
| ADR-0009 (Python packages) | No | Only uses stdlib + PyYAML (already a workspace dependency via workspace.py). |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| Add Makefile target | `make help` output | Yes — .PHONY + help text |
| Add new script | Script reference in AGENTS.md | Yes — add to table |

## Open Questions

- Should `--all` (push all branches) be default, or should we default to pushing
  only the manifest-declared branch (e.g., `jazzy`) and require `--all-branches`
  to push everything? Pushing all branches is what we did manually and matches
  a full-mirror use case, but for field robots only the default branch may matter.
- Should we also push tags? (`git push <remote> --tags`)

## Estimated Scope

Single PR.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
