### PR TITLE
[PLAN] plan-task: add guidance on updating plan during implementation

### DIFF
--- a/.agent/work-plans/PLAN_ISSUE-449.md
+++ b/.agent/work-plans/PLAN_ISSUE-449.md
@@ -1,0 +1,90 @@
+# Plan: plan-task — add guidance on updating plan during implementation
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/449
+
+## Context
+
+The `plan-task` skill generates a work plan up through "commit the plan" and
+"open draft PR" (steps 6 and 7) but says nothing about what happens to that plan
+during implementation. In practice, implementation deviates from the plan
+constantly — types change, modules get renamed, a function originally spec'd as
+"pure logic" picks up a ROS dependency. Without explicit guidance, the plan
+rots, and Copilot's plan-file review flags the drift as a finding, which has to
+be triaged as a false positive each round.
+
+This was concretely observed during `rolker/rqt_operator_tools#22`: across
+review rounds 1–8, Copilot repeatedly flagged `PLAN_ISSUE-20.md` wording that
+had been deliberately superseded by implementation choices. Round 8 (comment on
+`PLAN_ISSUE-20.md:108`: "pure logic, no Qt/ROS" vs. actual `rclcpp::Time`) was
+the most visible — the dogfooded fix in commit `9680d3e` landed four inline
+plan edits alongside the code changes that motivated them, and that pattern is
+what the skill should describe.
+
+## Approach
+
+Three small, tightly related doc edits. Single PR.
+
+1. **Add "During implementation" subsection to `.claude/skills/plan-task/SKILL.md`** —
+   insert between current step 7 (create/update draft PR) and step 8 (report to
+   user). Content: four rules (inline default, inline-plus-notes for
+   rationale-bearing deviations, never append-only, commit discipline), one
+   short worked example pair.
+
+2. **Add a one-line reference in `AGENTS.md` § Worktree Workflow**, near the
+   `PLAN_ISSUE-<N>.md` mention, pointing at the new skill subsection so
+   non-Claude agents who adopt plan-first later discover the rule. This
+   prevents the cascade barrier flagged in the review-issue comment.
+
+3. **Acknowledge the enforcement-layer choice in the skill prose** — one
+   sentence stating plan freshness is enforced by review feedback
+   (Copilot, `review-code`), not a local hook. Prevents future maintainers
+   from "fixing the gap" with a premature check.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.claude/skills/plan-task/SKILL.md` | Insert new "During implementation" subsection with four rules + worked example pair + enforcement-layer note |
+| `AGENTS.md` | One-line reference to the new subsection near the existing plan-first mention (sited via grep on `PLAN_ISSUE`) |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Only what's needed | Two files, ~40 lines of new prose total. No new enforcement layer, no new skill file, no restructuring of existing content. |
+| Capture decisions, not just implementations | The rule codifies a decision reached on PR #22; worked example points at commit `9680d3e` rather than an invented diff. |
+| Enforcement over documentation | Acknowledged explicitly in the skill prose: this is instruction-layer guidance, with Copilot's plan-file review acting as the de-facto signal. No hook is appropriate (checking "was the plan updated when it should be" is not mechanically tractable). |
+| A change includes its consequences | AGENTS.md update included; no other adapter files need updating (they reference the skill by name, not its internal steps). `AGENT_ONBOARDING.md` / `gemini-cli.instructions.md` already list `plan-task` as a skill name — no content edit needed there. |
+| Workspace improvements cascade to projects | AGENTS.md entry addresses the cascade barrier — the rule becomes discoverable from shared instructions, not locked inside a Claude-only skill. |
+| Improve incrementally | Single small PR, one feature (the rule), no refactoring. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0004 — Enforcement hierarchy | Yes | Instruction-layer only, by explicit design. Skill prose will state this so the choice isn't mistaken for an oversight. Review feedback (Copilot, `review-code`) is the de-facto enforcement signal; a hook isn't practical. |
+| 0006 — Shared AGENTS.md | Yes | AGENTS.md gets the one-line reference so the rule is discoverable framework-agnostically, even though the detailed guidance lives in the Claude skill. |
+| 0001, 0002, 0003, 0005, 0007, 0008, 0009, 0010 | No | Not applicable — no design decision requiring a new ADR, no worktree / project-agnostic / Make / ROS / Python / git-bug scope. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| A framework skill (`.claude/skills/plan-task/`) | That framework's adapter file; regenerate skills if needed | N/A — no non-Claude adapter references this skill's internal steps; they reference it by name only. `make generate-skills` regenerates Makefile-driven slash commands, not skill content — not applicable here. |
+| `AGENTS.md` | Framework adapters if affected | Yes — checked. The one-line reference is pointer-only (no new rule), so adapters don't need mirrored content. |
+
+## Open Questions
+
+- **Name of the new section inside `.claude/skills/plan-task/SKILL.md`** — "During implementation" (matches the verbal discussion) or "Step 8: Update the plan as implementation evolves" (matches the skill's existing numbered-step structure)? Recommendation: renumber existing step 8 ("Report to user") to step 9 and make the new content step 8, so the flow reads issue → plan → draft PR → implement-and-update-plan → report.
+- **Depth of the worked example** — reference `rolker/rqt_operator_tools@9680d3e` by commit SHA + a one-line snippet, or paste the full before/after? Recommendation: reference + one-line snippet. Full diff rots if either side edits the file later.
+
+## Estimated Scope
+
+Single PR. ~40 lines of new/changed content across two files. No tests
+(instruction doc). No dependency regeneration needed.
+
+---
+**Authored-By**: `Claude Code Agent`
+**Model**: `Claude Opus 4.7 (1M context)`

--- a/.agent/work-plans/PLAN_ISSUE-449.md
+++ b/.agent/work-plans/PLAN_ISSUE-449.md
@@ -32,10 +32,11 @@ Three small, tightly related doc edits. Single PR.
    rationale-bearing deviations, never append-only, commit discipline), one
    short worked example pair.
 
-2. **Add a one-line reference in `AGENTS.md` § Worktree Workflow**, near the
-   `PLAN_ISSUE-<N>.md` mention, pointing at the new skill subsection so
-   non-Claude agents who adopt plan-first later discover the rule. This
-   prevents the cascade barrier flagged in the review-issue comment.
+2. **Add a one-line reference in `AGENTS.md` § Post-Task Verification**,
+   alongside the existing work-plan bullet in that section, pointing at
+   the new skill subsection so non-Claude agents who adopt plan-first
+   later discover the rule. This prevents the cascade barrier flagged in
+   the review-issue comment.
 
 3. **Acknowledge the enforcement-layer choice in the skill prose** — one
    sentence stating plan freshness is enforced by review feedback
@@ -47,7 +48,7 @@ Three small, tightly related doc edits. Single PR.
 | File | Change |
 |------|--------|
 | `.claude/skills/plan-task/SKILL.md` | Insert new "During implementation" subsection with four rules + worked example pair + enforcement-layer note |
-| `AGENTS.md` | One-line reference to the new subsection near the existing plan-first mention (cited via grep on `PLAN_ISSUE`) |
+| `AGENTS.md` | One-line reference to the new subsection, added under `## Post-Task Verification` alongside the existing work-plan bullet |
 
 ## Principles Self-Check
 

