### PR TITLE
agent container: install git-bug for local-first issue access

### DIFF
--- a/.devcontainer/agent/Dockerfile
+++ b/.devcontainer/agent/Dockerfile
@@ -49,10 +49,24 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install git-bug (local-first issue tracking, see ADR-0010)
+# Pinned SHA256 per arch detects tampering or asset substitution.
+# Upstream v0.10.1 publishes linux binaries for amd64, 386, and arm (32-bit) only;
+# arm64 (Apple Silicon) is not available upstream and fails explicitly below.
 ARG GITBUG_VERSION=v0.10.1
-RUN curl -fsSL "https://github.com/MichaelMure/git-bug/releases/download/${GITBUG_VERSION}/git-bug_linux_amd64" \
-        -o /usr/local/bin/git-bug \
-    && chmod 755 /usr/local/bin/git-bug
+ARG GITBUG_SHA256_AMD64=3ba2f8b41e526fef1b6e825d5030823be65bb6521a287b1139bd609fed0d54a1
+ARG GITBUG_SHA256_ARM=308b1d17bc4d12685a95c2908baf2b14b77e81737f34b3bd82a8baf10850fd87
+RUN set -eux; \
+    case "$(dpkg --print-architecture)" in \
+        amd64) gitbug_arch=amd64; gitbug_sha256="${GITBUG_SHA256_AMD64}" ;; \
+        armhf) gitbug_arch=arm;   gitbug_sha256="${GITBUG_SHA256_ARM}"   ;; \
+        *)  echo "Unsupported architecture for git-bug ${GITBUG_VERSION}: $(dpkg --print-architecture)" >&2; \
+            echo "Upstream provides amd64, 386, arm only (no arm64)." >&2; \
+            exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/git-bug/git-bug/releases/download/${GITBUG_VERSION}/git-bug_linux_${gitbug_arch}" \
+        -o /usr/local/bin/git-bug; \
+    echo "${gitbug_sha256}  /usr/local/bin/git-bug" | sha256sum -c -; \
+    chmod 755 /usr/local/bin/git-bug
 
 # Install Claude Code CLI globally
 RUN npm install -g @anthropic-ai/claude-code

--- a/.devcontainer/agent/Dockerfile
+++ b/.devcontainer/agent/Dockerfile
@@ -50,8 +50,8 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 # Install git-bug (local-first issue tracking, see ADR-0010)
 # Pinned SHA256 per arch detects tampering or asset substitution.
-# Upstream v0.10.1 publishes linux binaries for amd64, 386, and arm (32-bit) only;
-# arm64 (Apple Silicon) is not available upstream and fails explicitly below.
+# Supports linux amd64 and armhf only; arm64 (Apple Silicon) and other arches
+# are not available upstream for v0.10.1 and fail explicitly below.
 ARG GITBUG_VERSION=v0.10.1
 ARG GITBUG_SHA256_AMD64=3ba2f8b41e526fef1b6e825d5030823be65bb6521a287b1139bd609fed0d54a1
 ARG GITBUG_SHA256_ARM=308b1d17bc4d12685a95c2908baf2b14b77e81737f34b3bd82a8baf10850fd87

--- a/.devcontainer/agent/Dockerfile
+++ b/.devcontainer/agent/Dockerfile
@@ -48,6 +48,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get update && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
+# Install git-bug (local-first issue tracking, see ADR-0010)
+ARG GITBUG_VERSION=v0.10.1
+RUN curl -fsSL "https://github.com/MichaelMure/git-bug/releases/download/${GITBUG_VERSION}/git-bug_linux_amd64" \
+        -o /usr/local/bin/git-bug \
+    && chmod 755 /usr/local/bin/git-bug
+
 # Install Claude Code CLI globally
 RUN npm install -g @anthropic-ai/claude-code
 

--- a/.devcontainer/agent/README.md
+++ b/.devcontainer/agent/README.md
@@ -46,10 +46,12 @@ The image is based on `ros:jazzy-perception` and includes:
 
 The build passes your host UID/GID to match file ownership.
 
-**Architecture**: amd64-only in practice. The image builds for the host's
-architecture (no `--platform` is set in `make agent-build`), and git-bug
-v0.10.1 has no upstream arm64 binary — Apple Silicon hosts will fail
-explicitly at the git-bug install step. Other Linux hosts work.
+**Architecture**: the image builds for the host's architecture (no
+`--platform` is set in `make agent-build`). Supported: `amd64` and
+`armhf` (32-bit ARM). Unsupported: `arm64` — git-bug v0.10.1 has no
+upstream arm64 binary, so the build fails explicitly at the git-bug
+install step on any arm64 host (Apple Silicon, AWS Graviton, 64-bit
+Raspberry Pi, etc.).
 
 ## Running
 

--- a/.devcontainer/agent/README.md
+++ b/.devcontainer/agent/README.md
@@ -41,6 +41,7 @@ The image is based on `ros:jazzy-perception` and includes:
 - ROS 2 Jazzy dev tools, rosdep, vcstool
 - Node.js 22.x + Claude Code CLI
 - GitHub CLI (`gh`) for read-only access (see [Read-Only GitHub Access](#read-only-github-access))
+- git-bug for local issue access (reads/comments without network, see ADR-0010)
 - Git (for local commits only — no SSH keys)
 
 The build passes your host UID/GID to match file ownership.

--- a/.devcontainer/agent/README.md
+++ b/.devcontainer/agent/README.md
@@ -41,10 +41,15 @@ The image is based on `ros:jazzy-perception` and includes:
 - ROS 2 Jazzy dev tools, rosdep, vcstool
 - Node.js 22.x + Claude Code CLI
 - GitHub CLI (`gh`) for read-only access (see [Read-Only GitHub Access](#read-only-github-access))
-- git-bug for local issue access (reads/comments without network, see ADR-0010)
+- git-bug for local issue access (reads/comments without network, see [ADR-0010](../../docs/decisions/0010-adopt-git-bug-for-local-issue-tracking.md))
 - Git (for local commits only — no SSH keys)
 
 The build passes your host UID/GID to match file ownership.
+
+**Architecture**: amd64-only in practice. The image builds for the host's
+architecture (no `--platform` is set in `make agent-build`), and git-bug
+v0.10.1 has no upstream arm64 binary — Apple Silicon hosts will fail
+explicitly at the git-bug install step. Other Linux hosts work.
 
 ## Running
 


### PR DESCRIPTION
## Summary

- Installs `git-bug` v0.10.1 in the agent Docker image
- Enables containerized agents to read/post issues locally without GitHub network access
- Supports ADR-0010 local-first workflow

This commit was originally authored on 2026-03-13 and has been parked on
the `feature/issue-247` branch (unrelated to that issue's hardening
scope). Moved here for proper review.

Closes #446

## Test plan

- [ ] Build the agent container: `docker build -f .devcontainer/agent/Dockerfile .devcontainer/agent/`
- [ ] Run `git-bug --version` inside the container — should print `v0.10.1`
- [ ] Confirm README reflects the addition

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
