### PR TITLE
feat: field-mode carve-out + worktree-rule hardening (closes #247, #445)

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -31,7 +31,9 @@ See [`AI_IDENTITY_STRATEGY.md`](AI_IDENTITY_STRATEGY.md) for the full identity d
 See [`AGENTS.md`](../AGENTS.md) for the shared workspace rules all agents must follow.
 
 Key points:
-- Never commit to `main` — use worktrees for isolation
+- Never commit to `main` on a github-origin repo — use worktrees for isolation.
+  Repos with non-github origin (field mode) have their own workflow; see
+  [`AGENTS.md` Field Mode](../AGENTS.md#field-mode-origin-not-githubcom).
 - Never `git checkout <branch>` — `setup.bash` blocks it
 - AI signature required on all GitHub Issues/PRs/Comments
 - Use `--body-file` for `gh` CLI, not inline `--body`

--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -31,8 +31,9 @@ See [`AI_IDENTITY_STRATEGY.md`](AI_IDENTITY_STRATEGY.md) for the full identity d
 See [`AGENTS.md`](../AGENTS.md) for the shared workspace rules all agents must follow.
 
 Key points:
-- Never commit to `main` on a github-origin repo — use worktrees for isolation.
-  Repos with non-github origin (field mode) have their own workflow; see
+- Never commit directly to the default branch (e.g. `main`, `jazzy`) on a
+  GitHub-origin repo — use worktrees for isolation. Repos with non-GitHub
+  origin (field mode) have their own workflow; see
   [`AGENTS.md` Field Mode](../AGENTS.md#field-mode-origin-not-githubcom).
 - Never `git checkout <branch>` — `setup.bash` blocks it
 - AI signature required on all GitHub Issues/PRs/Comments

--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -34,7 +34,7 @@ Key points:
 - Never commit directly to the default branch (e.g. `main`, `jazzy`) on a
   GitHub-origin repo — use worktrees for isolation. Repos with non-GitHub
   origin (field mode) have their own workflow; see
-  [`AGENTS.md` Field Mode](../AGENTS.md#field-mode-origin-not-githubcom).
+  [`AGENTS.md` Field Mode](../AGENTS.md#field-mode-origin-not-on-a-github-host).
 - Never `git checkout <branch>` — `setup.bash` blocks it
 - AI signature required on all GitHub Issues/PRs/Comments
 - Use `--body-file` for `gh` CLI, not inline `--body`

--- a/.agent/WORKTREE_GUIDE.md
+++ b/.agent/WORKTREE_GUIDE.md
@@ -68,13 +68,14 @@ source setup.bash                  # Set up ROS environment
 
 ## Field Mode
 
-Repos whose `origin` is not github.com (field machines pulling from gitcloud,
-private Forgejo, etc.) don't require worktrees for hotfixes. Agents may edit
-the main tree directly and commit to the default branch. See
-[`AGENTS.md` Field Mode](../AGENTS.md#field-mode-origin-not-githubcom) for the
-full rule and detection via `.agent/scripts/field_mode.sh`. Field commits are
-imported back to GitHub via the `/import-field-changes` skill on a connected
-dev machine.
+Repos whose `origin` host is not on the GitHub allowlist (currently
+`github.com` and `ssh.github.com` — see
+[`.agent/scripts/field_mode.sh`](../.agent/scripts/field_mode.sh)) don't
+require worktrees for hotfixes. Agents may edit the main tree directly
+and commit to the default branch. See
+[`AGENTS.md` Field Mode](../AGENTS.md#field-mode-origin-not-on-a-github-host)
+for the full rule. Field commits are imported back to GitHub via the
+`/import-field-changes` skill on a connected dev machine.
 
 ## Why Worktrees?
 

--- a/.agent/WORKTREE_GUIDE.md
+++ b/.agent/WORKTREE_GUIDE.md
@@ -66,6 +66,16 @@ source setup.bash                  # Set up ROS environment
 **Note**: `colcon_defaults.yaml` is placed in the target layer workspace so raw
 `colcon build` from that directory also picks up the correct flags.
 
+## Field Mode
+
+Repos whose `origin` is not github.com (field machines pulling from gitcloud,
+private Forgejo, etc.) don't require worktrees for hotfixes. Agents may edit
+the main tree directly and commit to the default branch. See
+[`AGENTS.md` Field Mode](../AGENTS.md#field-mode-origin-not-githubcom) for the
+full rule and detection via `.agent/scripts/field_mode.sh`. Field commits are
+imported back to GitHub via the `/import-field-changes` skill on a connected
+dev machine.
+
 ## Why Worktrees?
 
 ### The Problem

--- a/.agent/knowledge/README.md
+++ b/.agent/knowledge/README.md
@@ -17,7 +17,7 @@ checked out in `layers/`.
 - **[Skill Workflows](skill_workflows.md)**: Per-issue lifecycle sequence, governance skill index, and utility skill catalog.
 - **[Principles Review Guide](principles_review_guide.md)**: Evaluation criteria for workspace principles and ADRs. Used by lifecycle skills (triage, planning, review) and as a manual checklist.
 - **[Documentation Verification](documentation_verification.md)**: Mandatory verification workflow for writing accurate ROS 2 package documentation. Includes command cookbook and hallucination anti-patterns.
-- **[Field Mode Hotfix Walkthrough](field_mode_hotfix.md)**: Step-by-step flow for making a hotfix on a field machine (non-github origin) and reconciling back to GitHub via the import skill.
+- **[Field Mode Hotfix Walkthrough](field_mode_hotfix.md)**: Step-by-step flow for making a hotfix on a field machine (non-GitHub origin) and reconciling back to GitHub via the import skill.
 
 ## Project-Specific Knowledge
 

--- a/.agent/knowledge/README.md
+++ b/.agent/knowledge/README.md
@@ -17,6 +17,7 @@ checked out in `layers/`.
 - **[Skill Workflows](skill_workflows.md)**: Per-issue lifecycle sequence, governance skill index, and utility skill catalog.
 - **[Principles Review Guide](principles_review_guide.md)**: Evaluation criteria for workspace principles and ADRs. Used by lifecycle skills (triage, planning, review) and as a manual checklist.
 - **[Documentation Verification](documentation_verification.md)**: Mandatory verification workflow for writing accurate ROS 2 package documentation. Includes command cookbook and hallucination anti-patterns.
+- **[Field Mode Hotfix Walkthrough](field_mode_hotfix.md)**: Step-by-step flow for making a hotfix on a field machine (non-github origin) and reconciling back to GitHub via the import skill.
 
 ## Project-Specific Knowledge
 

--- a/.agent/knowledge/field_mode_hotfix.md
+++ b/.agent/knowledge/field_mode_hotfix.md
@@ -1,0 +1,155 @@
+# Field Mode Hotfix Walkthrough
+
+Concrete walkthrough for making a hotfix on a field machine and getting the
+change back to GitHub via the import skill. Reference implementation of the
+field-mode carve-out documented in [`AGENTS.md § Field
+Mode`](../../AGENTS.md#field-mode-origin-not-githubcom).
+
+## When This Applies
+
+Use this flow only when **both** of these are true:
+
+1. The repo you're editing has a non-github origin (`field_mode.sh --describe`
+   prints `field mode`).
+2. You are on a field machine — the boat, an operator station, or another
+   environment where the field remote (gitcloud, Forgejo, etc.) is the
+   authoritative copy.
+
+Neither the workspace repo nor github-origin project repos use this flow; they
+stay on the worktree + PR workflow regardless of where the machine physically
+sits.
+
+## Scenario
+
+You're on BizzyBoat. The `unh_echoboats_project11` repo on this machine has
+origin `git@gitcloud:field/unh_echoboats_project11.git`. Operator tmux is
+failing to start a pane because a launch file references a missing config
+key. The fix is one line in a config file. The next pier session is in an
+hour.
+
+## Step-by-Step
+
+### 1. Confirm field mode
+
+```bash
+cd layers/main/platforms_ws/src/unh_echoboats_project11
+.agent/scripts/field_mode.sh --describe
+# → field mode  (origin: git@gitcloud:field/unh_echoboats_project11.git)
+```
+
+If the output says `dev mode`, stop — you're on a github-origin repo and
+this flow does not apply. Use a worktree + PR.
+
+### 2. Check the default branch
+
+Project repos may use `jazzy` or another branch, not `main`:
+
+```bash
+git branch --show-current
+# → jazzy
+```
+
+This is the branch you'll commit to directly.
+
+### 3. Make the fix
+
+Edit the tracked file in place. No worktree needed:
+
+```bash
+$EDITOR config/operator_tmux.yaml
+```
+
+### 4. Commit — hooks and AI signature still required
+
+Field mode relaxes the worktree/PR requirement. It does **not** relax any
+other quality gate. Pre-commit hooks still run, the AI signature is still
+required, commits stay atomic:
+
+```bash
+git add config/operator_tmux.yaml
+git commit -m "$(cat <<'EOF'
+fix(operator_tmux): restore missing pane_order config key
+
+Pane startup failed because operator_tmux.yaml was missing the
+pane_order list. Added a default ordering matching the previous
+session's layout.
+
+Field hotfix — landing direct on jazzy per AGENTS.md Field Mode.
+
+Co-Authored-By: <your model> <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 5. Push to the field remote
+
+Push goes to `origin` (gitcloud), not github:
+
+```bash
+git push origin jazzy
+```
+
+No PR is opened — there is no GitHub on this side. The commit is live on the
+field branch immediately.
+
+### 6. Verify the fix on the boat
+
+Restart whatever was broken and confirm behavior:
+
+```bash
+tmux kill-session -t operator 2>/dev/null
+scripts/start_operator_tmux.sh
+```
+
+### 7. (Later, on the dev machine) Import back to GitHub
+
+When a dev machine next has connectivity and time to do review work, run the
+import skill from the workspace root:
+
+```bash
+/import-field-changes
+```
+
+The skill:
+
+- Fetches from the configured field remote (gitcloud)
+- Detects that `unh_echoboats_project11` is ahead of `origin` (github)
+- Creates a GitHub issue describing the incoming commit(s)
+- Opens a draft PR with pre-review notes (tests? topic names? idempotency?)
+- Leaves review + merge to a human
+
+The field hotfix goes through the normal review gate — just delayed until
+there's bandwidth for it, rather than blocking the boat.
+
+## Gotchas
+
+**Config file in `.agent/project_config.yaml` is required for the import
+skill.** It needs `field_remote: <name>` to know where to pull from. This
+file is created during field-machine bootstrap, but verify it exists on any
+dev machine that runs the import.
+
+**Don't cherry-pick field commits manually.** The import skill handles the
+branch/PR setup to avoid perturbing the main tree HEAD. Manual cherry-picks
+lose the pre-review and risk violating the dev-mode worktree rule.
+
+**Diverged repos need human merge.** If both sides have commits since they
+last synced, the import skill flags the repo and lets you resolve in a
+dedicated worktree. Don't force-push either direction.
+
+**Hotfix commits should still be atomic.** Multiple unrelated fixes in one
+commit make later review painful. If the boat needs five things fixed, that's
+five commits.
+
+**Field mode does NOT apply in the workspace repo.** Even if you clone the
+workspace from gitcloud on a field machine, workspace infrastructure is
+never hotfixed in the field. File a git-bug bug report instead
+(`gh_create_issue.sh` with `GITBUG_CREATE=1`) — it will sync back to GitHub
+via the git-bug bridge when the machine reconnects.
+
+## Related
+
+- [`AGENTS.md § Field Mode`](../../AGENTS.md#field-mode-origin-not-githubcom) — canonical rule
+- [`.agent/scripts/field_mode.sh`](../scripts/field_mode.sh) — mode detection helper
+- [`.claude/skills/import-field-changes/content.md`](../../.claude/skills/import-field-changes/content.md) — the import skill
+- Issue [#445](https://github.com/rolker/ros2_agent_workspace/issues/445) — field-mode design and decisions
+- Issue [#247](https://github.com/rolker/ros2_agent_workspace/issues/247) — dev-mode worktree hardening

--- a/.agent/knowledge/field_mode_hotfix.md
+++ b/.agent/knowledge/field_mode_hotfix.md
@@ -3,7 +3,7 @@
 Concrete walkthrough for making a hotfix on a field machine and getting the
 change back to GitHub via the import skill. Reference implementation of the
 field-mode carve-out documented in [`AGENTS.md § Field
-Mode`](../../AGENTS.md#field-mode-origin-not-githubcom).
+Mode`](../../AGENTS.md#field-mode-origin-not-on-a-github-host).
 
 ## When This Applies
 
@@ -159,7 +159,7 @@ git-bug bridge when the machine reconnects.
 
 ## Related
 
-- [`AGENTS.md § Field Mode`](../../AGENTS.md#field-mode-origin-not-githubcom) — canonical rule
+- [`AGENTS.md § Field Mode`](../../AGENTS.md#field-mode-origin-not-on-a-github-host) — canonical rule
 - [`.agent/scripts/field_mode.sh`](../scripts/field_mode.sh) — mode detection helper
 - [`.claude/skills/import-field-changes/content.md`](../../.claude/skills/import-field-changes/content.md) — the import skill
 - Issue [#445](https://github.com/rolker/ros2_agent_workspace/issues/445) — field-mode design and decisions

--- a/.agent/knowledge/field_mode_hotfix.md
+++ b/.agent/knowledge/field_mode_hotfix.md
@@ -2,8 +2,8 @@
 
 Concrete walkthrough for making a hotfix on a field machine and getting the
 change back to GitHub via the import skill. Reference implementation of the
-field-mode carve-out documented in [`AGENTS.md § Field
-Mode`](../../AGENTS.md#field-mode-origin-not-on-a-github-host).
+field-mode carve-out documented in
+[`AGENTS.md § Field Mode`](../../AGENTS.md#field-mode-origin-not-on-a-github-host).
 
 ## When This Applies
 
@@ -157,11 +157,15 @@ be committed in haste. File a git-bug bug report instead — `gh_create_issue.sh
 with `GITBUG_CREATE=1` creates a bug locally that syncs to GitHub via the
 git-bug bridge when the machine reconnects.
 
-**`no-commit-to-branch` hook can block your commit.** The workspace
-pre-commit template configures `no-commit-to-branch` for `main`, `jazzy`,
-`rolling`. If a field-mode project repo inherits that hook, committing
-directly to its default branch will fail at the pre-commit step even
-though field mode otherwise permits it. Check the repo's
+**`no-commit-to-branch` hook can block your commit.** This common
+pre-commit hook blocks direct commits to listed branches. Two templates
+in this workspace configure it: the project-repo template at
+`.agent/templates/pre-commit-config.yaml` (using
+`PLACEHOLDER_DEFAULT_BRANCH` that each project fills in), and the
+workspace's own `.pre-commit-config.yaml` (which lists `main`, `jazzy`,
+`rolling`). If a field-mode project repo has its default branch in the
+hook's list, committing directly will fail at pre-commit even though
+field mode otherwise permits it. Check the repo's
 `.pre-commit-config.yaml`; if `no-commit-to-branch` lists the default
 branch, remove that entry or drop the hook entirely for field-mode
 repos. Don't bypass with `--no-verify` — fix the config.

--- a/.agent/knowledge/field_mode_hotfix.md
+++ b/.agent/knowledge/field_mode_hotfix.md
@@ -7,15 +7,15 @@ Mode`](../../AGENTS.md#field-mode-origin-not-githubcom).
 
 ## When This Applies
 
-Use this flow when the repo you're editing has a non-github origin
+Use this flow when the repo you're editing has a non-GitHub origin
 (`.agent/scripts/field_mode.sh --describe` prints `field mode`). This is
 how field machines deploy hotfixes that have to land before the next run.
 
-**Github-origin repos** always use the worktree + PR workflow, regardless
+**GitHub-origin repos** always use the worktree + PR workflow, regardless
 of where the machine physically sits.
 
 **Workspace repo on a field machine**: `is_field_mode()` will return true
-if the workspace was cloned from a non-github mirror — the rule is purely
+if the workspace was cloned from a non-GitHub mirror — the rule is purely
 origin-based by design (see Decision 2 on #445). But hotfixing workspace
 infrastructure (agent rules, scripts, docs) from the field is strongly
 discouraged: those changes don't make the boat go, and they bypass the
@@ -34,13 +34,16 @@ hour.
 
 ### 1. Confirm field mode
 
+The detection script lives at the workspace root — pass the project repo
+as an argument so the relative path doesn't shift when you `cd` later:
+
 ```bash
-cd layers/main/platforms_ws/src/unh_echoboats_project11
-.agent/scripts/field_mode.sh --describe
+# From the workspace root
+.agent/scripts/field_mode.sh --describe layers/main/platforms_ws/src/unh_echoboats_project11
 # → field mode  (origin: git@gitcloud:field/unh_echoboats_project11.git)
 ```
 
-If the output says `dev mode`, stop — you're on a github-origin repo and
+If the output says `dev mode`, stop — you're on a GitHub-origin repo and
 this flow does not apply. Use a worktree + PR.
 
 ### 2. Check the default branch
@@ -48,6 +51,7 @@ this flow does not apply. Use a worktree + PR.
 Project repos may use `jazzy` or another branch, not `main`:
 
 ```bash
+cd layers/main/platforms_ws/src/unh_echoboats_project11
 git branch --show-current
 # → jazzy
 ```

--- a/.agent/knowledge/field_mode_hotfix.md
+++ b/.agent/knowledge/field_mode_hotfix.md
@@ -71,9 +71,10 @@ $EDITOR config/operator_tmux.yaml
 Field mode relaxes the worktree/PR requirement. It does **not** relax any
 other quality gate: pre-commit hooks still run, commits stay atomic, and
 the commit author is your configured agent identity (set by
-`set_git_identity_env.sh`). Adding a `Co-Authored-By` trailer for your
-agent model is conventional — substitute your framework's actual name,
-model, and noreply email:
+`set_git_identity_env.sh`). The workspace does not currently mandate a
+specific commit-trailer format; if your agent framework has a convention
+for attributing the model in commit messages (e.g. a `Co-Authored-By`
+trailer), apply it as you would on any other commit.
 
 ```bash
 git add config/operator_tmux.yaml
@@ -85,8 +86,6 @@ pane_order list. Added a default ordering matching the previous
 session's layout.
 
 Field hotfix — landing direct on jazzy per AGENTS.md Field Mode.
-
-Co-Authored-By: <agent name and model> <agent-noreply-email>
 EOF
 )"
 ```

--- a/.agent/knowledge/field_mode_hotfix.md
+++ b/.agent/knowledge/field_mode_hotfix.md
@@ -7,17 +7,20 @@ Mode`](../../AGENTS.md#field-mode-origin-not-githubcom).
 
 ## When This Applies
 
-Use this flow only when **both** of these are true:
+Use this flow when the repo you're editing has a non-github origin
+(`.agent/scripts/field_mode.sh --describe` prints `field mode`). This is
+how field machines deploy hotfixes that have to land before the next run.
 
-1. The repo you're editing has a non-github origin (`field_mode.sh --describe`
-   prints `field mode`).
-2. You are on a field machine — the boat, an operator station, or another
-   environment where the field remote (gitcloud, Forgejo, etc.) is the
-   authoritative copy.
+**Github-origin repos** always use the worktree + PR workflow, regardless
+of where the machine physically sits.
 
-Neither the workspace repo nor github-origin project repos use this flow; they
-stay on the worktree + PR workflow regardless of where the machine physically
-sits.
+**Workspace repo on a field machine**: `is_field_mode()` will return true
+if the workspace was cloned from a non-github mirror — the rule is purely
+origin-based by design (see Decision 2 on #445). But hotfixing workspace
+infrastructure (agent rules, scripts, docs) from the field is strongly
+discouraged: those changes don't make the boat go, and they bypass the
+review the workspace usually gets. File a git-bug bug report instead
+(see the gotcha at the bottom).
 
 ## Scenario
 
@@ -63,7 +66,10 @@ $EDITOR config/operator_tmux.yaml
 
 Field mode relaxes the worktree/PR requirement. It does **not** relax any
 other quality gate. Pre-commit hooks still run, the AI signature is still
-required, commits stay atomic:
+required, commits stay atomic. The `Co-Authored-By` trailer follows the
+[AGENTS.md AI Signature](../../AGENTS.md#ai-signature-required-on-all-github-issuesprscomments)
+pattern — substitute your framework's actual name, model, and noreply
+email:
 
 ```bash
 git add config/operator_tmux.yaml
@@ -76,7 +82,7 @@ session's layout.
 
 Field hotfix — landing direct on jazzy per AGENTS.md Field Mode.
 
-Co-Authored-By: <your model> <noreply@anthropic.com>
+Co-Authored-By: <agent name and model> <agent-noreply-email>
 EOF
 )"
 ```
@@ -140,11 +146,13 @@ dedicated worktree. Don't force-push either direction.
 commit make later review painful. If the boat needs five things fixed, that's
 five commits.
 
-**Field mode does NOT apply in the workspace repo.** Even if you clone the
-workspace from gitcloud on a field machine, workspace infrastructure is
-never hotfixed in the field. File a git-bug bug report instead
-(`gh_create_issue.sh` with `GITBUG_CREATE=1`) — it will sync back to GitHub
-via the git-bug bridge when the machine reconnects.
+**Don't hotfix workspace infra from the field.** `is_field_mode()` will
+return true on a field-cloned workspace repo (the rule is purely
+origin-based — there is no hard-coded carve-out, see Decision 2 on #445),
+but workspace infrastructure changes don't make the boat go and shouldn't
+be committed in haste. File a git-bug bug report instead — `gh_create_issue.sh`
+with `GITBUG_CREATE=1` creates a bug locally that syncs to GitHub via the
+git-bug bridge when the machine reconnects.
 
 ## Related
 

--- a/.agent/knowledge/field_mode_hotfix.md
+++ b/.agent/knowledge/field_mode_hotfix.md
@@ -157,6 +157,15 @@ be committed in haste. File a git-bug bug report instead — `gh_create_issue.sh
 with `GITBUG_CREATE=1` creates a bug locally that syncs to GitHub via the
 git-bug bridge when the machine reconnects.
 
+**`no-commit-to-branch` hook can block your commit.** The workspace
+pre-commit template configures `no-commit-to-branch` for `main`, `jazzy`,
+`rolling`. If a field-mode project repo inherits that hook, committing
+directly to its default branch will fail at the pre-commit step even
+though field mode otherwise permits it. Check the repo's
+`.pre-commit-config.yaml`; if `no-commit-to-branch` lists the default
+branch, remove that entry or drop the hook entirely for field-mode
+repos. Don't bypass with `--no-verify` — fix the config.
+
 ## Related
 
 - [`AGENTS.md § Field Mode`](../../AGENTS.md#field-mode-origin-not-on-a-github-host) — canonical rule

--- a/.agent/knowledge/field_mode_hotfix.md
+++ b/.agent/knowledge/field_mode_hotfix.md
@@ -66,14 +66,14 @@ Edit the tracked file in place. No worktree needed:
 $EDITOR config/operator_tmux.yaml
 ```
 
-### 4. Commit — hooks and AI signature still required
+### 4. Commit — hooks and identity still required
 
 Field mode relaxes the worktree/PR requirement. It does **not** relax any
-other quality gate. Pre-commit hooks still run, the AI signature is still
-required, commits stay atomic. The `Co-Authored-By` trailer follows the
-[AGENTS.md AI Signature](../../AGENTS.md#ai-signature-required-on-all-github-issuesprscomments)
-pattern — substitute your framework's actual name, model, and noreply
-email:
+other quality gate: pre-commit hooks still run, commits stay atomic, and
+the commit author is your configured agent identity (set by
+`set_git_identity_env.sh`). Adding a `Co-Authored-By` trailer for your
+agent model is conventional — substitute your framework's actual name,
+model, and noreply email:
 
 ```bash
 git add config/operator_tmux.yaml

--- a/.agent/scripts/field_mode.sh
+++ b/.agent/scripts/field_mode.sh
@@ -37,10 +37,14 @@ is_field_mode() {
 
 # describe_mode [repo_dir]
 # Print a human-readable mode summary to stdout.
+#
+# Uses `|| true` on the git call so that callers running with `set -e`
+# don't exit before the empty-string check; we want to print a message
+# and return 1 in that case, not silently abort the parent shell.
 describe_mode() {
     local repo_dir="${1:-$PWD}"
     local origin_url
-    origin_url=$(git -C "$repo_dir" remote get-url origin 2>/dev/null)
+    origin_url=$(git -C "$repo_dir" remote get-url origin 2>/dev/null || true)
     if [ -z "$origin_url" ]; then
         echo "not a git repo or no 'origin' remote: $repo_dir"
         return 1

--- a/.agent/scripts/field_mode.sh
+++ b/.agent/scripts/field_mode.sh
@@ -2,13 +2,15 @@
 # .agent/scripts/field_mode.sh
 # Detect whether the current repo is in "field mode" vs. "dev mode".
 #
-# Field mode = the repo's origin host is NOT github.com (e.g., gitcloud,
-# a private Forgejo, or another non-GitHub remote). In field mode, agents
-# may edit tracked files in the main tree and commit directly to the
-# default branch without opening a PR. See issue #445 for rationale.
+# Field mode = the repo's origin host is NOT on the GitHub allowlist
+# (currently `github.com` and `ssh.github.com` — see is_field_mode
+# below). Examples: gitcloud, a private Forgejo, another non-GitHub
+# remote. In field mode, agents may edit tracked files in the main
+# tree and commit directly to the default branch without opening a
+# PR. See issue #445 for rationale.
 #
-# Dev mode = the repo's origin host is github.com. Dev mode enforces the
-# worktree + PR workflow.
+# Dev mode = the repo's origin host is on the GitHub allowlist. Dev
+# mode enforces the worktree + PR workflow.
 #
 # Usage:
 #   # CLI with no args — exit status mirrors is_field_mode:
@@ -33,14 +35,11 @@
 #
 # Host is extracted from the origin URL by stripping the scheme
 # (`*://`), then any user prefix (`*@`), then anything from the first
-# `:` or `/` onwards. The remaining string is compared exactly to
-# `github.com`. This correctly handles:
-#   - SSH form     git@github.com:user/repo        → host=github.com
-#   - HTTPS form   https://github.com/user/repo    → host=github.com
-#   - ssh://       ssh://git@github.com/user/repo  → host=github.com
-# and rejects:
-#   - Substring traps: git@mygithub.com:..., git@github.company.internal:...
-#   - Path leaks:      https://example.com/github.com/foo.git
+# `:` or `/` onwards. The remaining host is lowercased and compared
+# against the GitHub allowlist (`github.com`, `ssh.github.com`). Any
+# host not in the allowlist — including `mygithub.com`, subdomains
+# like `github.company.internal`, and paths like
+# `https://example.com/github.com/foo` — is field mode.
 is_field_mode() {
     local repo_dir="${1:-$PWD}"
     local origin_url host

--- a/.agent/scripts/field_mode.sh
+++ b/.agent/scripts/field_mode.sh
@@ -49,6 +49,7 @@ is_field_mode() {
     host="${origin_url#*://}"   # strip scheme (if any)
     host="${host#*@}"           # strip user@ (if any)
     host="${host%%[:/]*}"       # take up to first : or /
+    host="${host,,}"            # lowercase (DNS is case-insensitive)
 
     [[ -n "$host" ]] && [[ "$host" != "github.com" ]]
 }

--- a/.agent/scripts/field_mode.sh
+++ b/.agent/scripts/field_mode.sh
@@ -2,37 +2,55 @@
 # .agent/scripts/field_mode.sh
 # Detect whether the current repo is in "field mode" vs. "dev mode".
 #
-# Field mode = the repo's origin is NOT github.com (e.g., gitcloud, a private
-# Forgejo, or another non-github remote). In field mode, agents may edit
-# tracked files in the main tree and commit directly to the default branch
-# without opening a PR. See issue #445 for rationale.
+# Field mode = the repo's origin host is NOT github.com (e.g., gitcloud,
+# a private Forgejo, or another non-GitHub remote). In field mode, agents
+# may edit tracked files in the main tree and commit directly to the
+# default branch without opening a PR. See issue #445 for rationale.
 #
-# Dev mode = the repo's origin is github.com. Dev mode enforces the worktree
-# + PR workflow.
+# Dev mode = the repo's origin host is github.com. Dev mode enforces the
+# worktree + PR workflow.
 #
 # Usage:
-#   # As CLI (exits 0 for field mode, 1 for dev mode):
-#   .agent/scripts/field_mode.sh
-#   .agent/scripts/field_mode.sh --describe   # human-readable summary
+#   # CLI with no args — exit status mirrors is_field_mode:
+#   #   0 = field mode, 1 = dev mode or error (no git repo / no origin)
+#   .agent/scripts/field_mode.sh [<repo_dir>]
 #
-#   # Sourced:
-#   source .agent/scripts/field_mode.sh
-#   if is_field_mode; then
+#   # CLI with --describe — prints a human-readable summary.
+#   # Exit 0 unless origin is missing (then exit 1).
+#   .agent/scripts/field_mode.sh --describe [<repo_dir>]
+#
+#   # Sourced (script must be reachable by path — not on PATH by default):
+#   source /path/to/.agent/scripts/field_mode.sh
+#   if is_field_mode; then                 # checks $PWD
 #     echo "field mode — direct main-tree edits permitted"
+#   fi
+#   if is_field_mode "/path/to/some/repo"; then  # check a specific repo
+#     ...
 #   fi
 
 # is_field_mode [repo_dir]
 # Exit 0 if the given repo (default: $PWD) is in field mode, else 1.
 #
-# A repo is in dev mode iff its origin host is exactly github.com.
-# The host is matched only when preceded by start-of-string, '/', or '@'
-# AND followed by ':' or '/', so hostnames like 'mygithub.com' or
-# 'github.company.internal' are NOT misclassified as dev mode.
+# Host is extracted from the origin URL by stripping the scheme
+# (`*://`), then any user prefix (`*@`), then anything from the first
+# `:` or `/` onwards. The remaining string is compared exactly to
+# `github.com`. This correctly handles:
+#   - SSH form     git@github.com:user/repo        → host=github.com
+#   - HTTPS form   https://github.com/user/repo    → host=github.com
+#   - ssh://       ssh://git@github.com/user/repo  → host=github.com
+# and rejects:
+#   - Substring traps: git@mygithub.com:..., git@github.company.internal:...
+#   - Path leaks:      https://example.com/github.com/foo.git
 is_field_mode() {
     local repo_dir="${1:-$PWD}"
-    local origin_url
+    local origin_url host
     origin_url=$(git -C "$repo_dir" remote get-url origin 2>/dev/null) || return 1
-    [[ ! "$origin_url" =~ (^|/|@)github\.com[:/] ]]
+
+    host="${origin_url#*://}"   # strip scheme (if any)
+    host="${host#*@}"           # strip user@ (if any)
+    host="${host%%[:/]*}"       # take up to first : or /
+
+    [[ -n "$host" ]] && [[ "$host" != "github.com" ]]
 }
 
 # describe_mode [repo_dir]

--- a/.agent/scripts/field_mode.sh
+++ b/.agent/scripts/field_mode.sh
@@ -23,11 +23,16 @@
 
 # is_field_mode [repo_dir]
 # Exit 0 if the given repo (default: $PWD) is in field mode, else 1.
+#
+# A repo is in dev mode iff its origin host is exactly github.com.
+# The host is matched only when preceded by start-of-string, '/', or '@'
+# AND followed by ':' or '/', so hostnames like 'mygithub.com' or
+# 'github.company.internal' are NOT misclassified as dev mode.
 is_field_mode() {
     local repo_dir="${1:-$PWD}"
     local origin_url
     origin_url=$(git -C "$repo_dir" remote get-url origin 2>/dev/null) || return 1
-    [[ "$origin_url" != *github.com* ]]
+    [[ ! "$origin_url" =~ (^|/|@)github\.com[:/] ]]
 }
 
 # describe_mode [repo_dir]

--- a/.agent/scripts/field_mode.sh
+++ b/.agent/scripts/field_mode.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# .agent/scripts/field_mode.sh
+# Detect whether the current repo is in "field mode" vs. "dev mode".
+#
+# Field mode = the repo's origin is NOT github.com (e.g., gitcloud, a private
+# Forgejo, or another non-github remote). In field mode, agents may edit
+# tracked files in the main tree and commit directly to the default branch
+# without opening a PR. See issue #445 for rationale.
+#
+# Dev mode = the repo's origin is github.com. Dev mode enforces the worktree
+# + PR workflow.
+#
+# Usage:
+#   # As CLI (exits 0 for field mode, 1 for dev mode):
+#   .agent/scripts/field_mode.sh
+#   .agent/scripts/field_mode.sh --describe   # human-readable summary
+#
+#   # Sourced:
+#   source .agent/scripts/field_mode.sh
+#   if is_field_mode; then
+#     echo "field mode — direct main-tree edits permitted"
+#   fi
+
+# is_field_mode [repo_dir]
+# Exit 0 if the given repo (default: $PWD) is in field mode, else 1.
+is_field_mode() {
+    local repo_dir="${1:-$PWD}"
+    local origin_url
+    origin_url=$(git -C "$repo_dir" remote get-url origin 2>/dev/null) || return 1
+    [[ "$origin_url" != *github.com* ]]
+}
+
+# describe_mode [repo_dir]
+# Print a human-readable mode summary to stdout.
+describe_mode() {
+    local repo_dir="${1:-$PWD}"
+    local origin_url
+    origin_url=$(git -C "$repo_dir" remote get-url origin 2>/dev/null)
+    if [ -z "$origin_url" ]; then
+        echo "not a git repo or no 'origin' remote: $repo_dir"
+        return 1
+    fi
+
+    if is_field_mode "$repo_dir"; then
+        echo "field mode  (origin: $origin_url)"
+    else
+        echo "dev mode    (origin: $origin_url)"
+    fi
+}
+
+# If invoked directly (not sourced), run as CLI
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    case "${1:-}" in
+        --describe)
+            shift
+            describe_mode "$@"
+            ;;
+        *)
+            is_field_mode "$@"
+            ;;
+    esac
+fi

--- a/.agent/scripts/field_mode.sh
+++ b/.agent/scripts/field_mode.sh
@@ -51,7 +51,14 @@ is_field_mode() {
     host="${host%%[:/]*}"       # take up to first : or /
     host="${host,,}"            # lowercase (DNS is case-insensitive)
 
-    [[ -n "$host" ]] && [[ "$host" != "github.com" ]]
+    # Dev-mode allowlist: GitHub's canonical git hosts. `ssh.github.com` is
+    # GitHub's SSH-over-443 fallback for users behind firewalls. Extend this
+    # list only for hosts GitHub itself documents for git clone.
+    case "$host" in
+        github.com|ssh.github.com) return 1 ;;  # dev mode
+    esac
+
+    [[ -n "$host" ]]            # field mode iff we extracted a host
 }
 
 # describe_mode [repo_dir]

--- a/.agent/scripts/tests/test_field_mode.sh
+++ b/.agent/scripts/tests/test_field_mode.sh
@@ -78,6 +78,14 @@ assert_field_mode "https://notgithub.com/foo/bar.git"
 assert_field_mode "git@github.company.internal:org/repo.git"
 echo ""
 
+echo "=== is_field_mode: path-position leaks (must be field mode) ==="
+# The host is example.com / gitcloud / etc. — 'github.com' only appears in
+# the URL path. A naive regex against the full URL would misclassify these.
+assert_field_mode "https://example.com/github.com/foo.git"
+assert_field_mode "https://example.com/mirrors/github.com/foo"
+assert_field_mode "git@gitcloud:team/github.com-mirror.git"
+echo ""
+
 echo "=== is_field_mode: edge cases ==="
 # No origin remote at all → dev mode (returns 1, the safer default)
 NO_ORIGIN_REPO=$(mktemp -d /tmp/no_origin.XXXXXX)

--- a/.agent/scripts/tests/test_field_mode.sh
+++ b/.agent/scripts/tests/test_field_mode.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# .agent/scripts/tests/test_field_mode.sh
+# Tests for is_field_mode() and describe_mode() in field_mode.sh
+#
+# Stubs `git remote get-url origin` by initializing throwaway repos with
+# specific origin URLs. Covers GitHub SSH/HTTPS variants, several
+# non-GitHub origins, and substring traps (mygithub.com etc.) that the
+# bare `*github.com*` pattern would mishandle.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../field_mode.sh"
+TEST_PASS=0
+TEST_FAIL=0
+
+# Source the script under test
+# shellcheck source=../field_mode.sh
+source "$SCRIPT"
+
+make_test_repo() {
+    local origin="$1"
+    local repo
+    repo=$(mktemp -d /tmp/field_mode_test.XXXXXX)
+    git -C "$repo" init -q
+    if [ -n "$origin" ]; then
+        git -C "$repo" remote add origin "$origin"
+    fi
+    echo "$repo"
+}
+
+assert_field_mode() {
+    local origin="$1"
+    local repo
+    repo=$(make_test_repo "$origin")
+    if is_field_mode "$repo"; then
+        echo "✅ PASS: '$origin' → field mode"
+        TEST_PASS=$((TEST_PASS + 1))
+    else
+        echo "❌ FAIL: '$origin' → expected field mode, got dev mode"
+        TEST_FAIL=$((TEST_FAIL + 1))
+    fi
+    rm -rf "$repo"
+}
+
+assert_dev_mode() {
+    local origin="$1"
+    local repo
+    repo=$(make_test_repo "$origin")
+    if is_field_mode "$repo"; then
+        echo "❌ FAIL: '$origin' → expected dev mode, got field mode"
+        TEST_FAIL=$((TEST_FAIL + 1))
+    else
+        echo "✅ PASS: '$origin' → dev mode"
+        TEST_PASS=$((TEST_PASS + 1))
+    fi
+    rm -rf "$repo"
+}
+
+echo "=== is_field_mode: github.com origins (dev mode) ==="
+assert_dev_mode "git@github.com:rolker/ros2_agent_workspace.git"
+assert_dev_mode "https://github.com/rolker/ros2_agent_workspace.git"
+assert_dev_mode "ssh://git@github.com/rolker/ros2_agent_workspace.git"
+assert_dev_mode "git@github.com:rolker/repo"  # no .git suffix
+echo ""
+
+echo "=== is_field_mode: non-github origins (field mode) ==="
+assert_field_mode "git@gitcloud:field/test-repo.git"
+assert_field_mode "https://gitlab.com/foo/bar.git"
+assert_field_mode "git@forgejo.example.com:org/repo.git"
+assert_field_mode "ssh://git@gitea.internal/team/repo.git"
+echo ""
+
+echo "=== is_field_mode: substring traps (must be field mode, not dev) ==="
+# These hostnames CONTAIN 'github.com' as a substring but aren't actually github.com
+assert_field_mode "git@mygithub.com:user/repo.git"
+assert_field_mode "https://notgithub.com/foo/bar.git"
+assert_field_mode "git@github.company.internal:org/repo.git"
+echo ""
+
+echo "=== is_field_mode: edge cases ==="
+# No origin remote at all → dev mode (returns 1, the safer default)
+NO_ORIGIN_REPO=$(mktemp -d /tmp/no_origin.XXXXXX)
+git -C "$NO_ORIGIN_REPO" init -q
+if is_field_mode "$NO_ORIGIN_REPO"; then
+    echo "❌ FAIL: no origin → expected dev mode (return 1)"
+    TEST_FAIL=$((TEST_FAIL + 1))
+else
+    echo "✅ PASS: no origin → dev mode (return 1, safer default)"
+    TEST_PASS=$((TEST_PASS + 1))
+fi
+rm -rf "$NO_ORIGIN_REPO"
+
+# Non-existent path → dev mode (return 1)
+if is_field_mode "/nonexistent/path/$$"; then
+    echo "❌ FAIL: nonexistent path → expected return 1"
+    TEST_FAIL=$((TEST_FAIL + 1))
+else
+    echo "✅ PASS: nonexistent path → return 1"
+    TEST_PASS=$((TEST_PASS + 1))
+fi
+echo ""
+
+echo "=== describe_mode output sanity ==="
+DEV_REPO=$(make_test_repo "git@github.com:rolker/test.git")
+DESC=$(describe_mode "$DEV_REPO")
+if [[ "$DESC" == *"dev mode"* ]] && [[ "$DESC" == *"github.com"* ]]; then
+    echo "✅ PASS: describe_mode dev → '$DESC'"
+    TEST_PASS=$((TEST_PASS + 1))
+else
+    echo "❌ FAIL: describe_mode dev → '$DESC'"
+    TEST_FAIL=$((TEST_FAIL + 1))
+fi
+rm -rf "$DEV_REPO"
+
+FIELD_REPO=$(make_test_repo "git@gitcloud:field/test.git")
+DESC=$(describe_mode "$FIELD_REPO")
+if [[ "$DESC" == *"field mode"* ]] && [[ "$DESC" == *"gitcloud"* ]]; then
+    echo "✅ PASS: describe_mode field → '$DESC'"
+    TEST_PASS=$((TEST_PASS + 1))
+else
+    echo "❌ FAIL: describe_mode field → '$DESC'"
+    TEST_FAIL=$((TEST_FAIL + 1))
+fi
+rm -rf "$FIELD_REPO"
+echo ""
+
+echo "=== Results ==="
+echo "Passed: $TEST_PASS"
+echo "Failed: $TEST_FAIL"
+exit "$TEST_FAIL"

--- a/.agent/scripts/tests/test_field_mode.sh
+++ b/.agent/scripts/tests/test_field_mode.sh
@@ -68,6 +68,11 @@ assert_dev_mode "git@github.com:rolker/ros2_agent_workspace.git"
 assert_dev_mode "https://github.com/rolker/ros2_agent_workspace.git"
 assert_dev_mode "ssh://git@github.com/rolker/ros2_agent_workspace.git"
 assert_dev_mode "git@github.com:rolker/repo"  # no .git suffix
+# Case normalization: DNS is case-insensitive, so mixed-case hosts must still
+# resolve to dev mode for github.com — otherwise a careless clone could flip
+# a GitHub-origin repo to field mode and permit main-tree edits.
+assert_dev_mode "git@GITHUB.COM:rolker/repo.git"
+assert_dev_mode "https://GitHub.com/rolker/repo.git"
 echo ""
 
 echo "=== is_field_mode: non-github origins (field mode) ==="

--- a/.agent/scripts/tests/test_field_mode.sh
+++ b/.agent/scripts/tests/test_field_mode.sh
@@ -14,6 +14,14 @@ SCRIPT="$SCRIPT_DIR/../field_mode.sh"
 TEST_PASS=0
 TEST_FAIL=0
 
+# Shared temp root — trap ensures cleanup even on unexpected failure under
+# set -e. All per-test repos are created as subdirs so they get swept too.
+TMPDIR_ROOT=$(mktemp -d /tmp/test_field_mode.XXXXXX)
+cleanup() {
+    rm -rf "$TMPDIR_ROOT"
+}
+trap cleanup EXIT
+
 # Source the script under test
 # shellcheck source=../field_mode.sh
 source "$SCRIPT"
@@ -21,7 +29,7 @@ source "$SCRIPT"
 make_test_repo() {
     local origin="$1"
     local repo
-    repo=$(mktemp -d /tmp/field_mode_test.XXXXXX)
+    repo=$(mktemp -d "$TMPDIR_ROOT/repo.XXXXXX")
     git -C "$repo" init -q
     if [ -n "$origin" ]; then
         git -C "$repo" remote add origin "$origin"
@@ -40,7 +48,6 @@ assert_field_mode() {
         echo "❌ FAIL: '$origin' → expected field mode, got dev mode"
         TEST_FAIL=$((TEST_FAIL + 1))
     fi
-    rm -rf "$repo"
 }
 
 assert_dev_mode() {
@@ -54,7 +61,6 @@ assert_dev_mode() {
         echo "✅ PASS: '$origin' → dev mode"
         TEST_PASS=$((TEST_PASS + 1))
     fi
-    rm -rf "$repo"
 }
 
 echo "=== is_field_mode: github.com origins (dev mode) ==="
@@ -88,7 +94,7 @@ echo ""
 
 echo "=== is_field_mode: edge cases ==="
 # No origin remote at all → dev mode (returns 1, the safer default)
-NO_ORIGIN_REPO=$(mktemp -d /tmp/no_origin.XXXXXX)
+NO_ORIGIN_REPO=$(mktemp -d "$TMPDIR_ROOT/no_origin.XXXXXX")
 git -C "$NO_ORIGIN_REPO" init -q
 if is_field_mode "$NO_ORIGIN_REPO"; then
     echo "❌ FAIL: no origin → expected dev mode (return 1)"
@@ -97,7 +103,6 @@ else
     echo "✅ PASS: no origin → dev mode (return 1, safer default)"
     TEST_PASS=$((TEST_PASS + 1))
 fi
-rm -rf "$NO_ORIGIN_REPO"
 
 # Non-existent path → dev mode (return 1)
 if is_field_mode "/nonexistent/path/$$"; then
@@ -119,7 +124,6 @@ else
     echo "❌ FAIL: describe_mode dev → '$DESC'"
     TEST_FAIL=$((TEST_FAIL + 1))
 fi
-rm -rf "$DEV_REPO"
 
 FIELD_REPO=$(make_test_repo "git@gitcloud:field/test.git")
 DESC=$(describe_mode "$FIELD_REPO")
@@ -130,7 +134,6 @@ else
     echo "❌ FAIL: describe_mode field → '$DESC'"
     TEST_FAIL=$((TEST_FAIL + 1))
 fi
-rm -rf "$FIELD_REPO"
 echo ""
 
 echo "=== Results ==="

--- a/.agent/scripts/tests/test_field_mode.sh
+++ b/.agent/scripts/tests/test_field_mode.sh
@@ -73,6 +73,11 @@ assert_dev_mode "git@github.com:rolker/repo"  # no .git suffix
 # a GitHub-origin repo to field mode and permit main-tree edits.
 assert_dev_mode "git@GITHUB.COM:rolker/repo.git"
 assert_dev_mode "https://GitHub.com/rolker/repo.git"
+# ssh.github.com is GitHub's SSH-over-443 fallback for users behind firewalls.
+# Both the scheme-less SSH form and the explicit ssh://...:443 form must
+# resolve to dev mode.
+assert_dev_mode "git@ssh.github.com:rolker/repo.git"
+assert_dev_mode "ssh://git@ssh.github.com:443/rolker/repo.git"
 echo ""
 
 echo "=== is_field_mode: non-github origins (field mode) ==="

--- a/.agent/templates/project_agents_guide.md
+++ b/.agent/templates/project_agents_guide.md
@@ -7,9 +7,15 @@
 **When this repo is checked out as part of a [ROS 2 Agent
 Workspace](https://github.com/rolker/ros2_agent_workspace)**, workflow
 rules (worktree vs. field mode, branch naming, etc.) are defined in the
-workspace `AGENTS.md`. Run the workspace's
-`.agent/scripts/field_mode.sh --describe <path-to-this-repo>` to
-determine the active mode before editing.
+workspace `AGENTS.md`. To determine the active mode before editing, run
+the detection script **from the workspace root** (the script is not on
+PATH, and `.agent/` lives at the workspace root, not inside this repo):
+
+```bash
+# From the workspace root, pass the path to this repo
+.agent/scripts/field_mode.sh --describe <path-to-this-repo>
+# e.g. .agent/scripts/field_mode.sh --describe layers/main/<layer>_ws/src/<this-repo>
+```
 
 **Standalone use** (this repo cloned alone, outside the workspace): only
 this repo's own conventions apply — the workspace-level workflow rules

--- a/.agent/templates/project_agents_guide.md
+++ b/.agent/templates/project_agents_guide.md
@@ -5,8 +5,10 @@
 ## Workflow
 
 Workflow rules (worktree vs. field mode, AI signature, branch naming) are
-defined in the workspace `AGENTS.md`. Run `field_mode.sh --describe` in this
-repo to determine the active mode before editing.
+defined in the workspace `AGENTS.md`. Use the workspace's
+`.agent/scripts/field_mode.sh --describe` to determine the active mode
+before editing — the script isn't on PATH; invoke it from the workspace
+root.
 
 ## Package Inventory
 

--- a/.agent/templates/project_agents_guide.md
+++ b/.agent/templates/project_agents_guide.md
@@ -4,11 +4,16 @@
 
 ## Workflow
 
-Workflow rules (worktree vs. field mode, AI signature, branch naming) are
-defined in the workspace `AGENTS.md`. Use the workspace's
-`.agent/scripts/field_mode.sh --describe` to determine the active mode
-before editing — the script isn't on PATH; invoke it from the workspace
-root.
+**When this repo is checked out as part of a [ROS 2 Agent
+Workspace](https://github.com/rolker/ros2_agent_workspace)**, workflow
+rules (worktree vs. field mode, branch naming, etc.) are defined in the
+workspace `AGENTS.md`. Run the workspace's
+`.agent/scripts/field_mode.sh --describe <path-to-this-repo>` to
+determine the active mode before editing.
+
+**Standalone use** (this repo cloned alone, outside the workspace): only
+this repo's own conventions apply — the workspace-level workflow rules
+don't bind here.
 
 ## Package Inventory
 

--- a/.agent/templates/project_agents_guide.md
+++ b/.agent/templates/project_agents_guide.md
@@ -4,10 +4,11 @@
 
 ## Workflow
 
-**When this repo is checked out as part of a [ROS 2 Agent
-Workspace](https://github.com/rolker/ros2_agent_workspace)**, workflow
-rules (worktree vs. field mode, branch naming, etc.) are defined in the
-workspace `AGENTS.md`. To determine the active mode before editing, run
+**When this repo is checked out as part of a
+[ROS 2 Agent Workspace](https://github.com/rolker/ros2_agent_workspace)**,
+workflow rules (worktree vs. field mode, branch naming, etc.) are
+defined in the workspace `AGENTS.md`. To determine the active mode
+before editing, run
 the detection script **from the workspace root** (the script is not on
 PATH, and `.agent/` lives at the workspace root, not inside this repo):
 

--- a/.agent/templates/project_agents_guide.md
+++ b/.agent/templates/project_agents_guide.md
@@ -2,6 +2,12 @@
 
 > One-line description from README or `package.xml`.
 
+## Workflow
+
+Workflow rules (worktree vs. field mode, AI signature, branch naming) are
+defined in the workspace `AGENTS.md`. Run `field_mode.sh --describe` in this
+repo to determine the active mode before editing.
+
 ## Package Inventory
 
 | Package | Language | Description |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,10 +145,14 @@ on PATH, so invoke from the workspace root:
 cd layers/main/platforms_ws/src/unh_echoboats_project11
 ../../../../.agent/scripts/field_mode.sh --describe
 
-# Sourced in a script (any path — uses $PWD by default)
-source .agent/scripts/field_mode.sh
-if is_field_mode; then
+# Sourced in a script — source by explicit path (the script is not on PATH).
+# is_field_mode takes an optional repo_dir arg, defaulting to $PWD.
+source /path/to/workspace/.agent/scripts/field_mode.sh
+if is_field_mode; then                  # checks current $PWD
     # field-mode behavior
+fi
+if is_field_mode "/path/to/repo"; then  # check a specific repo
+    # ...
 fi
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,10 +142,10 @@ fi
 ```
 
 **Reconciliation**: field commits come back to GitHub via the
-`/import-field-changes` skill on a connected dev machine. The skill fetches
-from the field remote, creates issues + draft PRs for each ahead-of-origin
-repo, and pre-reviews diffs against the Quality Standard. Agents don't run
-field-to-github imports manually.
+`/import-field-changes` skill on a connected dev machine. Use that skill
+rather than hand-rolling cherry-picks — it creates branches without
+perturbing the main tree HEAD, opens draft PRs with pre-review against
+the Quality Standard, and flags diverged repos for human merge.
 
 ## Issue-First Policy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,13 +143,17 @@ working in a gitcloud-origin clone is in field mode for that repo.
 - No committing secrets
 - No force-push, no destructive ops without explicit user approval
 
-**Hook caveat**: if a field-mode project repo uses `no-commit-to-branch`
-in its `.pre-commit-config.yaml` (the workspace template configures this
-for `main`, `jazzy`, `rolling`), direct commits to the default branch
-will be blocked even though field mode otherwise permits them. Field-mode
-project repos need to exclude their default branch from that hook's
-branch list, or drop the hook. This is a project-repo config concern,
-not a field-mode flag.
+**Hook caveat**: `no-commit-to-branch` is a common pre-commit hook that
+blocks direct commits to listed branches. If a field-mode project repo
+has its default branch in that list, commits will fail at pre-commit —
+even though field mode otherwise permits them. Two templates in this
+workspace configure the hook: the project-repo template
+(`.agent/templates/pre-commit-config.yaml`, where the project substitutes
+`PLACEHOLDER_DEFAULT_BRANCH`), and the workspace's own
+`.pre-commit-config.yaml` (which lists `main`, `jazzy`, `rolling`).
+Field-mode project repos need to remove their default branch from the
+hook's list, or drop the hook. This is a project-repo config concern,
+not a field-mode flag. Never bypass with `--no-verify`.
 
 **Detection**: the mode is inferred from the repo's origin URL. Use
 [`.agent/scripts/field_mode.sh`](.agent/scripts/field_mode.sh) — it isn't

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,9 @@ whole thing, do it right, do it with tests.
 
 ## Worktree Workflow
 
-Every task must use an isolated worktree.
+Every task on a GitHub-origin repo must use an isolated worktree. For
+non-GitHub-origin repos (field mode), the worktree/PR ceremony is
+relaxed — see [Field Mode](#field-mode-origin-not-githubcom) below.
 
 **Project repos**: Directories under `layers/main/*_ws/src/` are typically independent
 git repos, each containing one or more ROS 2 packages. Layer worktrees create git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,8 @@ setup (environment, identity, features), see your framework's adapter file:
 - Verify documentation claims against source code
 - Atomic commits: one logical change per commit
 - Branch naming: `feature/issue-<N>` or `feature/ISSUE-<N>-<description>`
-- All changes via Pull Requests
+- All changes via Pull Requests on GitHub-origin repos (field-mode repos
+  push to the field remote without PRs — see Worktree Workflow)
 
 ### Ask First (get human approval)
 
@@ -38,8 +39,10 @@ setup (environment, identity, features), see your framework's adapter file:
 
 ### Never (hard stops)
 
-- Commit to `main` on a github-origin repo — branch is protected; direct pushes
-  are rejected. Field-origin repos have their own workflow (see Worktree Workflow).
+- Commit directly to the default branch (e.g. `main`, `jazzy`) on a
+  GitHub-origin repo — branch protection rejects direct pushes; open a PR
+  from a worktree. Field-origin repos have their own workflow (see
+  Worktree Workflow).
 - `git checkout <branch>` — `setup.bash` blocks it; use worktrees
 - Skip hooks with `--no-verify`
 - Commit secrets or credentials
@@ -321,7 +324,7 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/worktree_enter.sh` | Enter worktree (must be sourced) **(source)** |
 | `.agent/scripts/worktree_remove.sh` | Remove worktree |
 | `.agent/scripts/worktree_list.sh` | List active worktrees |
-| `.agent/scripts/field_mode.sh` | Detect field mode (non-github origin) vs. dev mode **(source or exec)** |
+| `.agent/scripts/field_mode.sh` | Detect field mode (non-GitHub origin) vs. dev mode **(source or exec)** |
 | `.agent/scripts/agent start-task <N>` | High-level wrapper: create + enter worktree |
 | `.agent/scripts/dashboard.sh` | Unified workspace status (supports `--quick`) |
 | `.agent/scripts/build.sh` | Build all layers in order |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ whole thing, do it right, do it with tests.
 
 Every task on a GitHub-origin repo must use an isolated worktree. For
 non-GitHub-origin repos (field mode), the worktree/PR ceremony is
-relaxed — see [Field Mode](#field-mode-origin-not-githubcom) below.
+relaxed — see [Field Mode](#field-mode-origin-not-on-a-github-host) below.
 
 **Project repos**: Directories under `layers/main/*_ws/src/` are typically independent
 git repos, each containing one or more ROS 2 packages. Layer worktrees create git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,10 +125,13 @@ field-mode origins: gitcloud, private Forgejo, other non-GitHub remotes.
 - Commit to the default branch (`main`, `jazzy`, etc.)
 - Push to `origin` without opening a PR
 
-This is the only way field hotfixes can land before the next run — there's no
-GitHub, no PR review, no CI on the field remote. Mode is determined per repo
-by origin URL, not by the physical machine: a dev workstation working in a
-gitcloud-origin clone is in field mode for that repo.
+This is the only way field hotfixes can land before the next run — the
+workspace's PR-and-review workflow is GitHub-based, and a field remote
+isn't on GitHub. Other forges (Forgejo, GitLab) may support their own
+PR/CI mechanisms, but those don't plug into this workspace's review
+pipeline, so we treat them as field mode too. Mode is determined per
+repo by origin URL, not by the physical machine: a dev workstation
+working in a gitcloud-origin clone is in field mode for that repo.
 
 **What field mode does NOT change** (all still required):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ on PATH, so invoke from the workspace root:
 ```bash
 # Form A: from workspace root, pass the target repo path
 .agent/scripts/field_mode.sh --describe layers/main/platforms_ws/src/unh_echoboats_project11
-# → "field mode  (origin: git@gitcloud:field/unh_echoboats_project11)"
+# → field mode  (origin: git@gitcloud:field/unh_echoboats_project11.git)
 
 # Form B: cd into the target repo first, reference the script via the workspace root
 cd layers/main/platforms_ws/src/unh_echoboats_project11

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,36 +111,44 @@ See [`.agent/WORKTREE_GUIDE.md`](.agent/WORKTREE_GUIDE.md) for hybrid structure 
 
 ### Field Mode (origin not github.com)
 
-When a repo's `origin` is **not** github.com (e.g., gitcloud, private Forgejo),
-the worktree/PR ceremony is relaxed. Agents on a field machine may:
+When a repo's `origin` host is **not** `github.com` (e.g., gitcloud, private
+Forgejo), the worktree/PR ceremony is relaxed. **Field-mode repos may**:
 
 - Edit tracked files directly in the main/default tree
 - Commit to the default branch (`main`, `jazzy`, etc.)
 - Push to `origin` without opening a PR
 
 This is the only way field hotfixes can land before the next run — there's no
-GitHub, no PR review, no CI on the field remote.
+GitHub, no PR review, no CI on the field remote. Mode is determined per repo
+by origin URL, not by the physical machine: a dev workstation working in a
+gitcloud-origin clone is in field mode for that repo.
 
 **What field mode does NOT change** (all still required):
 
 - Pre-commit hooks run — never `--no-verify`
-- AI signature on commits
+- Commits use the configured agent git identity (set via
+  `set_git_identity_env.sh`)
 - Atomic commits (one logical change per commit)
 - No committing secrets
 - No force-push, no destructive ops without explicit user approval
 
 **Detection**: the mode is inferred from the repo's origin URL. Use
-[`.agent/scripts/field_mode.sh`](.agent/scripts/field_mode.sh):
+[`.agent/scripts/field_mode.sh`](.agent/scripts/field_mode.sh) — it isn't
+on PATH, so invoke from the workspace root:
 
 ```bash
-# CLI check
-.agent/scripts/field_mode.sh --describe
+# Form A: from workspace root, pass the target repo path
+.agent/scripts/field_mode.sh --describe layers/main/platforms_ws/src/unh_echoboats_project11
 # → "field mode  (origin: git@gitcloud:field/unh_echoboats_project11)"
 
-# Sourced in a script
+# Form B: cd into the target repo first, reference the script via the workspace root
+cd layers/main/platforms_ws/src/unh_echoboats_project11
+../../../../.agent/scripts/field_mode.sh --describe
+
+# Sourced in a script (any path — uses $PWD by default)
 source .agent/scripts/field_mode.sh
 if is_field_mode; then
-    # field mode behavior
+    # field-mode behavior
 fi
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ setup (environment, identity, features), see your framework's adapter file:
 ### Always (proceed autonomously)
 
 - Use worktrees for all feature work — never edit files in the main tree.
-  Exception: **field mode** (origin not github.com) — see Worktree Workflow.
+  Exception: **field mode** (origin not on a GitHub host) — see Worktree
+  Workflow.
 - Run pre-commit hooks before committing
 - Include AI signature on all GitHub Issues/PRs/Comments (`$AGENT_NAME` / `$AGENT_MODEL`)
 - Reference issue numbers in branches and PRs (`Closes #<N>`)
@@ -111,10 +112,14 @@ source setup.bash                  # set up ROS environment
 See [`.agent/WORKTREE_GUIDE.md`](.agent/WORKTREE_GUIDE.md) for hybrid structure details,
 `--repo-slug` disambiguation, and troubleshooting.
 
-### Field Mode (origin not github.com)
+### Field Mode (origin not on a GitHub host)
 
-When a repo's `origin` host is **not** `github.com` (e.g., gitcloud, private
-Forgejo), the worktree/PR ceremony is relaxed. **Field-mode repos may**:
+When a repo's `origin` host is **not** on the GitHub allowlist (currently
+`github.com` and `ssh.github.com` — the SSH-over-443 fallback; see
+[`.agent/scripts/field_mode.sh`](.agent/scripts/field_mode.sh) for the
+authoritative list), the worktree/PR ceremony is relaxed. Examples of
+field-mode origins: gitcloud, private Forgejo, other non-GitHub remotes.
+**Field-mode repos may**:
 
 - Edit tracked files directly in the main/default tree
 - Commit to the default branch (`main`, `jazzy`, etc.)
@@ -145,7 +150,7 @@ on PATH, so invoke from the workspace root:
 
 # Form B: cd into the target repo first, reference the script via the workspace root
 cd layers/main/platforms_ws/src/unh_echoboats_project11
-../../../../.agent/scripts/field_mode.sh --describe
+../../../../../.agent/scripts/field_mode.sh --describe
 
 # Sourced in a script — source by explicit path (the script is not on PATH).
 # is_field_mode takes an optional repo_dir arg, defaulting to $PWD.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,9 @@ setup (environment, identity, features), see your framework's adapter file:
 ### Always (proceed autonomously)
 
 - Use worktrees for all feature work — never edit files in the main tree.
-  Exception: **field mode** (origin not on a GitHub host) — see Worktree
-  Workflow.
+  Exception: **field mode** (origin not on the GitHub allowlist — see
+  [`field_mode.sh`](.agent/scripts/field_mode.sh); GitHub Enterprise is
+  field mode by design). See Worktree Workflow.
 - Run pre-commit hooks before committing
 - Include AI signature on all GitHub Issues/PRs/Comments (`$AGENT_NAME` / `$AGENT_MODEL`)
 - Reference issue numbers in branches and PRs (`Closes #<N>`)
@@ -141,6 +142,14 @@ working in a gitcloud-origin clone is in field mode for that repo.
 - Atomic commits (one logical change per commit)
 - No committing secrets
 - No force-push, no destructive ops without explicit user approval
+
+**Hook caveat**: if a field-mode project repo uses `no-commit-to-branch`
+in its `.pre-commit-config.yaml` (the workspace template configures this
+for `main`, `jazzy`, `rolling`), direct commits to the default branch
+will be blocked even though field mode otherwise permits them. Field-mode
+project repos need to exclude their default branch from that hook's
+branch list, or drop the hook. This is a project-repo config concern,
+not a field-mode flag.
 
 **Detection**: the mode is inferred from the repo's origin URL. Use
 [`.agent/scripts/field_mode.sh`](.agent/scripts/field_mode.sh) — it isn't

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ setup (environment, identity, features), see your framework's adapter file:
 
 ### Always (proceed autonomously)
 
-- Use worktrees for all feature work — never edit files in the main tree
+- Use worktrees for all feature work — never edit files in the main tree.
+  Exception: **field mode** (origin not github.com) — see Worktree Workflow.
 - Run pre-commit hooks before committing
 - Include AI signature on all GitHub Issues/PRs/Comments (`$AGENT_NAME` / `$AGENT_MODEL`)
 - Reference issue numbers in branches and PRs (`Closes #<N>`)
@@ -37,7 +38,8 @@ setup (environment, identity, features), see your framework's adapter file:
 
 ### Never (hard stops)
 
-- Commit to `main` — branch is protected; direct pushes are rejected
+- Commit to `main` on a github-origin repo — branch is protected; direct pushes
+  are rejected. Field-origin repos have their own workflow (see Worktree Workflow).
 - `git checkout <branch>` — `setup.bash` blocks it; use worktrees
 - Skip hooks with `--no-verify`
 - Commit secrets or credentials
@@ -103,6 +105,47 @@ source setup.bash                  # set up ROS environment
 
 See [`.agent/WORKTREE_GUIDE.md`](.agent/WORKTREE_GUIDE.md) for hybrid structure details,
 `--repo-slug` disambiguation, and troubleshooting.
+
+### Field Mode (origin not github.com)
+
+When a repo's `origin` is **not** github.com (e.g., gitcloud, private Forgejo),
+the worktree/PR ceremony is relaxed. Agents on a field machine may:
+
+- Edit tracked files directly in the main/default tree
+- Commit to the default branch (`main`, `jazzy`, etc.)
+- Push to `origin` without opening a PR
+
+This is the only way field hotfixes can land before the next run — there's no
+GitHub, no PR review, no CI on the field remote.
+
+**What field mode does NOT change** (all still required):
+
+- Pre-commit hooks run — never `--no-verify`
+- AI signature on commits
+- Atomic commits (one logical change per commit)
+- No committing secrets
+- No force-push, no destructive ops without explicit user approval
+
+**Detection**: the mode is inferred from the repo's origin URL. Use
+[`.agent/scripts/field_mode.sh`](.agent/scripts/field_mode.sh):
+
+```bash
+# CLI check
+.agent/scripts/field_mode.sh --describe
+# → "field mode  (origin: git@gitcloud:field/unh_echoboats_project11)"
+
+# Sourced in a script
+source .agent/scripts/field_mode.sh
+if is_field_mode; then
+    # field mode behavior
+fi
+```
+
+**Reconciliation**: field commits come back to GitHub via the
+`/import-field-changes` skill on a connected dev machine. The skill fetches
+from the field remote, creates issues + draft PRs for each ahead-of-origin
+repo, and pre-reviews diffs against the Quality Standard. Agents don't run
+field-to-github imports manually.
 
 ## Issue-First Policy
 
@@ -278,6 +321,7 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/worktree_enter.sh` | Enter worktree (must be sourced) **(source)** |
 | `.agent/scripts/worktree_remove.sh` | Remove worktree |
 | `.agent/scripts/worktree_list.sh` | List active worktrees |
+| `.agent/scripts/field_mode.sh` | Detect field mode (non-github origin) vs. dev mode **(source or exec)** |
 | `.agent/scripts/agent start-task <N>` | High-level wrapper: create + enter worktree |
 | `.agent/scripts/dashboard.sh` | Unified workspace status (supports `--quick`) |
 | `.agent/scripts/build.sh` | Build all layers in order |

--- a/docs/decisions/0001-adopt-architecture-decision-records.md
+++ b/docs/decisions/0001-adopt-architecture-decision-records.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-Accepted
+Accepted. Immutability rule narrowed by
+[ADR-0012](0012-permit-cross-reference-addendums-in-adrs.md) to permit
+cross-reference addendums (Status-line pointers and References sections)
+to accepted ADRs; substantive changes still require superseding.
 
 ## Context
 

--- a/docs/decisions/0002-worktree-isolation-over-branch-switching.md
+++ b/docs/decisions/0002-worktree-isolation-over-branch-switching.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted
+Accepted. Scoped exception in [ADR-0011](0011-field-mode-for-non-github-origins.md)
+permits direct default-branch edits in repos whose origin is not `github.com`
+(field-mode repos pulling from gitcloud, private Forgejo, etc.).
 
 ## Context
 
@@ -46,3 +48,10 @@ Enforcement:
 - Slightly more complex workflow than simple branch switching
 - Worktrees share ports, databases, and ROS 2 DDS discovery — true isolation requires
   containers (tracked separately as a future enhancement)
+
+## References
+
+- [ADR-0011](0011-field-mode-for-non-github-origins.md) — scoped exception
+  for non-GitHub-origin (field-mode) repos. Worktree isolation remains the
+  default; field mode applies only when the origin URL tells us no PR
+  review is possible on the other side.

--- a/docs/decisions/0002-worktree-isolation-over-branch-switching.md
+++ b/docs/decisions/0002-worktree-isolation-over-branch-switching.md
@@ -3,8 +3,9 @@
 ## Status
 
 Accepted. Scoped exception in [ADR-0011](0011-field-mode-for-non-github-origins.md)
-permits direct default-branch edits in repos whose origin is not `github.com`
-(field-mode repos pulling from gitcloud, private Forgejo, etc.).
+permits direct default-branch edits in repos whose origin host is not on
+the GitHub allowlist (field-mode repos pulling from gitcloud, private
+Forgejo, etc.).
 
 ## Context
 

--- a/docs/decisions/0011-field-mode-for-non-github-origins.md
+++ b/docs/decisions/0011-field-mode-for-non-github-origins.md
@@ -33,8 +33,12 @@ this ADR now records.
 
 ## Decision
 
-**A repo is in "field mode" when its `origin` host is not `github.com`.**
-Field-mode repos may:
+**A repo is in "field mode" when its `origin` host is not on the
+GitHub allowlist.** The allowlist lives in
+[`.agent/scripts/field_mode.sh`](../../.agent/scripts/field_mode.sh)
+and currently contains `github.com` and `ssh.github.com` (GitHub's
+SSH-over-443 fallback). Hosts are added to the allowlist only when
+GitHub itself documents them for git clone. Field-mode repos may:
 
 - Edit tracked files directly in the main/default tree
 - Commit directly to the default branch (e.g. `main`, `jazzy`)

--- a/docs/decisions/0011-field-mode-for-non-github-origins.md
+++ b/docs/decisions/0011-field-mode-for-non-github-origins.md
@@ -56,8 +56,9 @@ the existing `/import-field-changes` skill on a connected dev machine.
 
 This is a scoped exception to ADR-0002. Worktree isolation remains the
 default for GitHub-origin repos. The exception applies only when the
-origin URL tells us a PR workflow is impossible (no GitHub on the other
-side).
+origin URL tells us the workspace's GitHub-based PR workflow isn't
+available — other forges (Forgejo, GitLab) may have their own PR/CI
+mechanisms, but those don't plug into this workspace's review pipeline.
 
 ### Decisions Recorded on Issue #445
 

--- a/docs/decisions/0011-field-mode-for-non-github-origins.md
+++ b/docs/decisions/0011-field-mode-for-non-github-origins.md
@@ -1,0 +1,113 @@
+# ADR-0011: Field Mode — Permit Direct Default-Branch Edits in Non-GitHub-Origin Repos
+
+## Status
+
+Accepted
+
+## Context
+
+[ADR-0002](0002-worktree-isolation-over-branch-switching.md) established that
+all feature work uses git worktrees, and "never edit files in the main tree"
+became a top-of-`AGENTS.md` rule (further hardened by issue #247). The rule
+is correct on dev machines where origin is GitHub: the worktree + PR workflow
+is the quality gate.
+
+The rule breaks down on field machines (e.g., BizzyBoat, mercat) where:
+
+- The project-repo origin is `gitcloud` (or another non-GitHub remote) —
+  there is no GitHub on the field side
+- There is no PR review, no CI, no protected branch
+- A hotfix has to land on the default branch and be pushed before the next run
+- Worktree-creating scripts implicitly assume PR review on the other end
+
+Field deployments started using the workspace in early 2026 (BizzyBoat
+sessions Apr 2-6, etc.). Initially, agents either (a) violated the rule
+under time pressure or (b) went through worktree+PR motions that nobody
+read because the field machine was the only reader.
+
+The reconciliation half — pulling field commits back to GitHub for review on
+a connected dev machine — was already shipped in PR #440 (the
+`/import-field-changes` skill, which did not require its own ADR). What was
+deferred (per issue #432) was the field-side edit permission itself, which
+this ADR now records.
+
+## Decision
+
+**A repo is in "field mode" when its `origin` host is not `github.com`.**
+Field-mode repos may:
+
+- Edit tracked files directly in the main/default tree
+- Commit directly to the default branch (e.g. `main`, `jazzy`)
+- Push to `origin` without opening a PR
+
+Field mode does NOT relax: pre-commit hooks, AI signature, atomic commits,
+secret-handling rules, or destructive-op confirmation.
+
+Detection is implemented in
+[`.agent/scripts/field_mode.sh`](../../.agent/scripts/field_mode.sh)
+(sourceable helper or executable), inspecting the host portion of the
+origin URL with a tight host-anchor pattern so substrings like
+`mygithub.com` are not misclassified. Reconciliation back to GitHub uses
+the existing `/import-field-changes` skill on a connected dev machine.
+
+This is a scoped exception to ADR-0002. Worktree isolation remains the
+default for GitHub-origin repos. The exception applies only when the
+origin URL tells us a PR workflow is impossible (no GitHub on the other
+side).
+
+### Decisions Recorded on Issue #445
+
+1. **Mode detection: per-repo origin URL check** — rejected machine-wide
+   config files and `.agent/project_config.yaml`-based detection because
+   the origin URL is the ground truth and field machines bootstrap with
+   non-GitHub origin already.
+2. **No hard-coded workspace-repo carve-out** — `is_field_mode()` will
+   return true on a field-cloned workspace repo. Hotfixing workspace
+   infrastructure from the field is discouraged in the walkthrough but
+   not mechanically blocked. If workspace commits ever appear on `main`
+   from a field machine, they'll be handled ad hoc.
+3. **`setup.bash` checkout guardrail stays strict** — field hotfixes are
+   edit-and-commit on the current branch, not branch switching, so the
+   guardrail doesn't need a mode-aware bypass.
+4. **Project-repo `.agents/README.md` template gets a one-line pointer** —
+   `AGENTS.md` owns the rule. Per-project rule duplication is avoided to
+   prevent drift; project-repo guides defer to the workspace canonical
+   docs.
+
+## Consequences
+
+**Positive:**
+- Field deployments can ship hotfixes without ceremony nobody reads
+- The relaxation is mechanical and documented, not informal — agents
+  can determine mode from the repo state, not from memory or convention
+- Reconciliation (PR #440 / `/import-field-changes`) ensures field
+  commits still pass through the dev-mode review gate, just delayed
+- The carve-out is narrow: GitHub-origin repos still enforce ADR-0002
+
+**Negative:**
+- Two parallel rule paths increase doc complexity (mitigated by `AGENTS.md`
+  + the field-mode walkthrough being the only canonical surfaces)
+- Field commits skip the immediate review gate; the dev-side import
+  depends on someone running the skill in a timely way
+- A non-GitHub mirror clone of the workspace would technically be in
+  field mode without intent — accepted because the workspace repo is
+  unlikely to be edited from the field, and the failure mode is
+  recoverable by ad-hoc cleanup
+
+## References
+
+- [ADR-0002](0002-worktree-isolation-over-branch-switching.md) — Worktree
+  Isolation Over Branch Switching (this ADR is a scoped exception)
+- Issue [#445](https://github.com/rolker/ros2_agent_workspace/issues/445) —
+  Field mode design and decisions
+- Issue [#247](https://github.com/rolker/ros2_agent_workspace/issues/247) —
+  Dev-mode worktree hardening (the rule field mode carves out from)
+- Issue [#432](https://github.com/rolker/ros2_agent_workspace/issues/432) —
+  Asked the question this ADR answers (closed when PR #440 shipped the
+  reconciliation half without addressing the edit-side question)
+- PR [#440](https://github.com/rolker/ros2_agent_workspace/pull/440) —
+  Shipped `/import-field-changes` for the reconciliation half
+- [`.agent/knowledge/field_mode_hotfix.md`](../../.agent/knowledge/field_mode_hotfix.md) —
+  Concrete walkthrough
+- [`.agent/scripts/field_mode.sh`](../../.agent/scripts/field_mode.sh) —
+  Detection helper

--- a/docs/decisions/0012-permit-cross-reference-addendums-in-adrs.md
+++ b/docs/decisions/0012-permit-cross-reference-addendums-in-adrs.md
@@ -1,0 +1,92 @@
+# ADR-0012: Permit Cross-Reference Addendums in Accepted ADRs
+
+## Status
+
+Accepted. Narrows the immutability rule from
+[ADR-0001](0001-adopt-architecture-decision-records.md).
+
+## Context
+
+[ADR-0001](0001-adopt-architecture-decision-records.md) established that
+*"ADRs are immutable once accepted — supersede rather than edit"*. The
+intent of that rule is sound: substantive edits to accepted ADRs
+(rewording the Decision, reversing position, changing Consequences) can
+silently reverse settled decisions and undermine the "check
+`docs/decisions/` before proposing changes" discoverability the practice
+depends on.
+
+But a strict read of "immutable" also blocks a useful, low-risk class of
+edit: **cross-reference addendums** — pointers from one ADR to another
+that was written later. Specifically:
+
+- A Status-line note like *"Scoped exception in ADR-0011 permits ..."*
+  on ADR-0002, making the relationship discoverable from the older ADR.
+- A References section at the end of an ADR listing related ADRs (earlier
+  or later) that inform or qualify it.
+
+These additions are purely navigational. They don't restate, reword, or
+reverse the original Decision — they point at additional decisions the
+reader should know about. Without them, relationships between ADRs are
+only visible when reading the newer ADR, not the older one.
+
+This gap surfaced on [#445](https://github.com/rolker/ros2_agent_workspace/issues/445)
+/ PR [#448](https://github.com/rolker/ros2_agent_workspace/pull/448): ADR-0011
+(field mode) is a scoped exception to ADR-0002 (worktree isolation).
+The ADR-0011 → ADR-0002 direction is natural to write; the ADR-0002 →
+ADR-0011 direction required editing an accepted ADR.
+
+## Decision
+
+Narrow ADR-0001's immutability rule: cross-reference addendums to
+accepted ADRs are permitted; substantive changes still require
+superseding.
+
+### Permitted (cross-reference addendums)
+
+- Updating the **Status** line to note a related ADR (e.g. *"Scoped
+  exception in ADR-N…"*)
+- Adding or appending to a **References** section listing related ADRs
+- Fixing broken links, typos in metadata, or formatting nits that don't
+  change meaning
+
+### Still requires a new/superseding ADR (substantive changes)
+
+- Rewording the **Decision** section
+- Reversing or softening the position
+- Adding or removing **Consequences** that weren't previously recorded
+- Anything a reader could mistake for "this ADR now says something
+  different"
+
+### How to tell the difference
+
+Ask: *if someone reads only the edited ADR without knowing about the
+change, will they get a misleading picture of what was originally
+decided?* If yes → supersede. If no → addendum is fine.
+
+## Consequences
+
+**Positive:**
+- Relationships between ADRs are discoverable from both directions —
+  forward (ADR-0011 references ADR-0002) and backward (ADR-0002 notes
+  ADR-0011).
+- Keeps the supersede mechanism for what it's designed for: substantive
+  change. Navigation isn't change.
+- Self-bootstrapping: the one-line Status update to ADR-0001 that
+  records this narrowing (*"narrowed by ADR-0012"*) is itself the first
+  addendum permitted under this rule.
+
+**Negative:**
+- Slippery-slope risk — if the "cross-reference" category expands
+  gradually, substantive edits could sneak in under the label. The "how
+  to tell" test above is the guardrail.
+- One more thing for ADR authors to think about when touching existing
+  ADRs. Mitigated by the rule-of-thumb being quick to apply.
+
+## References
+
+- [ADR-0001](0001-adopt-architecture-decision-records.md) — Adopt
+  Architecture Decision Records (this ADR narrows ADR-0001's
+  immutability rule)
+- Issue [#445](https://github.com/rolker/ros2_agent_workspace/issues/445)
+  / PR [#448](https://github.com/rolker/ros2_agent_workspace/pull/448)
+  — where the need for this narrowing surfaced


### PR DESCRIPTION
## Summary

Combined work for #247 (dev-mode worktree hardening) and #445 (field-mode
carve-out). Both touch the same documentation surfaces, so a single PR
avoids the intermediate "strict-rule-then-exception" state.

### What changed

- **New script** `.agent/scripts/field_mode.sh` — dual-use (CLI + sourceable)
  helper that detects field mode from the repo's origin URL. Field mode = origin
  is not github.com.
- **AGENTS.md** — adds the field-mode carve-out to the worktree workflow,
  scopes the "never edit main tree" / "never commit to main" boundaries to
  github-origin repos, and registers the new script.
- **WORKTREE_GUIDE.md** — brief Field Mode pointer section at the top.
- **AGENT_ONBOARDING.md** — Key Points list updated with field-mode reference.
- **.agent/templates/project_agents_guide.md** — one-line workflow pointer per
  Decision 4 on #445 (template gets the pointer; AGENTS.md owns the rule).
- **.agent/knowledge/field_mode_hotfix.md** (new) — concrete BizzyBoat
  walkthrough covering detection → edit → commit → push → later import.
- **.agent/knowledge/README.md** — index entry for the new walkthrough.

### Decisions recorded on #445

1. Mode detection: per-repo origin URL check (no machine-wide flag).
2. Workspace repo carve-out: none — handle ad-hoc if it ever happens.
3. `setup.bash` checkout guardrail: leave strict (no code change).
4. Project-repo `.agents/README.md`: one-line pointer in template, AGENTS.md
   owns the rule.

### Existing infrastructure this builds on

The reconciliation half (field commits → GitHub PRs) was shipped in PR #440
as the `/import-field-changes` skill. This PR documents the field-side edit
permission that #432 explicitly deferred when the import skill was built.

## Test plan

- [x] `field_mode.sh --describe` correctly identifies dev mode in this repo
- [x] `field_mode.sh --describe <path>` correctly identifies field mode in a
      faked gitcloud-origin repo
- [x] Sourcing the script and calling `is_field_mode` returns the right exit
      code in both dev and field repos
- [x] Pre-commit hooks pass on every commit (including the docs-only ones)
- [x] git-bug v0.10.1 verified installed; bridge configured; local bug
      create/remove cycle works (smoke test for the workspace-bug-report
      fallback that field-mode docs reference)
- [ ] **Field-machine verification deferred**: full smoke of `gh_create_issue.sh
      GITBUG_CREATE=1` from an actually-offline field machine — to be done
      next time someone is on BizzyBoat or another field machine, since dev
      machine has GitHub reachable

Closes #247
Closes #445

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