--- a/.agent/work-plans/PLAN_ISSUE-449.md
+++ b/.agent/work-plans/PLAN_ISSUE-449.md
@@ -82,11 +82,16 @@ Both items below were resolved during implementation; annotations reflect
 the decisions that landed.
 
 - **Name of the new section inside `.claude/skills/plan-task/SKILL.md`** —
-  Resolved: unnumbered `### During implementation` subsection placed
-  between step 7 and step 8, nested under `## Steps`. Keeps the existing
-  numbered steps untouched while the new guidance is visible in the flow.
-  (Initially landed as a `##` heading, demoted to `###` in a follow-up
-  round so it stays structurally inside `## Steps`.)
+  Resolved: `## During implementation` top-level section placed after
+  `## Steps` (i.e. after step 8), peer to `## Guidelines`, with
+  `### Worked example` as a subsection. Keeps the 8 numbered steps
+  under `## Steps` internally consistent (no mixed numbered/unnumbered
+  peers) and reads honestly as guidance for the post-skill
+  implementation phase. (Landed through several iterations: first
+  `##` inserted between steps which broke nesting; then `###`
+  unnumbered inside Steps which Copilot flagged as inconsistent with
+  the numbered peers; finally moved to its current after-Steps
+  location.)
 - **Depth of the worked example** — Resolved: short before/after excerpt
   pasted inline, plus a SHA reference to `rolker/rqt_operator_tools@9680d3e`.
   Readers see the pattern without clicking through; the SHA anchors the

