### PR TITLE
fix: agents self-report model via 3rd arg (closes #407)

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -14,8 +14,9 @@ For agents without a framework-specific instruction file.
 source .agent/scripts/setup.bash
 
 # 2. Configure git identity
-# Host-based (shared workspace):
-source .agent/scripts/set_git_identity_env.sh "<Agent Name>" "<email>"
+# Host-based (shared workspace): pass your actual model as the 3rd argument
+# (from your system prompt — do NOT rely on framework_config.sh defaults).
+source .agent/scripts/set_git_identity_env.sh "<Agent Name>" "<email>" "<your model>"
 # Container/isolated:
 .agent/scripts/configure_git_identity.sh "<Agent Name>" "<email>"
 

--- a/.agent/AI_IDENTITY_STRATEGY.md
+++ b/.agent/AI_IDENTITY_STRATEGY.md
@@ -36,7 +36,7 @@ Agent identity is determined from these sources (in order of preference):
    - Template is at `.agent/.identity.template`
 
 **How to determine your identity:**
-1. **Use environment variables** (recommended) - Set by `set_git_identity_env.sh --detect`
+1. **Use environment variables** (recommended) - Set by sourcing `set_git_identity_env.sh` with your agent name, email, and runtime model as the 3rd argument (self-report form). `--detect` is a fallback for agents that cannot introspect their own model.
 2. **Read from** `.agent/.identity` file if it exists (check with `[ -f .agent/.identity ]`)
 3. **Ask the user** if auto-detection fails
 4. **Use fallback** values if necessary: "AI Agent" / "Unknown Model"
@@ -208,16 +208,18 @@ We distinguish the **content** author from the **setup** author.
 1.  **Determine your complete identity** when first starting work in this workspace:
     - **Framework name**: e.g., "Copilot CLI Agent", "Antigravity Agent", "Gemini CLI Agent"
     - **Email format**: `roland+<platform>@ccom.unh.edu`
-    - **Model name**: Your actual runtime model (e.g., "GPT-4o", "Gemini 2.5 Pro")
-    - **Auto-detect** using: `source .agent/scripts/set_git_identity_env.sh --detect`
+    - **Model name**: Your actual runtime model (e.g., "GPT-4o", "Gemini 2.5 Pro") — read it from your system prompt
+    - **Self-report (preferred)**: `source .agent/scripts/set_git_identity_env.sh "<Name>" "<email>" "<your model>"`
+    - **Fallback**: `source .agent/scripts/set_git_identity_env.sh --detect` if you cannot introspect your model
     - **Or read from**: `.agent/.identity` file
-    - **Ask the user** if auto-detection fails
+    - **Ask the user** if self-reporting and auto-detection both fail
 2.  **Choose the appropriate configuration method**:
     - **Host-based agents (Copilot CLI, Gemini CLI)**: Use ephemeral identity (environment variables)
     - **Containerized agents (Antigravity)**: Use persistent identity (.git/config)
     - See "Configuration Methods: Ephemeral vs. Persistent" section above for details
 3.  **Configure git identity** before making any commits:
-    - **Ephemeral**: `source .agent/scripts/set_git_identity_env.sh --detect` (or `--agent <framework>`)
+    - **Ephemeral (preferred)**: `source .agent/scripts/set_git_identity_env.sh "<Name>" "<email>" "<your model>"` (self-report)
+    - **Ephemeral (fallback)**: `source .agent/scripts/set_git_identity_env.sh --detect` or `--agent <framework>` — uses the `framework_config.sh` fallback model, which may be stale
     - **Persistent**: `./.agent/scripts/configure_git_identity.sh "<Name>" "<Email>"`
 4.  **Use correct model name in signatures**:
     - After configuration, `$AGENT_MODEL` environment variable will be set

--- a/.agent/AI_IDENTITY_STRATEGY.md
+++ b/.agent/AI_IDENTITY_STRATEGY.md
@@ -54,15 +54,19 @@ Agent identity is determined from these sources (in order of preference):
 
 **Use for**: Copilot CLI, Gemini CLI, or any agent running directly on the host that shares the working copy with the human user.
 
-**Method**: Source the environment variable script:
+**Method**: Source the environment variable script. Prefer the 3-arg form so the agent
+self-reports its runtime model (`framework_config.sh` entries are stale-prone fallbacks):
 ```bash
-# Auto-detect (recommended)
+# Recommended — agent self-reports its model from its system prompt
+source .agent/scripts/set_git_identity_env.sh "Copilot CLI Agent" "roland+copilot-cli@ccom.unh.edu" "<your model>"
+
+# Auto-detect framework + look up model from framework_config.sh (model may be stale)
 source .agent/scripts/set_git_identity_env.sh --detect
 
-# Or specify framework
+# Or specify framework explicitly (also uses framework_config.sh for model)
 source .agent/scripts/set_git_identity_env.sh --agent copilot
 
-# Or manual (not recommended)
+# 2-arg form falls back to framework_config.sh for the model — avoid for signatures
 source .agent/scripts/set_git_identity_env.sh "Copilot CLI Agent" "roland+copilot-cli@ccom.unh.edu"
 ```
 

--- a/.agent/AI_IDENTITY_STRATEGY.md
+++ b/.agent/AI_IDENTITY_STRATEGY.md
@@ -38,7 +38,7 @@ Agent identity is determined from these sources (in order of preference):
 **How to determine your identity:**
 1. **Use environment variables** (recommended) - Set by sourcing `set_git_identity_env.sh` with your agent name, email, and runtime model as the 3rd argument (self-report form). `--detect` is a fallback for agents that cannot introspect their own model.
 2. **Read from** `.agent/.identity` file if it exists (check with `[ -f .agent/.identity ]`)
-3. **Ask the user** if auto-detection fails
+3. **Ask the user** if you cannot self-report and auto-detection fails
 4. **Use fallback** values if necessary: "AI Agent" / "Unknown Model"
 5. **Configure git** with your identity before making any commits
 

--- a/.agent/instructions/gemini-cli.instructions.md
+++ b/.agent/instructions/gemini-cli.instructions.md
@@ -7,11 +7,13 @@ That file contains the shared workspace rules for all AI agents.
 
 ```bash
 source .agent/scripts/setup.bash                    # ROS 2 + checkout guardrail
-source .agent/scripts/set_git_identity_env.sh "Gemini CLI Agent" "roland+gemini-cli@ccom.unh.edu"
+# Pass your actual model as the 3rd argument (from your system prompt — do NOT rely on the fallback).
+source .agent/scripts/set_git_identity_env.sh "Gemini CLI Agent" "roland+gemini-cli@ccom.unh.edu" "<your model>"
 ```
 
-After sourcing, verify `$AGENT_MODEL` matches your actual model (from your system prompt).
-If stale, update the default in `.agent/scripts/framework_config.sh` and commit the one-line fix.
+Replace `<your model>` with your actual runtime model (e.g. `Gemini 2.5 Pro`, `Gemini 3 Pro`).
+Verify with `echo "$AGENT_MODEL"` — it should echo exactly what you passed. Do not edit
+`framework_config.sh` to match your model; the entries there are fallback-only.
 
 ## Gemini-Specific Notes
 

--- a/.agent/scripts/framework_config.sh
+++ b/.agent/scripts/framework_config.sh
@@ -34,9 +34,10 @@ declare -A FRAMEWORK_EMAILS=(
 # `set_git_identity_env.sh` (from their system prompt).
 #
 # DO NOT bump these values for every new model release. Doing so re-creates
-# the staleness treadmill that issue #407 eliminated. If your AI signature
-# shows one of these values, you forgot to pass the 3rd arg — fix the caller,
-# not this file.
+# the staleness treadmill that issue #407 eliminated. If an agent intended to
+# self-report its runtime model and its AI signature shows one of these values,
+# it forgot to pass the 3rd arg — fix the caller, not this file. (Callers using
+# --agent or --detect intentionally read from this table by design.)
 declare -A FRAMEWORK_MODELS=(
     ["copilot"]="GPT-4o"
     ["gemini"]="Gemini 2.0 Flash"

--- a/.agent/scripts/framework_config.sh
+++ b/.agent/scripts/framework_config.sh
@@ -26,9 +26,17 @@ declare -A FRAMEWORK_EMAILS=(
 )
 
 # Framework default model lookup table
-# Maps framework key to typical/default model name
-# NOTE: These are defaults - actual runtime model may differ
-# Agents should detect their actual model when possible
+# Maps framework key to fallback model name.
+#
+# IMPORTANT: These are FALLBACKS ONLY — used when an agent sources this script
+# with only 2 args (name, email) and framework auto-detection can't determine
+# a model. Agents MUST pass their actual runtime model as the 3rd argument to
+# `set_git_identity_env.sh` (from their system prompt).
+#
+# DO NOT bump these values for every new model release. Doing so re-creates
+# the staleness treadmill that issue #407 eliminated. If your AI signature
+# shows one of these values, you forgot to pass the 3rd arg — fix the caller,
+# not this file.
 declare -A FRAMEWORK_MODELS=(
     ["copilot"]="GPT-4o"
     ["gemini"]="Gemini 2.0 Flash"

--- a/.agent/scripts/framework_config.sh
+++ b/.agent/scripts/framework_config.sh
@@ -28,9 +28,10 @@ declare -A FRAMEWORK_EMAILS=(
 # Framework default model lookup table
 # Maps framework key to fallback model name.
 #
-# IMPORTANT: These are FALLBACKS ONLY — used when an agent sources this script
-# with only 2 args (name, email) and framework auto-detection can't determine
-# a model. Agents MUST pass their actual runtime model as the 3rd argument to
+# IMPORTANT: These are FALLBACKS ONLY — consulted whenever a caller does not
+# supply the model explicitly: `--agent <fw>`, `--detect`, and the 2-arg form
+# all read from this table. Only the 3-arg self-report form bypasses it.
+# Agents MUST pass their actual runtime model as the 3rd argument to
 # `set_git_identity_env.sh` (from their system prompt).
 #
 # DO NOT bump these values for every new model release. Doing so re-creates

--- a/.agent/scripts/set_git_identity_env.sh
+++ b/.agent/scripts/set_git_identity_env.sh
@@ -152,11 +152,16 @@ elif [ $# -eq 2 ]; then
         AGENT_FRAMEWORK="custom"
     fi
 elif [ $# -eq 3 ]; then
-    # Manual name, email, and model
+    # Manual name, email, and self-reported model — detect framework so identity stays complete
     AGENT_NAME="$1"
     AGENT_EMAIL="$2"
     AGENT_MODEL="$3"
-    AGENT_FRAMEWORK="custom"
+    DETECTED=$(detect_framework)
+    if [ "$DETECTED" != "unknown" ]; then
+        AGENT_FRAMEWORK="$DETECTED"
+    else
+        AGENT_FRAMEWORK="custom"
+    fi
 else
     echo "Error: Invalid arguments"
     show_usage

--- a/.agent/scripts/test_identity_introspection.sh
+++ b/.agent/scripts/test_identity_introspection.sh
@@ -109,37 +109,49 @@ fi
 echo ""
 
 # Test 5c: Manual 2-parameter usage (backward compatibility)
+#
+# AGENT_FRAMEWORK and AGENT_MODEL are environment-dependent: the 2-arg path runs
+# framework detection and looks up the matching fallback model from
+# framework_config.sh. In a scrubbed env, detection returns "unknown" →
+# AGENT_FRAMEWORK=custom, AGENT_MODEL="Unknown Model". In a real agent session
+# (e.g. CLAUDECODE=1) detection succeeds and both values reflect the framework.
+# Accept either outcome so the test is deterministic across environments.
 echo "Test 5c: Manual 2-parameter usage (backward compatibility)..."
 # Clear any existing variables
 unset AGENT_NAME AGENT_EMAIL AGENT_MODEL AGENT_FRAMEWORK
 # Source with 2 parameters
 source "$SCRIPT_DIR/set_git_identity_env.sh" "Test Agent" "test@example.com" > /dev/null 2>&1
-if [ "$AGENT_NAME" = "Test Agent" ] && [ "$AGENT_EMAIL" = "test@example.com" ] && [ "$AGENT_MODEL" = "Unknown Model" ] && [ "$AGENT_FRAMEWORK" = "custom" ]; then
-    echo "✅ 2-parameter usage works correctly (model = 'Unknown Model')"
+if [ "$AGENT_NAME" = "Test Agent" ] && [ "$AGENT_EMAIL" = "test@example.com" ] && [ -n "$AGENT_MODEL" ] && [ -n "$AGENT_FRAMEWORK" ]; then
+    echo "✅ 2-parameter usage works correctly (framework=$AGENT_FRAMEWORK, model=$AGENT_MODEL)"
 else
     echo "❌ 2-parameter usage failed"
     echo "   AGENT_NAME=$AGENT_NAME (expected: Test Agent)"
     echo "   AGENT_EMAIL=$AGENT_EMAIL (expected: test@example.com)"
-    echo "   AGENT_MODEL=$AGENT_MODEL (expected: Unknown Model)"
-    echo "   AGENT_FRAMEWORK=$AGENT_FRAMEWORK (expected: custom)"
+    echo "   AGENT_MODEL=$AGENT_MODEL (expected: non-empty)"
+    echo "   AGENT_FRAMEWORK=$AGENT_FRAMEWORK (expected: non-empty)"
     exit 1
 fi
 echo ""
 
-# Test 5d: Manual 3-parameter usage (new feature)
+# Test 5d: Manual 3-parameter usage (self-report form)
+#
+# The 3-arg form preserves the caller-supplied model verbatim; AGENT_FRAMEWORK
+# is whatever detection returns (or "custom" on miss). Assertions:
+#   - model matches the 3rd arg exactly (self-report contract)
+#   - framework is set (non-empty) — completes the four-component identity
 echo "Test 5d: Manual 3-parameter usage with model (new feature)..."
 # Clear any existing variables
 unset AGENT_NAME AGENT_EMAIL AGENT_MODEL AGENT_FRAMEWORK
 # Source with 3 parameters
 source "$SCRIPT_DIR/set_git_identity_env.sh" "Test Agent" "test@example.com" "Test Model 1.0" > /dev/null 2>&1
-if [ "$AGENT_NAME" = "Test Agent" ] && [ "$AGENT_EMAIL" = "test@example.com" ] && [ "$AGENT_MODEL" = "Test Model 1.0" ] && [ "$AGENT_FRAMEWORK" = "custom" ]; then
-    echo "✅ 3-parameter usage works correctly (model specified)"
+if [ "$AGENT_NAME" = "Test Agent" ] && [ "$AGENT_EMAIL" = "test@example.com" ] && [ "$AGENT_MODEL" = "Test Model 1.0" ] && [ -n "$AGENT_FRAMEWORK" ]; then
+    echo "✅ 3-parameter usage works correctly (model=$AGENT_MODEL, framework=$AGENT_FRAMEWORK)"
 else
     echo "❌ 3-parameter usage failed"
     echo "   AGENT_NAME=$AGENT_NAME (expected: Test Agent)"
     echo "   AGENT_EMAIL=$AGENT_EMAIL (expected: test@example.com)"
     echo "   AGENT_MODEL=$AGENT_MODEL (expected: Test Model 1.0)"
-    echo "   AGENT_FRAMEWORK=$AGENT_FRAMEWORK (expected: custom)"
+    echo "   AGENT_FRAMEWORK=$AGENT_FRAMEWORK (expected: non-empty)"
     exit 1
 fi
 echo ""

--- a/.agent/scripts/test_identity_introspection.sh
+++ b/.agent/scripts/test_identity_introspection.sh
@@ -110,25 +110,50 @@ echo ""
 
 # Test 5c: Manual 2-parameter usage (backward compatibility)
 #
-# AGENT_FRAMEWORK and AGENT_MODEL are environment-dependent: the 2-arg path runs
-# framework detection and looks up the matching fallback model from
-# framework_config.sh. In a scrubbed env, detection returns "unknown" →
-# AGENT_FRAMEWORK=custom, AGENT_MODEL="Unknown Model". In a real agent session
-# (e.g. CLAUDECODE=1) detection succeeds and both values reflect the framework.
-# Accept either outcome so the test is deterministic across environments.
+# The 2-arg path in set_git_identity_env.sh runs framework detection and looks
+# up the matching fallback model from framework_config.sh. The contract is:
+#   - detection miss → (AGENT_FRAMEWORK=custom,            AGENT_MODEL="Unknown Model")
+#   - detection hit  → (AGENT_FRAMEWORK=<detected>,        AGENT_MODEL=FRAMEWORK_MODELS[normalized key])
+# Framework normalization mirrors set_git_identity_env.sh: strip trailing -cli,
+# lowercase. AGENT_FRAMEWORK must never be the raw sentinel "unknown".
 echo "Test 5c: Manual 2-parameter usage (backward compatibility)..."
 # Clear any existing variables
 unset AGENT_NAME AGENT_EMAIL AGENT_MODEL AGENT_FRAMEWORK
 # Source with 2 parameters
 source "$SCRIPT_DIR/set_git_identity_env.sh" "Test Agent" "test@example.com" > /dev/null 2>&1
-if [ "$AGENT_NAME" = "Test Agent" ] && [ "$AGENT_EMAIL" = "test@example.com" ] && [ -n "$AGENT_MODEL" ] && [ -n "$AGENT_FRAMEWORK" ]; then
+
+test_5c_ok=true
+test_5c_reason=""
+if [ "$AGENT_NAME" != "Test Agent" ] || [ "$AGENT_EMAIL" != "test@example.com" ]; then
+    test_5c_ok=false
+    test_5c_reason="name/email mismatch"
+elif [ "$AGENT_FRAMEWORK" = "unknown" ] || [ -z "$AGENT_FRAMEWORK" ]; then
+    test_5c_ok=false
+    test_5c_reason="AGENT_FRAMEWORK must not be empty or 'unknown' (should map to 'custom' on detection miss)"
+elif [ "$AGENT_FRAMEWORK" = "custom" ]; then
+    if [ "$AGENT_MODEL" != "Unknown Model" ]; then
+        test_5c_ok=false
+        test_5c_reason="framework=custom implies model='Unknown Model', got '$AGENT_MODEL'"
+    fi
+else
+    # Detected framework: model must match FRAMEWORK_MODELS[normalized key]
+    fwkey="${AGENT_FRAMEWORK%-cli}"
+    fwkey="${fwkey,,}"
+    expected_model="${FRAMEWORK_MODELS[$fwkey]:-Unknown Model}"
+    if [ "$AGENT_MODEL" != "$expected_model" ]; then
+        test_5c_ok=false
+        test_5c_reason="framework='$AGENT_FRAMEWORK' (key='$fwkey') implies model='$expected_model', got '$AGENT_MODEL'"
+    fi
+fi
+
+if [ "$test_5c_ok" = "true" ]; then
     echo "✅ 2-parameter usage works correctly (framework=$AGENT_FRAMEWORK, model=$AGENT_MODEL)"
 else
-    echo "❌ 2-parameter usage failed"
+    echo "❌ 2-parameter usage failed: $test_5c_reason"
     echo "   AGENT_NAME=$AGENT_NAME (expected: Test Agent)"
     echo "   AGENT_EMAIL=$AGENT_EMAIL (expected: test@example.com)"
-    echo "   AGENT_MODEL=$AGENT_MODEL (expected: non-empty)"
-    echo "   AGENT_FRAMEWORK=$AGENT_FRAMEWORK (expected: non-empty)"
+    echo "   AGENT_MODEL=$AGENT_MODEL"
+    echo "   AGENT_FRAMEWORK=$AGENT_FRAMEWORK"
     exit 1
 fi
 echo ""
@@ -136,22 +161,27 @@ echo ""
 # Test 5d: Manual 3-parameter usage (self-report form)
 #
 # The 3-arg form preserves the caller-supplied model verbatim; AGENT_FRAMEWORK
-# is whatever detection returns (or "custom" on miss). Assertions:
-#   - model matches the 3rd arg exactly (self-report contract)
-#   - framework is set (non-empty) — completes the four-component identity
+# comes from framework detection with the raw sentinel "unknown" collapsed to
+# "custom" (see set_git_identity_env.sh:154-164). Contract:
+#   - model matches the 3rd arg exactly (self-report)
+#   - framework is non-empty AND is never the raw sentinel "unknown"
 echo "Test 5d: Manual 3-parameter usage with model (new feature)..."
 # Clear any existing variables
 unset AGENT_NAME AGENT_EMAIL AGENT_MODEL AGENT_FRAMEWORK
 # Source with 3 parameters
 source "$SCRIPT_DIR/set_git_identity_env.sh" "Test Agent" "test@example.com" "Test Model 1.0" > /dev/null 2>&1
-if [ "$AGENT_NAME" = "Test Agent" ] && [ "$AGENT_EMAIL" = "test@example.com" ] && [ "$AGENT_MODEL" = "Test Model 1.0" ] && [ -n "$AGENT_FRAMEWORK" ]; then
+if [ "$AGENT_NAME" = "Test Agent" ] \
+   && [ "$AGENT_EMAIL" = "test@example.com" ] \
+   && [ "$AGENT_MODEL" = "Test Model 1.0" ] \
+   && [ -n "$AGENT_FRAMEWORK" ] \
+   && [ "$AGENT_FRAMEWORK" != "unknown" ]; then
     echo "✅ 3-parameter usage works correctly (model=$AGENT_MODEL, framework=$AGENT_FRAMEWORK)"
 else
     echo "❌ 3-parameter usage failed"
     echo "   AGENT_NAME=$AGENT_NAME (expected: Test Agent)"
     echo "   AGENT_EMAIL=$AGENT_EMAIL (expected: test@example.com)"
     echo "   AGENT_MODEL=$AGENT_MODEL (expected: Test Model 1.0)"
-    echo "   AGENT_FRAMEWORK=$AGENT_FRAMEWORK (expected: non-empty)"
+    echo "   AGENT_FRAMEWORK=$AGENT_FRAMEWORK (expected: non-empty and not 'unknown')"
     exit 1
 fi
 echo ""

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,11 +22,13 @@ only in the workspace repo. When reviewing:
 
 ```bash
 source .agent/scripts/setup.bash                    # ROS 2 + checkout guardrail
-source .agent/scripts/set_git_identity_env.sh "Copilot CLI Agent" "roland+copilot-cli@ccom.unh.edu"
+# Pass your actual model as the 3rd argument (from your system prompt — do NOT rely on the fallback).
+source .agent/scripts/set_git_identity_env.sh "Copilot CLI Agent" "roland+copilot-cli@ccom.unh.edu" "<your model>"
 ```
 
-After sourcing, verify `$AGENT_MODEL` matches your actual model (from your system prompt).
-If stale, update the default in `.agent/scripts/framework_config.sh` and commit the one-line fix.
+Replace `<your model>` with your actual runtime model (e.g. `Claude Sonnet 4.5`, `GPT-5`).
+Verify with `echo "$AGENT_MODEL"` — it should echo exactly what you passed. Do not edit
+`framework_config.sh` to match your model; the entries there are fallback-only.
 
 ## Copilot-Specific Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,13 @@
 
 ```bash
 source .agent/scripts/setup.bash                    # ROS 2 + checkout guardrail
-source .agent/scripts/set_git_identity_env.sh "Claude Code Agent" "roland+claude-code@ccom.unh.edu"
+# Pass your actual model as the 3rd argument (from your system prompt — do NOT rely on the fallback).
+source .agent/scripts/set_git_identity_env.sh "Claude Code Agent" "roland+claude-code@ccom.unh.edu" "<your model>"
 ```
 
-After sourcing, verify `$AGENT_MODEL` matches your actual model (from your system prompt).
-If stale, update the default in `.agent/scripts/framework_config.sh` and commit the one-line fix.
+Replace `<your model>` with your actual runtime model (e.g. `Claude Opus 4.7 (1M context)`,
+`Claude Sonnet 4.6`). Verify with `echo "$AGENT_MODEL"` — it should echo exactly what you passed.
+Do not edit `framework_config.sh` to match your model; the entries there are fallback-only.
 
 ## Claude-Specific Notes
 


### PR DESCRIPTION
## Summary

- Adapter docs (CLAUDE.md, Copilot, Gemini, AGENT_ONBOARDING.md, AI_IDENTITY_STRATEGY.md) now tell agents to pass their actual runtime model as the 3rd arg to `set_git_identity_env.sh` (from the agent's system prompt).
- Removed the "if stale, update `framework_config.sh` and commit the one-line fix" instructions that created the bump-the-config treadmill.
- `framework_config.sh` `FRAMEWORK_MODELS` entries are now explicitly marked fallback-only with a "do not bump per release" warning. Values themselves are unchanged to keep existing tests happy.
- `set_git_identity_env.sh` 3-arg form now runs framework detection and preserves the detected framework ID (falling back to `custom` only when detection fails), so the four-component identity (framework + name + email + model) stays complete when an agent self-reports its model. **This is a behavior change to the 3-arg path** — previous behavior was `AGENT_FRAMEWORK=custom` unconditionally.
- `test_identity_introspection.sh` Tests 5c and 5d updated to assert framework/model are *set and consistent* rather than locked to `custom`, so the suite is deterministic across detection environments (scrubbed → `custom`, real agent session → detected key). This also closes the pre-existing 5c brittleness.

## Why this matters

Git history on `framework_config.sh` shows exactly the treadmill #407 describes: `Claude 3.5 Sonnet` → `Claude Opus 4.5` → `Claude Opus 4.6`, and #442 was queued to bump to `Opus 4.7`. Each bump is a committed edit to a shared file that every future agent has to repeat. Self-reporting the model at source time removes the shared mutable state entirely.

## Test plan

- [x] `source .agent/scripts/set_git_identity_env.sh "Claude Code Agent" "roland+claude-code@ccom.unh.edu" "Claude Opus 4.7 (1M context)"` — `$AGENT_MODEL` reflects exactly what was passed, `$AGENT_FRAMEWORK=claude-code` (verified in this session).
- [x] Same invocation in a scrubbed env (`env -i …`) — `$AGENT_FRAMEWORK=custom` fallback kicks in as designed.
- [x] `.agent/scripts/test_identity_introspection.sh` passes in both environments (real agent session and scrubbed env).
- [x] Pre-commit hooks: all passed (trailing whitespace, shellcheck, branch/issue verification, etc.).

## Follow-ups

- #442 (bump `AGENT_MODEL` default to Opus 4.7): superseded by this PR. If merged, #442 can be closed as no-longer-needed.
- Cross-repo: the same pattern likely needs the same fix in `rolker/agent_workspace` (called out in #407).

Closes #407

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
