### PR TITLE
[PLAN] Design workflow for merging field changes from gitcloud back to GitHub

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -55,7 +55,7 @@ Available workflow skills: `review-issue`, `plan-task`, `review-plan`,
 `review-code`, `brainstorm`, `research`, `audit-workspace`, `audit-project`,
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
 `triage-reviews`, `skill-importer`, `document-package`, `issue-triage`,
-`test-engineering`, `inspiration-tracker`.
+`test-engineering`, `inspiration-tracker`, `import-field-changes`.
 
 ## References
 

--- a/.agent/instructions/gemini-cli.instructions.md
+++ b/.agent/instructions/gemini-cli.instructions.md
@@ -30,7 +30,7 @@ Available workflow skills: `review-issue`, `plan-task`, `review-plan`,
 `review-code`, `brainstorm`, `research`, `audit-workspace`, `audit-project`,
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
 `triage-reviews`, `skill-importer`, `document-package`, `issue-triage`,
-`test-engineering`, `inspiration-tracker`.
+`test-engineering`, `inspiration-tracker`, `import-field-changes`.
 
 ## References
 

--- a/.agent/scripts/pull_remote.py
+++ b/.agent/scripts/pull_remote.py
@@ -16,16 +16,19 @@ Prerequisites:
 """
 
 import argparse
+import json as json_mod
 import sys
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
-from remote_utils import (
+from remote_utils import (  # noqa: E402
     add_common_args,
     get_default_branch,
+    get_repos,
     remote_exists,
+    resolve_repo_path,
     run_git,
     run_script,
 )
@@ -184,6 +187,56 @@ def process_repo(repo_path, repo_name, version, args):
     return _fetch_and_report(repo_path, args.remote, version, args.dry_run)
 
 
+def _get_ahead_commits(repo_path, branch, remote_ref):
+    """Get list of commits on remote not on local. Returns list of dicts."""
+    success, output, _ = run_git(repo_path, ["log", "--oneline", f"{branch}..{remote_ref}"])
+    if not success or not output:
+        return []
+    commits = []
+    for line in output.splitlines():
+        parts = line.split(" ", 1)
+        commits.append({"sha": parts[0], "subject": parts[1] if len(parts) > 1 else ""})
+    return commits
+
+
+def _json_report(repo_path, repo_name, version, remote_name):
+    """Generate JSON-friendly report for a single repo."""
+    branch = get_default_branch(repo_path, version)
+    remote_ref = f"{remote_name}/{branch}"
+
+    # Check remote ref exists
+    success, _, _ = run_git(repo_path, ["rev-parse", "--verify", remote_ref])
+    if not success:
+        return None  # no remote branch
+
+    # Count ahead/behind
+    success, output, _ = run_git(
+        repo_path, ["rev-list", "--left-right", "--count", f"{branch}...{remote_ref}"]
+    )
+    if not success or not output:
+        return None
+
+    parts = output.split()
+    if len(parts) != 2:
+        return None
+
+    ahead, behind = int(parts[0]), int(parts[1])
+    if behind == 0:
+        return None  # nothing new on remote
+
+    commits = _get_ahead_commits(repo_path, branch, remote_ref)
+    return {
+        "repo": repo_name,
+        "path": str(repo_path),
+        "default_branch": branch,
+        "remote_ref": remote_ref,
+        "ahead": ahead,
+        "behind": behind,
+        "diverged": ahead > 0 and behind > 0,
+        "commits": commits,
+    }
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Fetch/pull from a named remote for all workspace repositories."
@@ -199,7 +252,42 @@ def main():
         "--branch",
         help="Create/update a local branch with remote changes (e.g., sync/gitcloud)",
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON report of repos with remote-ahead commits (fetch-only mode)",
+    )
     args = parser.parse_args()
+
+    if args.json:
+        # JSON mode: fetch all, report repos with changes as structured data
+        if args.pull or args.branch:
+            parser.error("--json cannot be combined with --pull or --branch")
+
+        root_dir = SCRIPT_DIR.parent.parent
+        repos = get_repos(args)
+        results = []
+
+        # Workspace repo
+        run_git(root_dir, ["fetch", args.remote], args.dry_run)
+        ws_version = get_default_branch(root_dir, None)
+        entry = _json_report(root_dir, "ros2_agent_workspace", ws_version, args.remote)
+        if entry:
+            results.append(entry)
+
+        for repo in repos:
+            repo_path = resolve_repo_path(root_dir, repo)
+            if repo_path is None:
+                continue
+            if not remote_exists(repo_path, args.remote):
+                continue
+            run_git(repo_path, ["fetch", args.remote], args.dry_run)
+            entry = _json_report(repo_path, repo["name"], repo["version"], args.remote)
+            if entry:
+                results.append(entry)
+
+        print(json_mod.dumps(results, indent=2))
+        sys.exit(0)
 
     if args.pull or args.branch:
         labels = [

--- a/.agent/scripts/pull_remote.py
+++ b/.agent/scripts/pull_remote.py
@@ -187,9 +187,11 @@ def process_repo(repo_path, repo_name, version, args):
     return _fetch_and_report(repo_path, args.remote, version, args.dry_run)
 
 
-def _get_ahead_commits(repo_path, branch, remote_ref):
+def _get_ahead_commits(repo_path, branch, remote_ref, max_count=50):
     """Get list of commits on remote not on local. Returns list of dicts."""
-    success, output, _ = run_git(repo_path, ["log", "--oneline", f"{branch}..{remote_ref}"])
+    success, output, _ = run_git(
+        repo_path, ["log", "--oneline", f"--max-count={max_count}", f"{branch}..{remote_ref}"]
+    )
     if not success or not output:
         return []
     commits = []
@@ -252,7 +254,7 @@ def main():
         "--branch",
         help="Create/update a local branch with remote changes (e.g., sync/gitcloud)",
     )
-    parser.add_argument(
+    mode.add_argument(
         "--json",
         action="store_true",
         help="Output JSON report of repos with remote-ahead commits (fetch-only mode)",
@@ -260,20 +262,20 @@ def main():
     args = parser.parse_args()
 
     if args.json:
-        # JSON mode: fetch all, report repos with changes as structured data
-        if args.pull or args.branch:
-            parser.error("--json cannot be combined with --pull or --branch")
-
         root_dir = SCRIPT_DIR.parent.parent
         repos = get_repos(args)
         results = []
+        errors = []
 
         # Workspace repo
-        run_git(root_dir, ["fetch", args.remote], args.dry_run)
-        ws_version = get_default_branch(root_dir, None)
-        entry = _json_report(root_dir, "ros2_agent_workspace", ws_version, args.remote)
-        if entry:
-            results.append(entry)
+        success, _, err = run_git(root_dir, ["fetch", args.remote], args.dry_run)
+        if not success:
+            errors.append(f"ros2_agent_workspace: fetch failed: {err}")
+        else:
+            ws_version = get_default_branch(root_dir, None)
+            entry = _json_report(root_dir, "ros2_agent_workspace", ws_version, args.remote)
+            if entry:
+                results.append(entry)
 
         for repo in repos:
             repo_path = resolve_repo_path(root_dir, repo)
@@ -281,13 +283,20 @@ def main():
                 continue
             if not remote_exists(repo_path, args.remote):
                 continue
-            run_git(repo_path, ["fetch", args.remote], args.dry_run)
+            success, _, err = run_git(repo_path, ["fetch", args.remote], args.dry_run)
+            if not success:
+                errors.append(f"{repo['name']}: fetch failed: {err}")
+                continue
             entry = _json_report(repo_path, repo["name"], repo["version"], args.remote)
             if entry:
                 results.append(entry)
 
+        if errors:
+            for e in errors:
+                print(f"ERROR: {e}", file=sys.stderr)
+
         print(json_mod.dumps(results, indent=2))
-        sys.exit(0)
+        sys.exit(1 if errors else 0)
 
     if args.pull or args.branch:
         labels = [

--- a/.agent/scripts/pull_remote.py
+++ b/.agent/scripts/pull_remote.py
@@ -10,6 +10,7 @@ Usage:
     python3 pull_remote.py --remote gitcloud                    # fetch + report
     python3 pull_remote.py --remote gitcloud --pull             # fetch + merge
     python3 pull_remote.py --remote gitcloud --branch sync/gc   # fetch into branch
+    python3 pull_remote.py --remote gitcloud --json             # fetch + JSON output
 
 Prerequisites:
     Remotes must already exist in each repo. Use add_remote.py for one-time setup.

--- a/.agent/work-plans/PLAN_ISSUE-432.md
+++ b/.agent/work-plans/PLAN_ISSUE-432.md
@@ -16,13 +16,12 @@ worktree creation was heavy enough to tempt shortcuts.
 
 Phase 1 only (happy path). Phases 2-3 deferred to follow-up issues.
 
-1. **Add `--fetch-only` flag to `pull_remote.py`** — currently default mode
-   fetches and reports. Formalize this as an explicit flag that returns
-   structured output (JSON) listing repos with ahead commits, commit count,
-   and whether diverged.
+1. **Add `--json` flag to `pull_remote.py`** — structured output mode that
+   returns JSON listing repos with ahead commits, commit count, and whether
+   diverged. Used by the skill for machine-readable detection.
 
 2. **Create `import-field-changes` skill** — batch skill that:
-   a. Calls `pull_remote.py --fetch-only --remote <name>` (default: gitcloud)
+   a. Calls `pull_remote.py --remote <name> --json`
    b. For each repo with changes: examines diff, generates issue body with
       commit summary and pre-review findings
    c. Creates issue in the project repo via `gh_create_issue.sh`
@@ -42,7 +41,7 @@ Phase 1 only (happy path). Phases 2-3 deferred to follow-up issues.
 
 | File | Change |
 |------|--------|
-| `.agent/scripts/pull_remote.py` | Add `--fetch-only` with JSON output mode |
+| `.agent/scripts/pull_remote.py` | Add `--json` structured output mode |
 | `.agent/project_config.yaml` | New gitignored config file (document in setup) |
 | `.gitignore` | Add `.agent/project_config.yaml` |
 | `.claude/skills/import-field-changes/` | New skill directory |

--- a/.agent/work-plans/PLAN_ISSUE-432.md
+++ b/.agent/work-plans/PLAN_ISSUE-432.md
@@ -43,6 +43,8 @@ Phase 1 only (happy path). Phases 2-3 deferred to follow-up issues.
 | File | Change |
 |------|--------|
 | `.agent/scripts/pull_remote.py` | Add `--fetch-only` with JSON output mode |
+| `.agent/project_config.yaml` | New gitignored config file (document in setup) |
+| `.gitignore` | Add `.agent/project_config.yaml` |
 | `.claude/skills/import-field-changes/` | New skill directory |
 | `.claude/skills/import-field-changes/content.md` | Skill definition |
 | `AGENTS.md` | Add skill to reference if needed |
@@ -73,14 +75,24 @@ Phase 1 only (happy path). Phases 2-3 deferred to follow-up issues.
 | `pull_remote.py` flags | Script reference table in AGENTS.md | Yes |
 | Add new skill | Framework adapter skill lists | Yes |
 
+## Decisions
+
+- **Remote name**: read from `.agent/project_config.yaml` (gitignored, project-specific).
+  No hardcoded default. Error with helpful message if file missing or key absent.
+  ```yaml
+  # .agent/project_config.yaml
+  field_remote: gitcloud
+  ```
+- **Issue title convention**: `Field import: <repo> (YYYY-MM-DD)` — one issue per
+  repo, predictable and searchable.
+- **Resync**: deferred to Phase 2. After PRs merge, normal `push_remote.py` handles
+  non-diverged repos. Force-push resync is a separate concern.
+
 ## Open Questions
 
-- Should the skill default to `gitcloud` remote or require explicit `--remote`?
-- Should the issue title follow a convention (e.g., "Import field changes: <repo> <date>")?
-- Should Phase 1 include the resync step (force-push origin→gitcloud after merge)?
-  Previous comments suggest this is needed but adds risk.
+None — all design questions resolved.
 
 ## Estimated Scope
 
-Single PR for Phase 1. Follow-up issues for: Phase 2 (auto-fix in worktree),
-Phase 3 (resync), ADR for field branch conventions.
+Single PR for Phase 1. Follow-up issues for: Phase 2 (auto-fix in worktree +
+resync), ADR for field branch conventions.

--- a/.agent/work-plans/PLAN_ISSUE-432.md
+++ b/.agent/work-plans/PLAN_ISSUE-432.md
@@ -1,0 +1,86 @@
+# Plan: Import field changes from gitcloud
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/432
+
+## Context
+
+Field machines push changes to gitcloud during testing. These need to flow
+back to GitHub for review. Manual imports are error-prone (wrong topics,
+missing tests, violated worktree rules). Today's session (2026-04-20) proved
+the PR review step catches real issues — but the ceremony of per-repo
+worktree creation was heavy enough to tempt shortcuts.
+
+## Approach
+
+Phase 1 only (happy path). Phases 2-3 deferred to follow-up issues.
+
+1. **Add `--fetch-only` flag to `pull_remote.py`** — currently default mode
+   fetches and reports. Formalize this as an explicit flag that returns
+   structured output (JSON) listing repos with ahead commits, commit count,
+   and whether diverged.
+
+2. **Create `import-field-changes` skill** — batch skill that:
+   a. Calls `pull_remote.py --fetch-only --remote <name>` (default: gitcloud)
+   b. For each repo with changes: examines diff, generates issue body with
+      commit summary and pre-review findings
+   c. Creates issue in the project repo via `gh_create_issue.sh`
+   d. Creates feature branch from gitcloud HEAD (or notes divergence)
+   e. Pushes branch, opens draft PR referencing issue
+   f. Reports summary to user
+
+3. **Pre-review integration** — skill examines each diff against Quality
+   Standard criteria (tests present? topic names match remaps? idempotent?)
+   and includes findings in the issue body.
+
+4. **Divergence handling (Phase 1 scope)** — detect and report. Create
+   worktree for diverged repos (merge needed). Do not auto-merge in Phase 1;
+   report to user for manual resolution or follow-up.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/pull_remote.py` | Add `--fetch-only` with JSON output mode |
+| `.claude/skills/import-field-changes/` | New skill directory |
+| `.claude/skills/import-field-changes/content.md` | Skill definition |
+| `AGENTS.md` | Add skill to reference if needed |
+| `.github/copilot-instructions.md` | Add skill to adapter list |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Skill reports findings; human decides whether to merge PRs or request fixes |
+| Enforcement over documentation | Automates the "treat field imports as drafts" Quality Standard directive |
+| Only what's needed | Phase 1 only — no auto-fix, no force-push resync |
+| Improve incrementally | Single skill + minor script extension; builds on existing infrastructure |
+| Workspace vs. project separation | Skill is generic; issues created in project repos |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | Diverged repos get worktrees; non-diverged repos only create branches (no main-tree editing) |
+| 0003 — Project-agnostic | Yes | Skill works for any remote name, any repo |
+| 0006 — Shared AGENTS.md | Yes | Skill added to reference tables in adapters |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `pull_remote.py` flags | Script reference table in AGENTS.md | Yes |
+| Add new skill | Framework adapter skill lists | Yes |
+
+## Open Questions
+
+- Should the skill default to `gitcloud` remote or require explicit `--remote`?
+- Should the issue title follow a convention (e.g., "Import field changes: <repo> <date>")?
+- Should Phase 1 include the resync step (force-push origin→gitcloud after merge)?
+  Previous comments suggest this is needed but adds risk.
+
+## Estimated Scope
+
+Single PR for Phase 1. Follow-up issues for: Phase 2 (auto-fix in worktree),
+Phase 3 (resync), ADR for field branch conventions.

--- a/.claude/skills/import-field-changes/content.md
+++ b/.claude/skills/import-field-changes/content.md
@@ -57,6 +57,19 @@ git -C <path> diff <default_branch>..<remote>/<default_branch> --stat
 git -C <path> log --oneline <default_branch>..<remote>/<default_branch>
 ```
 
+### 3. For each repo with changes
+
+Process repos sequentially:
+
+#### 3a. Summarize the diff
+
+Read the diff between local default branch and remote:
+
+```bash
+git -C <path> diff <default_branch>..<remote>/<default_branch> --stat
+git -C <path> log --oneline <default_branch>..<remote>/<default_branch>
+```
+
 #### 3b. Pre-review against Quality Standard
 
 Examine the diff for Quality Standard concerns:

--- a/.claude/skills/import-field-changes/content.md
+++ b/.claude/skills/import-field-changes/content.md
@@ -57,19 +57,6 @@ git -C <path> diff <default_branch>..<remote>/<default_branch> --stat
 git -C <path> log --oneline <default_branch>..<remote>/<default_branch>
 ```
 
-### 3. For each repo with changes
-
-Process repos sequentially:
-
-#### 3a. Summarize the diff
-
-Read the diff between local default branch and remote:
-
-```bash
-git -C <path> diff <default_branch>..<remote>/<default_branch> --stat
-git -C <path> log --oneline <default_branch>..<remote>/<default_branch>
-```
-
 #### 3b. Pre-review against Quality Standard
 
 Examine the diff for Quality Standard concerns:
@@ -90,20 +77,22 @@ Body should include:
 - Pre-review findings (if any)
 - Whether the repo is diverged (merge needed)
 
-Use `gh issue create` in the project repo directory.
+Use `.agent/scripts/gh_create_issue.sh` from the project repo directory.
 
 #### 3d. Create branch and PR
 
+Create the branch without checking it out (avoids changing main tree HEAD):
+
 **Non-diverged case** (remote ahead, local not ahead):
 ```bash
-git -C <path> checkout -b feature/issue-<N> <remote>/<default_branch>
+git -C <path> branch feature/issue-<N> <remote>/<default_branch>
 git -C <path> push -u origin feature/issue-<N>
 ```
 
 **Diverged case** (both sides have commits):
 ```bash
 # Branch from remote HEAD — merge will happen in worktree
-git -C <path> checkout -b feature/issue-<N> <remote>/<default_branch>
+git -C <path> branch feature/issue-<N> <remote>/<default_branch>
 git -C <path> push -u origin feature/issue-<N>
 ```
 

--- a/.claude/skills/import-field-changes/content.md
+++ b/.claude/skills/import-field-changes/content.md
@@ -96,8 +96,9 @@ git -C <path> branch feature/issue-<N> <remote>/<default_branch>
 git -C <path> push -u origin feature/issue-<N>
 ```
 
-Create draft PR:
+Create draft PR (run from within the project repo directory):
 ```bash
+cd <path>
 gh pr create --draft --title "Field import: <repo_name> (<date>)" \
   --body-file <body> --base <default_branch>
 ```

--- a/.claude/skills/import-field-changes/content.md
+++ b/.claude/skills/import-field-changes/content.md
@@ -1,0 +1,137 @@
+# Import Field Changes
+
+## Usage
+
+```
+/import-field-changes
+```
+
+## Overview
+
+Batch-import field changes from a secondary remote (e.g., gitcloud) back to
+GitHub for review. For each repo with remote-ahead commits: creates an issue,
+opens a draft PR, and pre-reviews the diff against the Quality Standard.
+
+**Lifecycle position**: field deployment → push to gitcloud → **import-field-changes** → triage-reviews → merge
+
+## Steps
+
+### 1. Read project config
+
+Read `.agent/project_config.yaml` for the field remote name:
+
+```yaml
+# .agent/project_config.yaml (gitignored)
+field_remote: gitcloud
+```
+
+If the file doesn't exist or `field_remote` is missing, stop with:
+
+> `.agent/project_config.yaml` not found or missing `field_remote` key.
+> Create it with: `echo "field_remote: gitcloud" > .agent/project_config.yaml`
+
+### 2. Fetch and detect changes
+
+Run from the workspace root:
+
+```bash
+python3 .agent/scripts/pull_remote.py --remote <field_remote> --json
+```
+
+This fetches all repos and outputs a JSON array of repos with remote-ahead
+commits, including: repo name, path, default branch, ahead/behind counts,
+diverged flag, and commit list.
+
+If the result is empty, report "No field changes to import" and stop.
+
+### 3. For each repo with changes
+
+Process repos sequentially:
+
+#### 3a. Summarize the diff
+
+Read the diff between local default branch and remote:
+
+```bash
+git -C <path> diff <default_branch>..<remote>/<default_branch> --stat
+git -C <path> log --oneline <default_branch>..<remote>/<default_branch>
+```
+
+#### 3b. Pre-review against Quality Standard
+
+Examine the diff for Quality Standard concerns:
+- Are there tests for new functionality?
+- Do topic names match actual published topics (check for remap mismatches)?
+- Is error handling present for failure modes?
+- Are scripts idempotent?
+- Any hardcoded paths or credentials?
+
+Note findings for the issue body.
+
+#### 3c. Create issue in the project repo
+
+Title: `Field import: <repo_name> (<YYYY-MM-DD>)`
+
+Body should include:
+- List of commits being imported
+- Pre-review findings (if any)
+- Whether the repo is diverged (merge needed)
+
+Use `gh issue create` in the project repo directory.
+
+#### 3d. Create branch and PR
+
+**Non-diverged case** (remote ahead, local not ahead):
+```bash
+git -C <path> checkout -b feature/issue-<N> <remote>/<default_branch>
+git -C <path> push -u origin feature/issue-<N>
+```
+
+**Diverged case** (both sides have commits):
+```bash
+# Branch from remote HEAD — merge will happen in worktree
+git -C <path> checkout -b feature/issue-<N> <remote>/<default_branch>
+git -C <path> push -u origin feature/issue-<N>
+```
+
+Create draft PR:
+```bash
+gh pr create --draft --title "Field import: <repo_name> (<date>)" \
+  --body-file <body> --base <default_branch>
+```
+
+Note: for diverged repos, note in the PR body that a merge with the
+default branch is needed before this can be merged.
+
+#### 3e. Handle pre-review findings
+
+If pre-review found issues that should be fixed:
+1. Create a worktree for the issue
+2. Apply fixes (add tests, fix topic names, etc.)
+3. Commit and push to the PR branch
+4. Note fixes in the PR description
+
+If no issues found, the PR is ready for Copilot review as-is.
+
+### 4. Report summary
+
+Output a table:
+
+```markdown
+## Field Import Summary
+
+| Repo | Commits | Diverged | Issue | PR | Pre-review |
+|------|---------|----------|-------|-----|------------|
+| <name> | <N> | Yes/No | #<N> | #<N> | Clean / <N> findings |
+```
+
+## Guidelines
+
+- **Never edit in the main tree** — all fixes go through worktrees
+- **One issue per repo** — even if the repo has multiple unrelated field commits
+- **Pre-review is advisory** — findings go in the issue, not auto-fixed unless
+  the fix is trivial and unambiguous (e.g., missing shebang)
+- **Diverged repos need human judgment** — report them prominently, don't
+  auto-merge
+- **This skill does not resync gitcloud** — after PRs merge, use
+  `push_remote.py` manually to update gitcloud

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ Available workflow skills: `review-issue`, `plan-task`, `review-plan`,
 `review-code`, `brainstorm`, `research`, `audit-workspace`, `audit-project`,
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
 `triage-reviews`, `skill-importer`, `document-package`, `issue-triage`,
-`test-engineering`, `inspiration-tracker`.
+`test-engineering`, `inspiration-tracker`, `import-field-changes`.
 
 ## References
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ configs/manifest_repo/
 configs/manifest
 .agent/project_knowledge
 
+# Project-specific config (field remote name, etc. — not shared)
+.agent/project_config.yaml
+
 # Ignore colcon/ROS artifacts in root if any
 build/
 install/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,7 +289,7 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/sync_repos.py` | Sync all workspace repositories (includes git-bug) |
 | `.agent/scripts/add_remote.py` | Add a named remote to all repos (one-time setup) |
 | `.agent/scripts/push_remote.py` | Push to a named remote across all repos |
-| `.agent/scripts/pull_remote.py` | Fetch/pull from a named remote across all repos |
+| `.agent/scripts/pull_remote.py` | Fetch/pull from a named remote across all repos (`--json` for structured output) |
 | `.agent/scripts/validate_workspace.py` | Validate repos match .repos config |
 | `.agent/scripts/detect_agent_identity.sh` | Auto-detect agent framework + model |
 | `.agent/scripts/fetch_pr_reviews.sh` | Fetch all PR reviews and CI status |


### PR DESCRIPTION
Closes #432

# Plan: Import field changes from gitcloud

## Issue

https://github.com/rolker/ros2_agent_workspace/issues/432

## Context

Field machines push changes to gitcloud during testing. These need to flow
back to GitHub for review. Manual imports are error-prone (wrong topics,
missing tests, violated worktree rules). Today's session (2026-04-20) proved
the PR review step catches real issues — but the ceremony of per-repo
worktree creation was heavy enough to tempt shortcuts.

## Approach

Phase 1 only (happy path). Phases 2-3 deferred to follow-up issues.

1. **Add `--fetch-only` flag to `pull_remote.py`** — currently default mode
   fetches and reports. Formalize this as an explicit flag that returns
   structured output (JSON) listing repos with ahead commits, commit count,
   and whether diverged.

2. **Create `import-field-changes` skill** — batch skill that:
   a. Calls `pull_remote.py --fetch-only --remote <name>` (default: gitcloud)
   b. For each repo with changes: examines diff, generates issue body with
      commit summary and pre-review findings
   c. Creates issue in the project repo via `gh_create_issue.sh`
   d. Creates feature branch from gitcloud HEAD (or notes divergence)
   e. Pushes branch, opens draft PR referencing issue
   f. Reports summary to user

3. **Pre-review integration** — skill examines each diff against Quality
   Standard criteria (tests present? topic names match remaps? idempotent?)
   and includes findings in the issue body.

4. **Divergence handling (Phase 1 scope)** — detect and report. Create
   worktree for diverged repos (merge needed). Do not auto-merge in Phase 1;
   report to user for manual resolution or follow-up.

## Files to Change

| File | Change |
|------|--------|
| `.agent/scripts/pull_remote.py` | Add `--fetch-only` with JSON output mode |
| `.claude/skills/import-field-changes/` | New skill directory |
| `.claude/skills/import-field-changes/content.md` | Skill definition |
| `AGENTS.md` | Add skill to reference if needed |
| `.github/copilot-instructions.md` | Add skill to adapter list |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Human control and transparency | Skill reports findings; human decides whether to merge PRs or request fixes |
| Enforcement over documentation | Automates the "treat field imports as drafts" Quality Standard directive |
| Only what's needed | Phase 1 only — no auto-fix, no force-push resync |
| Improve incrementally | Single skill + minor script extension; builds on existing infrastructure |
| Workspace vs. project separation | Skill is generic; issues created in project repos |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0002 — Worktree isolation | Yes | Diverged repos get worktrees; non-diverged repos only create branches (no main-tree editing) |
| 0003 — Project-agnostic | Yes | Skill works for any remote name, any repo |
| 0006 — Shared AGENTS.md | Yes | Skill added to reference tables in adapters |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| `pull_remote.py` flags | Script reference table in AGENTS.md | Yes |
| Add new skill | Framework adapter skill lists | Yes |

## Open Questions

- Should the skill default to `gitcloud` remote or require explicit `--remote`?
- Should the issue title follow a convention (e.g., "Import field changes: <repo> <date>")?
- Should Phase 1 include the resync step (force-push origin→gitcloud after merge)?
  Previous comments suggest this is needed but adds risk.

## Estimated Scope

Single PR for Phase 1. Follow-up issues for: Phase 2 (auto-fix in worktree),
Phase 3 (resync), ADR for field branch conventions.