--- a/.agent/work-plans/PLAN_ISSUE-449.md
+++ b/.agent/work-plans/PLAN_ISSUE-449.md
@@ -47,7 +47,7 @@ Three small, tightly related doc edits. Single PR.
 | File | Change |
 |------|--------|
 | `.claude/skills/plan-task/SKILL.md` | Insert new "During implementation" subsection with four rules + worked example pair + enforcement-layer note |
-| `AGENTS.md` | One-line reference to the new subsection near the existing plan-first mention (sited via grep on `PLAN_ISSUE`) |
+| `AGENTS.md` | One-line reference to the new subsection near the existing plan-first mention (cited via grep on `PLAN_ISSUE`) |
 
 ## Principles Self-Check
 

--- a/.agent/work-plans/PLAN_ISSUE-449.md
+++ b/.agent/work-plans/PLAN_ISSUE-449.md
@@ -78,8 +78,19 @@ Three small, tightly related doc edits. Single PR.
 
 ## Open Questions
 
-- **Name of the new section inside `.claude/skills/plan-task/SKILL.md`** — "During implementation" (matches the verbal discussion) or "Step 8: Update the plan as implementation evolves" (matches the skill's existing numbered-step structure)? Recommendation: renumber existing step 8 ("Report to user") to step 9 and make the new content step 8, so the flow reads issue → plan → draft PR → implement-and-update-plan → report.
-- **Depth of the worked example** — reference `rolker/rqt_operator_tools@9680d3e` by commit SHA + a one-line snippet, or paste the full before/after? Recommendation: reference + one-line snippet. Full diff rots if either side edits the file later.
+Both items below were resolved during implementation; annotations reflect
+the decisions that landed.
+
+- **Name of the new section inside `.claude/skills/plan-task/SKILL.md`** —
+  Resolved: unnumbered `### During implementation` subsection placed
+  between step 7 and step 8, nested under `## Steps`. Keeps the existing
+  numbered steps untouched while the new guidance is visible in the flow.
+  (Initially landed as a `##` heading, demoted to `###` in a follow-up
+  round so it stays structurally inside `## Steps`.)
+- **Depth of the worked example** — Resolved: short before/after excerpt
+  pasted inline, plus a SHA reference to `rolker/rqt_operator_tools@9680d3e`.
+  Readers see the pattern without clicking through; the SHA anchors the
+  example to a real commit for anyone who wants full context.
 
 ## Estimated Scope
 

--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -180,9 +180,20 @@ fi
 rm -f "$BODY_FILE"
 ```
 
-### During implementation
+### 8. Report to user
 
-The `plan-task` skill produces its artifact at step 7 (the draft PR).
+Summarize:
+- What the plan proposes
+- Which principles and ADRs were considered
+- Any open questions that need input
+- Link to the draft PR
+- Pointer to the "During implementation" section below, so the
+  implementer knows to keep the plan in sync with landed code
+
+## During implementation
+
+The `plan-task` skill's primary artifact is the committed plan file
+created in steps 5–6; step 7 publishes that plan into a draft PR.
 Implementation then proceeds on the same branch — and typically deviates
 from the plan: types get refined, functions change signatures, a "pure
 logic" module picks up a dependency. Keep the plan in sync as this
@@ -222,7 +233,7 @@ misalignment between the plan and the PR. If drift becomes a recurring
 finding across multiple PRs, that's a signal the rule needs more teeth,
 not that the rule is wrong.
 
-#### Worked example
+### Worked example
 
 From `rolker/rqt_operator_tools@9680d3e` (PR #22 round-8 fix pass —
 the code change and its plan edit landed in the same commit):
@@ -247,16 +258,6 @@ motivated it (rule 4). No `Implementation Notes` entry is needed — the
 `Implementation Notes` entry would have been warranted for a case like
 the `QGridLayout` swap cited above, where the rationale doesn't fit in a
 one-line plan edit.
-
-### 8. Report to user
-
-Summarize:
-- What the plan proposes
-- Which principles and ADRs were considered
-- Any open questions that need input
-- Link to the draft PR
-- Pointer to the "During implementation" subsection above, so the
-  implementer knows to keep the plan in sync with landed code
 
 ## Guidelines
 

--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -180,7 +180,7 @@ fi
 rm -f "$BODY_FILE"
 ```
 
-## During implementation
+### During implementation
 
 The `plan-task` skill produces its artifact at step 7 (the draft PR).
 Implementation then proceeds on the same branch — and typically deviates
@@ -222,7 +222,7 @@ misalignment between the plan and the PR. If drift becomes a recurring
 finding across multiple PRs, that's a signal the rule needs more teeth,
 not that the rule is wrong.
 
-### Worked example
+#### Worked example
 
 From `rolker/rqt_operator_tools@9680d3e` (PR #22 round-8 fix pass —
 the code change and its plan edit landed in the same commit):

--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -180,22 +180,15 @@ fi
 rm -f "$BODY_FILE"
 ```
 
-### 8. Report to user
-
-Summarize:
-- What the plan proposes
-- Which principles and ADRs were considered
-- Any open questions that need input
-- Link to the draft PR
-
 ## During implementation
 
-The `plan-task` skill finishes when the draft PR is up. Implementation then
-proceeds on the same branch — and typically deviates from the plan: types
-get refined, functions change signatures, a "pure logic" module picks up
-a dependency. Keep the plan in sync as this happens so the file stays
-usable reference material — for Copilot's plan-file review, for
-`review-code`, and for the next agent who picks up the package.
+The `plan-task` skill produces its artifact at step 7 (the draft PR).
+Implementation then proceeds on the same branch — and typically deviates
+from the plan: types get refined, functions change signatures, a "pure
+logic" module picks up a dependency. Keep the plan in sync as this
+happens so the file stays usable reference material — for Copilot's
+plan-file review, for `review-code`, and for the next agent who picks
+up the package.
 
 1. **Inline edits are the default.** When implementation diverges from the
    plan in any way — wording, method names, file paths, dependency
@@ -254,6 +247,16 @@ motivated it (rule 4). No `Implementation Notes` entry is needed — the
 `Implementation Notes` entry would have been warranted for a case like
 the `QGridLayout` swap cited above, where the rationale doesn't fit in a
 one-line plan edit.
+
+### 8. Report to user
+
+Summarize:
+- What the plan proposes
+- Which principles and ADRs were considered
+- Any open questions that need input
+- Link to the draft PR
+- Pointer to the "During implementation" subsection above, so the
+  implementer knows to keep the plan in sync with landed code
 
 ## Guidelines
 

--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -188,6 +188,73 @@ Summarize:
 - Any open questions that need input
 - Link to the draft PR
 
+## During implementation
+
+The `plan-task` skill finishes when the draft PR is up. Implementation then
+proceeds on the same branch — and typically deviates from the plan: types
+get refined, functions change signatures, a "pure logic" module picks up
+a dependency. Keep the plan in sync as this happens so the file stays
+usable reference material — for Copilot's plan-file review, for
+`review-code`, and for the next agent who picks up the package.
+
+1. **Inline edits are the default.** When implementation diverges from the
+   plan in any way — wording, method names, file paths, dependency
+   choices, a test contract that tightened during coding — edit the plan
+   inline to match the landed code. Git history preserves the original
+   planning state; nobody benefits from stale text at the top of an
+   otherwise-current plan.
+
+2. **Appended "Implementation Notes" only for rationale-bearing design
+   pivots.** If the deviation is a real design decision whose *why* is
+   not obvious from the code diff alone (e.g. "switched from `QGridLayout`
+   to a custom layout because `QGridLayout` can't express slack-to-outside
+   with shared inner edges"), make the inline edit *and* add a one-liner
+   to an `## Implementation Notes` section at the bottom of the plan
+   capturing the rationale. The section is for rationale only, not a
+   changelog.
+
+3. **Never append-only.** Leaving stale text at the top of the plan while
+   listing "changes" in a section below misleads Copilot, human reviewers,
+   and future onboarding agents — all of whom read the top first.
+
+4. **Commit discipline.** Plan edits flow in commits alongside the code
+   changes that triggered them (same commit when caught while coding;
+   follow-up commit if caught later during review triage). Never amend a
+   pushed commit just to update the plan.
+
+This guidance is enforced at the instructions layer only. There is no
+local hook for "did you update the plan"; the enforcement signal is
+review feedback — Copilot's plan-drift flags and `review-code` catching
+misalignment between the plan and the PR. If drift becomes a recurring
+finding across multiple PRs, that's a signal the rule needs more teeth,
+not that the rule is wrong.
+
+### Worked example
+
+From `rolker/rqt_operator_tools@9680d3e` (PR #22 round-8 fix pass —
+the code change and its plan edit landed in the same commit):
+
+**Before** — `.agent/work-plans/PLAN_ISSUE-20.md:108`:
+
+```
+│   │   ├── staleness_tracker.hpp                 # pure logic, no Qt/ROS
+```
+
+**After** — same file, same commit as the `rclcpp::Time` adoption in
+`staleness_tracker.cpp`:
+
+```
+│   │   ├── staleness_tracker.hpp                 # pure logic, uses rclcpp::Time (no Qt)
+```
+
+The edit is inline (rule 1) and co-located with the code change that
+motivated it (rule 4). No `Implementation Notes` entry is needed — the
+*why* (consistent clock math under `use_sim_time`) is visible in the
+`staleness_tracker.cpp` diff in the same commit (rule 2). An
+`Implementation Notes` entry would have been warranted for a case like
+the `QGridLayout` swap cited above, where the rationale doesn't fit in a
+one-line plan edit.
+
 ## Guidelines
 
 - **Generate, don't just evaluate** — this skill produces a plan, not a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,9 +265,9 @@ Before marking a task complete or opening a PR:
 **Plan-first workflow**: if the PR opened with a work plan (`.agent/work-plans/PLAN_ISSUE-<N>.md`),
 the plan is expected to stay in sync with the landed code as implementation
 proceeds. Inline edits are the default; see the "During implementation"
-section of `.claude/skills/plan-task/SKILL.md` for the full rules. Keeps
-the plan useful as reference material for review and future agents, and
-avoids recurring plan-drift flags from Copilot.
+section of `.claude/skills/plan-task/SKILL.md` for the full rules. This
+keeps the plan useful as reference material for review and future agents,
+and avoids recurring plan-drift flags from Copilot.
 
 ## Script Reference
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,11 +263,12 @@ Before marking a task complete or opening a PR:
 4. List any gaps; complete them or explain in PR description
 
 **Plan-first workflow**: if the PR opened with a work plan (`.agent/work-plans/PLAN_ISSUE-<N>.md`),
-the plan is expected to stay in sync with the landed code as implementation
-proceeds. Inline edits are the default; see the "During implementation"
-section of `.claude/skills/plan-task/SKILL.md` for the full rules. This
-keeps the plan useful as reference material for review and future agents,
-and avoids recurring plan-drift flags from Copilot.
+the plan is expected to stay in sync with the committed implementation on
+the branch / in the PR as implementation proceeds. Inline edits are the
+default; see the "During implementation" section of
+`.claude/skills/plan-task/SKILL.md` for the full rules. This keeps the
+plan useful as reference material for review and future agents, and
+avoids recurring plan-drift flags from Copilot.
 
 ## Script Reference
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,13 @@ Before marking a task complete or opening a PR:
 3. Check consequences: do tests, docs, or dependent references need updating?
 4. List any gaps; complete them or explain in PR description
 
+**Plan-first workflow**: if the PR opened with a work plan (`.agent/work-plans/PLAN_ISSUE-<N>.md`),
+the plan is expected to stay in sync with the landed code as implementation
+proceeds. Inline edits are the default; see the "During implementation"
+section of `.claude/skills/plan-task/SKILL.md` for the full rules. Keeps
+the plan useful as reference material for review and future agents, and
+avoids recurring plan-drift flags from Copilot.
+
 ## Script Reference
 
 `scripts/` at the repo root is a symlink to `.agent/scripts/` for convenience.


### PR DESCRIPTION
Closes #449

# Plan: plan-task — add guidance on updating plan during implementation

## Issue

https://github.com/rolker/ros2_agent_workspace/issues/449

## Context

The `plan-task` skill generates a work plan up through "commit the plan" and
"open draft PR" (steps 6 and 7) but says nothing about what happens to that plan
during implementation. In practice, implementation deviates from the plan
constantly — types change, modules get renamed, a function originally spec'd as
"pure logic" picks up a ROS dependency. Without explicit guidance, the plan
rots, and Copilot's plan-file review flags the drift as a finding, which has to
be triaged as a false positive each round.

This was concretely observed during `rolker/rqt_operator_tools#22`: across
review rounds 1–8, Copilot repeatedly flagged `PLAN_ISSUE-20.md` wording that
had been deliberately superseded by implementation choices. Round 8 (comment on
`PLAN_ISSUE-20.md:108`: "pure logic, no Qt/ROS" vs. actual `rclcpp::Time`) was
the most visible — the dogfooded fix in commit `9680d3e` landed four inline
plan edits alongside the code changes that motivated them, and that pattern is
what the skill should describe.

## Approach

Three small, tightly related doc edits. Single PR.

1. **Add "During implementation" subsection to `.claude/skills/plan-task/SKILL.md`** —
   insert between current step 7 (create/update draft PR) and step 8 (report to
   user). Content: four rules (inline default, inline-plus-notes for
   rationale-bearing deviations, never append-only, commit discipline), one
   short worked example pair.

2. **Add a one-line reference in `AGENTS.md` § Worktree Workflow**, near the
   `PLAN_ISSUE-<N>.md` mention, pointing at the new skill subsection so
   non-Claude agents who adopt plan-first later discover the rule. This
   prevents the cascade barrier flagged in the review-issue comment.

3. **Acknowledge the enforcement-layer choice in the skill prose** — one
   sentence stating plan freshness is enforced by review feedback
   (Copilot, `review-code`), not a local hook. Prevents future maintainers
   from "fixing the gap" with a premature check.

## Files to Change

| File | Change |
|------|--------|
| `.claude/skills/plan-task/SKILL.md` | Insert new "During implementation" subsection with four rules + worked example pair + enforcement-layer note |
| `AGENTS.md` | One-line reference to the new subsection near the existing plan-first mention (sited via grep on `PLAN_ISSUE`) |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Only what's needed | Two files, ~40 lines of new prose total. No new enforcement layer, no new skill file, no restructuring of existing content. |
| Capture decisions, not just implementations | The rule codifies a decision reached on PR #22; worked example points at commit `9680d3e` rather than an invented diff. |
| Enforcement over documentation | Acknowledged explicitly in the skill prose: this is instruction-layer guidance, with Copilot's plan-file review acting as the de-facto signal. No hook is appropriate (checking "was the plan updated when it should be" is not mechanically tractable). |
| A change includes its consequences | AGENTS.md update included; no other adapter files need updating (they reference the skill by name, not its internal steps). `AGENT_ONBOARDING.md` / `gemini-cli.instructions.md` already list `plan-task` as a skill name — no content edit needed there. |
| Workspace improvements cascade to projects | AGENTS.md entry addresses the cascade barrier — the rule becomes discoverable from shared instructions, not locked inside a Claude-only skill. |
| Improve incrementally | Single small PR, one feature (the rule), no refactoring. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0004 — Enforcement hierarchy | Yes | Instruction-layer only, by explicit design. Skill prose will state this so the choice isn't mistaken for an oversight. Review feedback (Copilot, `review-code`) is the de-facto enforcement signal; a hook isn't practical. |
| 0006 — Shared AGENTS.md | Yes | AGENTS.md gets the one-line reference so the rule is discoverable framework-agnostically, even though the detailed guidance lives in the Claude skill. |
| 0001, 0002, 0003, 0005, 0007, 0008, 0009, 0010 | No | Not applicable — no design decision requiring a new ADR, no worktree / project-agnostic / Make / ROS / Python / git-bug scope. |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| A framework skill (`.claude/skills/plan-task/`) | That framework's adapter file; regenerate skills if needed | N/A — no non-Claude adapter references this skill's internal steps; they reference it by name only. `make generate-skills` regenerates Makefile-driven slash commands, not skill content — not applicable here. |
| `AGENTS.md` | Framework adapters if affected | Yes — checked. The one-line reference is pointer-only (no new rule), so adapters don't need mirrored content. |

## Open Questions

- **Name of the new section inside `.claude/skills/plan-task/SKILL.md`** — "During implementation" (matches the verbal discussion) or "Step 8: Update the plan as implementation evolves" (matches the skill's existing numbered-step structure)? Recommendation: renumber existing step 8 ("Report to user") to step 9 and make the new content step 8, so the flow reads issue → plan → draft PR → implement-and-update-plan → report.
- **Depth of the worked example** — reference `rolker/rqt_operator_tools@9680d3e` by commit SHA + a one-line snippet, or paste the full before/after? Recommendation: reference + one-line snippet. Full diff rots if either side edits the file later.

## Estimated Scope

Single PR. ~40 lines of new/changed content across two files. No tests
(instruction doc). No dependency regeneration needed.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
