### PR TITLE
[PLAN] fix: layer worktree Python paths shadowed by main tree symlink-install

### DIFF
--- a/.agent/scripts/tests/test_worktree_create.sh
+++ b/.agent/scripts/tests/test_worktree_create.sh
@@ -37,6 +37,18 @@ setup_mock_workspace() {
     # Copy the script under test into the mock workspace
     cp "$CREATE_SCRIPT" .agent/scripts/worktree_create.sh
     chmod +x .agent/scripts/worktree_create.sh
+
+    # Layer manifest is required by worktree_create.sh
+    mkdir -p configs/manifest
+    cat > configs/manifest/layers.txt << 'LAYERS_EOF'
+underlay
+core
+platforms
+site
+sensors
+simulation
+ui
+LAYERS_EOF
 }
 
 # Cleanup test repository
@@ -177,6 +189,18 @@ setup_mock_layer_workspace() {
     # Copy the script under test into the mock workspace
     cp "$CREATE_SCRIPT" .agent/scripts/worktree_create.sh
     chmod +x .agent/scripts/worktree_create.sh
+
+    # Layer manifest is required by worktree_create.sh
+    mkdir -p configs/manifest
+    cat > configs/manifest/layers.txt << 'LAYERS_EOF'
+underlay
+core
+platforms
+site
+sensors
+simulation
+ui
+LAYERS_EOF
 
     rm -rf "$tmp_clone"
 }
@@ -675,6 +699,151 @@ test_find_worktree_by_skill_cross_repo_sort() {
     return 0
 }
 run_test "find_worktree_by_skill picks newest timestamp across repo slugs" test_find_worktree_by_skill_cross_repo_sort
