### PR TITLE
feat: add Quality Standard section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,24 @@ setup (environment, identity, features), see your framework's adapter file:
 - Construct GitHub URLs from directory names — use `gh` CLI to look them up
 - Run bare `pip install` or use `--break-system-packages` — use `.venv` for dev tools (see ADR-0009)
 
+## Quality Standard
+
+This is software for autonomous robot boats operating on open water. Robustness
+is not optional. The marginal cost of completeness is near zero with AI — do the
+whole thing, do it right, do it with tests.
+
+- When fixing a bug, fix it completely: add the test, handle the edge case, check
+  the lifecycle transition. Never leave a "good enough" fix when the proper one is
+  within reach.
+- When triaging reviews, do not dismiss concerns about error handling, silent
+  failures, stale data, or missing validation as "nits" unless the failure mode
+  genuinely cannot occur. "Config is under our control" and "pathological input"
+  are not blanket dismissals — field configs change under pressure.
+- When importing field fixes, treat them as drafts: add tests, verify topic names,
+  check for idempotency. The PR is the quality gate.
+- Never offer to "table this for later" when the permanent solve is five minutes
+  away. Never present a workaround when the real fix exists.
+
 ## Worktree Workflow
 
 Every task must use an isolated worktree.


### PR DESCRIPTION
## Summary

- Adds "Quality Standard" section to AGENTS.md between Boundaries and Worktree Workflow
- Establishes completeness and robustness expectations for all AI agents
- Key points: fix completely with tests, don't dismiss review catches, treat field imports as drafts, never table the permanent solve

## Motivation

Review triage was dismissing valid Copilot catches (error handling, stale data, missing validation) as "nits" or "false positives". For autonomous marine robots, these are real quality concerns. The marginal cost of doing the complete fix is near zero with AI.

Inspired by Garry Tan's "Boil the Ocean" philosophy.

## Test plan

- [ ] Verify the section renders correctly in AGENTS.md
- [ ] Verify future review triages treat error handling / stale data concerns as valid by default

Closes #437

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
