### PR TITLE
docs(AGENTS.md): recommend --symlink-install in Build & Test example (closes #434)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,12 +209,19 @@ make dashboard                                   # Unified workspace status
 make dashboard QUICK=1                           # Quick mode (skip sync + GitHub)
 
 # Single package
-cd layers/main/<layer>_ws && colcon build --packages-select <package>
+cd layers/main/<layer>_ws && colcon build --symlink-install --packages-select <package>
 # setup.bash must be sourced in the same shell — agents run each command in a fresh subprocess
 source .agent/scripts/setup.bash && cd layers/main/<layer>_ws && colcon test --packages-select <package> && colcon test-result --verbose
 
 make lint                                        # Lint + hooks (auto-installs pre-commit)
 ```
+
+**Always use `--symlink-install`** for development builds — it symlinks Python
+files and package markers so edits take effect without a rebuild. `make build`,
+the workspace build scripts, and worktree-generated `<layer>_ws/build.sh` all
+include this flag by default; the single-package example above does too. (Note:
+ament_cmake `install(DIRECTORY ...)` directives still copy their contents, so
+data-file edits still need a rebuild.)
 
 **Build in layer directories only** — never `colcon build` from the workspace root.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,10 +218,13 @@ make lint                                        # Lint + hooks (auto-installs p
 
 **Always use `--symlink-install`** for development builds — it symlinks Python
 files and package markers so edits take effect without a rebuild. `make build`,
-the workspace build scripts, and worktree-generated `<layer>_ws/build.sh` all
-include this flag by default; the single-package example above does too. (Note:
-ament_cmake `install(DIRECTORY ...)` directives still copy their contents, so
-data-file edits still need a rebuild.)
+the workspace build scripts (`.agent/scripts/build.sh`), and the single-package
+example above pass this flag explicitly. Worktree-generated `<layer>_ws/build.sh`
+enables symlink installs by default via a generated `colcon/defaults.yaml`
+(`symlink-install: true`) rather than via the CLI flag, so raw `colcon build`
+from the layer workspace picks it up automatically. (Note: ament_cmake
+`install(DIRECTORY ...)` directives still copy their contents, so data-file
+edits still need a rebuild.)
 
 **Build in layer directories only** — never `colcon build` from the workspace root.
 


### PR DESCRIPTION
## Summary

Closes the one remaining documentation gap for #434. The scripts that 99%
of agents use (`make build`, `.agent/scripts/build.sh`, worktree-generated
`<layer>_ws/build.sh`) have been passing `--symlink-install` for months —
this PR just makes AGENTS.md's single-package example match, so an agent
following that example doesn't accidentally end up with a non-symlink
install.

## Changes

- `AGENTS.md` Build & Test single-package example: add `--symlink-install`
- `AGENTS.md`: short note explaining the flag and clarifying that the
  existing scripts already use it (so the note is documentation, not new
  policy)

## Test plan

- [x] `make lint` passes (pre-commit hooks ran on commit)
- [x] Example command syntactically valid (no behavior change to the
      scripts, which already pass `--symlink-install`)

Closes #434

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