+
+# ===== #427 path-priority block tests =====
+
+# Test 21: Layer worktree setup.bash contains the #427 prioritization block
+test_layer_setup_bash_has_path_priority_block() {
+    setup_mock_layer_workspace
+    cd "$WORKSPACE_DIR" || return 1
+
+    .agent/scripts/worktree_create.sh --issue 427001 --type layer --layer core --packages test_pkg >/dev/null 2>&1 || true
+
+    local wt_setup="$WORKSPACE_DIR/layers/worktrees/issue-pkg_origin-427001/setup.bash"
+    if [ ! -f "$wt_setup" ]; then
+        echo "    setup.bash missing: $wt_setup"
+        cleanup_mock_layer_workspace
+        return 1
+    fi
+
+    local fail=0
+    grep -Fq "# 5. Prioritize worktree target layer over main tree symlink-install paths (#427)" "$wt_setup" \
+        || { echo "    missing #427 header"; fail=1; }
+    grep -Fq "core_ws/install" "$wt_setup" \
+        || { echo "    missing core_ws/install reference"; fail=1; }
+    grep -Fq "core_ws/build" "$wt_setup" \
+        || { echo "    missing core_ws/build reference"; fail=1; }
+    grep -Fq "_wt_path_prepend AMENT_PREFIX_PATH" "$wt_setup" \
+        || { echo "    AMENT_PREFIX_PATH not routed through idempotency helper"; fail=1; }
+    grep -Fq "_wt_path_prepend PYTHONPATH" "$wt_setup" \
+        || { echo "    PYTHONPATH not routed through idempotency helper"; fail=1; }
+
+    cleanup_mock_layer_workspace
+    return $fail
+}
+run_test "Layer setup.bash has #427 path priority block with idempotent helper" \
+    test_layer_setup_bash_has_path_priority_block
+
+# Test 22: Workspace worktree does NOT emit the #427 block
+# Workspace worktrees don't generate setup.bash at all (only layer worktrees do),
+# so the override block — which is layer-specific — must never appear in any
+# file the workspace worktree creates.
+test_workspace_no_path_priority_block() {
+    setup_mock_workspace
+    cd "$WORKSPACE_DIR" || return 1
+
+    local output
+    output=$(.agent/scripts/worktree_create.sh --issue 427002 --type workspace 2>&1) || true
+
+    if [[ "$output" != *"Worktree Created Successfully"* ]]; then
+        echo "    workspace worktree creation failed"
+        echo "    output: $output"
+        cleanup_mock_workspace
+        return 1
+    fi
+
+    # The slug is derived from origin basename ("origin" for the bare repo path).
+    local wt_dir="$WORKSPACE_DIR/.workspace-worktrees/issue-origin-427002"
+    if [ ! -d "$wt_dir" ]; then
+        echo "    workspace worktree dir missing: $wt_dir"
+        cleanup_mock_workspace
+        return 1
+    fi
+
+    # The override block uses a distinctive header — if it appears anywhere
+    # under the worktree (including a stray setup.bash), the negative invariant
+    # is broken.
+    if grep -Frq "Prioritize worktree target layer" "$wt_dir" 2>/dev/null; then
+        echo "    workspace worktree contains the #427 priority block"
+        cleanup_mock_workspace
+        return 1
+    fi
+    if grep -Frq "_wt_path_prepend" "$wt_dir" 2>/dev/null; then
+        echo "    workspace worktree contains the path-prepend helper"
+        cleanup_mock_workspace
+        return 1
+    fi
+
+    cleanup_mock_workspace
+    return 0
+}
+run_test "Workspace worktree omits #427 path priority block" \
+    test_workspace_no_path_priority_block
+
+# Test 23: Re-sourcing the override block is idempotent (no path growth)
+test_layer_setup_bash_idempotent_resourcing() {
+    setup_mock_layer_workspace
+    cd "$WORKSPACE_DIR" || return 1
+
+    .agent/scripts/worktree_create.sh --issue 427003 --type layer --layer core --packages test_pkg >/dev/null 2>&1 || true
+
+    local wt_dir="$WORKSPACE_DIR/layers/worktrees/issue-pkg_origin-427003"
+    if [ ! -d "$wt_dir" ]; then
+        echo "    worktree not created"
+        cleanup_mock_layer_workspace
+        return 1
+    fi
+
+    # Fabricate a build/install pair so the override loop has matching dirs.
+    local pkg=fake_pkg
+    mkdir -p "$wt_dir/core_ws/install/$pkg/lib/python3.99/site-packages"
+    mkdir -p "$wt_dir/core_ws/build/$pkg"
+
+    # Extract the override block from the generated setup.bash and source it twice.
+    local block_file
+    block_file=$(mktemp "$TEST_DIR/block_XXXXXX.sh")
+    sed -n '/# 5\. Prioritize worktree target layer/,/^unset -f _wt_path_prepend$/p' \
+        "$wt_dir/setup.bash" > "$block_file"
+
+    local out
+    out=$(bash -c "
+        set -u
+        WORKTREE_DIR='$wt_dir'
+        AMENT_PREFIX_PATH=''
+        PYTHONPATH=''
+        source '$block_file'
+        source '$block_file'
+        echo \"AMENT_PREFIX_PATH=\$AMENT_PREFIX_PATH\"
+        echo \"PYTHONPATH=\$PYTHONPATH\"
+    " 2>&1)
+
+    local fail=0
+    local ament_count py_sp_count py_build_count
+    ament_count=$(echo "$out" | grep '^AMENT_PREFIX_PATH=' | grep -o "install/$pkg" | wc -l)
+    py_sp_count=$(echo "$out"  | grep '^PYTHONPATH='       | grep -o "site-packages" | wc -l)
+    py_build_count=$(echo "$out" | grep '^PYTHONPATH='     | grep -o "build/$pkg" | wc -l)
+
+    if [ "$ament_count" -ne 1 ]; then
+        echo "    AMENT_PREFIX_PATH grew on re-source (count=$ament_count, expected 1)"
+        echo "    out: $out"
+        fail=1
+    fi
+    if [ "$py_sp_count" -ne 1 ]; then
+        echo "    PYTHONPATH site-packages grew on re-source (count=$py_sp_count, expected 1)"
+        echo "    out: $out"
+        fail=1
+    fi
+    if [ "$py_build_count" -ne 1 ]; then
+        echo "    PYTHONPATH build dir grew on re-source (count=$py_build_count, expected 1)"
+        echo "    out: $out"
+        fail=1
+    fi
+
+    cleanup_mock_layer_workspace
+    return $fail
+}
+run_test "Layer setup.bash override block is idempotent on re-sourcing" \
+    test_layer_setup_bash_idempotent_resourcing
 
 # Summary
 echo "========================================"

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -173,29 +173,38 @@ if [ -x ${_escaped_main_root}/.venv/bin/pre-commit ]; then
 fi
 SETUP_PRECOMMIT
 
-    # Worktree PYTHONPATH override: force-prepend target layer's build and install
-    # paths so they take priority over the main tree's symlink-install develop hooks.
-    # Without this, colcon's baked-in absolute paths cause the main tree's stale
-    # egg-info to shadow the worktree's new/modified entry points. See #427.
+    # Worktree path override: force-prepend target layer's build, install, and
+    # prefix paths so they take priority over the main tree's symlink-install
+    # develop hooks. Without this, colcon's baked-in absolute paths cause the
+    # main tree's stale egg-info and AMENT_PREFIX_PATH to shadow the worktree's
+    # new/modified packages. See #427.
     if [ -n "$target_layer" ]; then
-        cat >> "$wt_dir/setup.bash" << SETUP_PYTHONPATH_FIX
+        cat >> "$wt_dir/setup.bash" << SETUP_PATH_FIX
 
 # 5. Prioritize worktree target layer over main tree symlink-install paths (#427)
 # Colcon's setup.bash bakes absolute paths to layers/main/ at build time. Symlinked
-# higher layers re-source the main tree's install, bringing in stale develop hooks.
-# Force-prepend the worktree's target layer paths so they win.
+# higher layers re-source the main tree's install, bringing in stale develop hooks
+# and AMENT_PREFIX_PATH entries. Force-prepend the worktree's target layer paths
+# so they win.
+_wt_target_install="\$WORKTREE_DIR/${target_layer}_ws/install"
 for _wt_pkg_build in "\$WORKTREE_DIR/${target_layer}_ws/build"/*/; do
     [ -d "\$_wt_pkg_build" ] || continue
     _wt_pkg=\$(basename "\$_wt_pkg_build")
-    for _wt_sp in "\$WORKTREE_DIR/${target_layer}_ws/install/\$_wt_pkg"/lib/python3.*/site-packages; do
+    _wt_pkg_prefix="\$_wt_target_install/\$_wt_pkg"
+    # AMENT_PREFIX_PATH: ensure worktree install prefix is found before main tree
+    if [ -d "\$_wt_pkg_prefix" ]; then
+        export AMENT_PREFIX_PATH="\$_wt_pkg_prefix\${AMENT_PREFIX_PATH:+:\$AMENT_PREFIX_PATH}"
+    fi
+    # PYTHONPATH: prepend site-packages and build dir for Python packages
+    for _wt_sp in "\$_wt_pkg_prefix"/lib/python3.*/site-packages; do
         [ -d "\$_wt_sp" ] || continue
-        export PYTHONPATH="\$_wt_sp:\$PYTHONPATH"
-        export PYTHONPATH="\${_wt_pkg_build%/}:\$PYTHONPATH"
+        export PYTHONPATH="\$_wt_sp\${PYTHONPATH:+:\$PYTHONPATH}"
+        export PYTHONPATH="\${_wt_pkg_build%/}\${PYTHONPATH:+:\$PYTHONPATH}"
         break
     done
 done
-unset _wt_pkg_build _wt_pkg _wt_sp
-SETUP_PYTHONPATH_FIX
+unset _wt_target_install _wt_pkg_build _wt_pkg _wt_pkg_prefix _wt_sp
+SETUP_PATH_FIX
     fi
 
     cat >> "$wt_dir/setup.bash" << 'SETUP_FOOTER2'

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -74,6 +74,7 @@ if v and v != 'unknown': print(v)
 generate_worktree_scripts() {
     local wt_dir="$1"
     local main_root="$2"
+    local target_layer="${3:-}"
 
     echo ""
     echo "Generating convenience scripts..."
@@ -172,9 +173,31 @@ if [ -x ${_escaped_main_root}/.venv/bin/pre-commit ]; then
 fi
 SETUP_PRECOMMIT
 
+    # Worktree PYTHONPATH override: force-prepend target layer's build and install
+    # paths so they take priority over the main tree's symlink-install develop hooks.
+    # Without this, colcon's baked-in absolute paths cause the main tree's stale
+    # egg-info to shadow the worktree's new/modified entry points. See #427.
+    if [ -n "$target_layer" ]; then
+        cat >> "$wt_dir/setup.bash" << SETUP_PYTHONPATH_FIX
+
+# 5. Prioritize worktree target layer over main tree symlink-install paths (#427)
+# Colcon's setup.bash bakes absolute paths to layers/main/ at build time. Symlinked
+# higher layers re-source the main tree's install, bringing in stale develop hooks.
+# Force-prepend the worktree's target layer paths so they win.
+for _wt_pkg_build in "\$WORKTREE_DIR/${target_layer}_ws/build"/*/; do
+    [ -d "\$_wt_pkg_build" ] || continue
+    _wt_pkg=\$(basename "\$_wt_pkg_build")
+    _wt_sp="\$WORKTREE_DIR/${target_layer}_ws/install/\$_wt_pkg/lib/python3.12/site-packages"
+    [ -d "\$_wt_sp" ] && export PYTHONPATH="\$_wt_sp:\$PYTHONPATH"
+    export PYTHONPATH="\${_wt_pkg_build%/}:\$PYTHONPATH"
+done
+unset _wt_pkg_build _wt_pkg _wt_sp
+SETUP_PYTHONPATH_FIX
+    fi
+
     cat >> "$wt_dir/setup.bash" << 'SETUP_FOOTER2'
 
-# 5. Prevent interactive editor hangs
+# 6. Prevent interactive editor hangs
 export GIT_EDITOR=true
 
 echo "Environment ready."
@@ -946,7 +969,7 @@ EOF
     fi
 
     # Generate convenience scripts (setup.bash, build.sh, test.sh, etc.)
-    generate_worktree_scripts "$WORKTREE_DIR" "$ROOT_DIR"
+    generate_worktree_scripts "$WORKTREE_DIR" "$ROOT_DIR" "$TARGET_LAYER"
 fi
 
 # For workspace worktrees, symlink the layers directory

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -187,9 +187,12 @@ SETUP_PRECOMMIT
 for _wt_pkg_build in "\$WORKTREE_DIR/${target_layer}_ws/build"/*/; do
     [ -d "\$_wt_pkg_build" ] || continue
     _wt_pkg=\$(basename "\$_wt_pkg_build")
-    _wt_sp="\$WORKTREE_DIR/${target_layer}_ws/install/\$_wt_pkg/lib/python3.12/site-packages"
-    [ -d "\$_wt_sp" ] && export PYTHONPATH="\$_wt_sp:\$PYTHONPATH"
-    export PYTHONPATH="\${_wt_pkg_build%/}:\$PYTHONPATH"
+    for _wt_sp in "\$WORKTREE_DIR/${target_layer}_ws/install/\$_wt_pkg"/lib/python3.*/site-packages; do
+        [ -d "\$_wt_sp" ] || continue
+        export PYTHONPATH="\$_wt_sp:\$PYTHONPATH"
+        export PYTHONPATH="\${_wt_pkg_build%/}:\$PYTHONPATH"
+        break
+    done
 done
 unset _wt_pkg_build _wt_pkg _wt_sp
 SETUP_PYTHONPATH_FIX

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -185,7 +185,20 @@ SETUP_PRECOMMIT
 # Colcon's setup.bash bakes absolute paths to layers/main/ at build time. Symlinked
 # higher layers re-source the main tree's install, bringing in stale develop hooks
 # and AMENT_PREFIX_PATH entries. Force-prepend the worktree's target layer paths
-# so they win.
+# so they win. Idempotent on re-source: strips any prior occurrence of the entry
+# before prepending, so vars don't grow on repeated sourcing.
+_wt_path_prepend() {
+    local _v=\$1 _e=\$2 _c
+    _c=\${!_v}
+    _c=":\$_c:"
+    _c=\${_c//:\$_e:/:}
+    _c=\${_c#:}; _c=\${_c%:}
+    if [ -n "\$_c" ]; then
+        export "\$_v=\$_e:\$_c"
+    else
+        export "\$_v=\$_e"
+    fi
+}
 _wt_target_install="\$WORKTREE_DIR/${target_layer}_ws/install"
 for _wt_pkg_build in "\$WORKTREE_DIR/${target_layer}_ws/build"/*/; do
     [ -d "\$_wt_pkg_build" ] || continue
@@ -193,17 +206,18 @@ for _wt_pkg_build in "\$WORKTREE_DIR/${target_layer}_ws/build"/*/; do
     _wt_pkg_prefix="\$_wt_target_install/\$_wt_pkg"
     # AMENT_PREFIX_PATH: ensure worktree install prefix is found before main tree
     if [ -d "\$_wt_pkg_prefix" ]; then
-        export AMENT_PREFIX_PATH="\$_wt_pkg_prefix\${AMENT_PREFIX_PATH:+:\$AMENT_PREFIX_PATH}"
+        _wt_path_prepend AMENT_PREFIX_PATH "\$_wt_pkg_prefix"
     fi
     # PYTHONPATH: prepend site-packages and build dir for Python packages
     for _wt_sp in "\$_wt_pkg_prefix"/lib/python3.*/site-packages; do
         [ -d "\$_wt_sp" ] || continue
-        export PYTHONPATH="\$_wt_sp\${PYTHONPATH:+:\$PYTHONPATH}"
-        export PYTHONPATH="\${_wt_pkg_build%/}\${PYTHONPATH:+:\$PYTHONPATH}"
+        _wt_path_prepend PYTHONPATH "\$_wt_sp"
+        _wt_path_prepend PYTHONPATH "\${_wt_pkg_build%/}"
         break
     done
 done
 unset _wt_target_install _wt_pkg_build _wt_pkg _wt_pkg_prefix _wt_sp
+unset -f _wt_path_prepend
 SETUP_PATH_FIX
     fi
 

--- a/.agent/work-plans/PLAN_ISSUE-427.md
+++ b/.agent/work-plans/PLAN_ISSUE-427.md
@@ -1,0 +1,75 @@
+# Plan: fix layer worktree Python paths shadowed by main tree symlink-install
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/427
+
+## Context
+
+Layer worktrees symlink all non-target layers to the main tree. Colcon's
+`setup.bash` bakes absolute `layers/main/` paths at build time, so sourcing
+any symlinked higher layer re-sources the main tree's install for the target
+layer. The main tree's `pythonpath_develop.dsv` hook adds its `build/<pkg>`
+directory to `PYTHONPATH`, and that build directory has stale egg-info. The
+worktree's own paths end up later on `sys.path`, so `pkg_resources` finds
+the main tree first.
+
+## Approach
+
+1. **Pass `TARGET_LAYER` into `generate_worktree_scripts()`** — Add a third
+   parameter so the function knows which layer is the target. Currently it
+   only receives `wt_dir` and `main_root`.
+
+2. **Append a PYTHONPATH override block to the generated `setup.bash`** —
+   After the "Source workspace layers" loop and before the "Environment
+   ready" message, add a block that iterates over the target layer's
+   `build/*/` directories and force-prepends both the build dir (for
+   egg-info) and the matching install site-packages dir to `PYTHONPATH`.
+   Use `local_setup.bash`-style prepend (raw `export`) to bypass ament's
+   `prepend-non-duplicate` which refuses to reorder existing entries.
+
+3. **Only emit the block for layer worktrees** — The function already knows
+   `WORKTREE_TYPE="layer"`. Guard the new block so workspace worktrees
+   (which don't have a target layer) are unaffected.
+
+4. **Regenerate the existing issue-16 worktree's `setup.bash`** — Manually
+   verify the fix by re-running `worktree_create.sh` for issue 16 (or
+   patching its `setup.bash` in place) and confirming `ros2 launch -h`
+   shows `--tui`.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/worktree_create.sh` | Pass `TARGET_LAYER` to `generate_worktree_scripts()`; emit PYTHONPATH override block in generated `setup.bash` |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | Existing worktrees won't auto-update; document that users should recreate or manually patch `setup.bash`. Verify with the ros2launch_gui worktree. |
+| Only what's needed | Single targeted fix — no refactoring of the script generator |
+| Enforcement over documentation | The fix is automatic in generated scripts, not a manual workaround |
+| Workspace improvements cascade to projects | All future layer worktrees for any project benefit |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0002 (worktree isolation) | Yes | Fix ensures worktree isolation actually works for Python packages |
+| ADR-0008 (ROS 2 conventions) | No | No packaging changes; works within colcon's existing mechanisms |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Generated `setup.bash` format | Existing worktrees need recreation or manual patch | No — document in PR description |
+| `generate_worktree_scripts()` signature | Call site at line ~942 | Yes |
+
+## Open Questions
+
+- None — approach is verified experimentally.
+
+## Estimated Scope
+
+Single PR, one file changed.

--- a/.agent/work-plans/PLAN_ISSUE-427.md
+++ b/.agent/work-plans/PLAN_ISSUE-427.md
@@ -41,7 +41,9 @@ the main tree first.
 
 | File | Change |
 |------|--------|
-| `.agent/scripts/worktree_create.sh` | Pass `TARGET_LAYER` to `generate_worktree_scripts()`; emit PYTHONPATH override block in generated `setup.bash` |
+| `.agent/scripts/worktree_create.sh` | Pass `TARGET_LAYER` to `generate_worktree_scripts()`; emit prefix-path override block in generated `setup.bash` covering both `PYTHONPATH` and `AMENT_PREFIX_PATH`; idempotent re-sourcing via a `_wt_path_prepend` helper |
+| `.agent/scripts/tests/test_worktree_create.sh` | Add `configs/manifest/layers.txt` to the mock workspace/layer setup helpers (manifest is required since #417); add three regression tests — (1) layer worktree's generated `setup.bash` contains the #427 priority block + helper, (2) workspace worktrees never emit the block, (3) functional idempotency: source the extracted block twice in a sub-bash and assert each prefix appears exactly once |
+| `.agent/work-plans/PLAN_ISSUE-427.md` | This plan |
 
 ## Principles Self-Check
 
@@ -72,4 +74,4 @@ the main tree first.
 
 ## Estimated Scope
 
-Single PR, one file changed.
+Single PR, two implementation files changed (`worktree_create.sh` + `tests/test_worktree_create.sh`) plus this plan file.


### PR DESCRIPTION
Closes #427

# Plan: fix layer worktree Python paths shadowed by main tree symlink-install

## Issue

https://github.com/rolker/ros2_agent_workspace/issues/427

## Context

Layer worktrees symlink all non-target layers to the main tree. Colcon's
`setup.bash` bakes absolute `layers/main/` paths at build time, so sourcing
any symlinked higher layer re-sources the main tree's install for the target
layer. The main tree's `pythonpath_develop.dsv` hook adds its `build/<pkg>`
directory to `PYTHONPATH`, and that build directory has stale egg-info. The
worktree's own paths end up later on `sys.path`, so `pkg_resources` finds
the main tree first.

## Approach

1. **Pass `TARGET_LAYER` into `generate_worktree_scripts()`** — Add a third
   parameter so the function knows which layer is the target. Currently it
   only receives `wt_dir` and `main_root`.

2. **Append a PYTHONPATH override block to the generated `setup.bash`** —
   After the "Source workspace layers" loop and before the "Environment
   ready" message, add a block that iterates over the target layer's
   `build/*/` directories and force-prepends both the build dir (for
   egg-info) and the matching install site-packages dir to `PYTHONPATH`.
   Use `local_setup.bash`-style prepend (raw `export`) to bypass ament's
   `prepend-non-duplicate` which refuses to reorder existing entries.

3. **Only emit the block for layer worktrees** — The function already knows
   `WORKTREE_TYPE="layer"`. Guard the new block so workspace worktrees
   (which don't have a target layer) are unaffected.

4. **Regenerate the existing issue-16 worktree's `setup.bash`** — Manually
   verify the fix by re-running `worktree_create.sh` for issue 16 (or
   patching its `setup.bash` in place) and confirming `ros2 launch -h`
   shows `--tui`.

## Files to Change

| File | Change |
|------|--------|
| `.agent/scripts/worktree_create.sh` | Pass `TARGET_LAYER` to `generate_worktree_scripts()`; emit PYTHONPATH override block in generated `setup.bash` |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| A change includes its consequences | Existing worktrees won't auto-update; document that users should recreate or manually patch `setup.bash`. Verify with the ros2launch_gui worktree. |
| Only what's needed | Single targeted fix — no refactoring of the script generator |
| Enforcement over documentation | The fix is automatic in generated scripts, not a manual workaround |
| Workspace improvements cascade to projects | All future layer worktrees for any project benefit |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| ADR-0002 (worktree isolation) | Yes | Fix ensures worktree isolation actually works for Python packages |
| ADR-0008 (ROS 2 conventions) | No | No packaging changes; works within colcon's existing mechanisms |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| Generated `setup.bash` format | Existing worktrees need recreation or manual patch | No — document in PR description |
| `generate_worktree_scripts()` signature | Call site at line ~942 | Yes |

## Open Questions

- None — approach is verified experimentally.

## Estimated Scope

Single PR, one file changed.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
