### PR TITLE
Port review-skill improvements from agent_workspace + encourage use

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -48,6 +48,19 @@ Key points:
 source .agent/scripts/worktree_enter.sh --issue <N>
 ```
 
+## Pre-Push Code Review
+
+The shared rule (see [`AGENTS.md` Post-Task Verification](../AGENTS.md#post-task-verification))
+expects authors to run `/review-code` against their diff before opening
+a PR. The skill body is plain markdown at
+[`.claude/skills/review-code/SKILL.md`](../.claude/skills/review-code/SKILL.md);
+follow its steps regardless of framework.
+
+**Adversarial Specialist is Claude-only** — its dispatch relies on
+Claude Code's `Agent` tool. Other frameworks should run the remaining
+specialists (Static Analysis, Governance, Plan Drift) and note that
+Adversarial was skipped due to the runtime.
+
 ## Workflow Skills
 
 Reusable workflow procedures are documented at the repo root in `.claude/skills/*/SKILL.md`.

--- a/.agent/instructions/gemini-cli.instructions.md
+++ b/.agent/instructions/gemini-cli.instructions.md
@@ -20,6 +20,20 @@ Verify with `echo "$AGENT_MODEL"` — it should echo exactly what you passed. Do
 - **Google Cloud**: If Gemini CLI has access to Google Cloud services, check your environment for available integrations.
 - If `gh` CLI is installed, use it for GitHub operations.
 
+## Pre-Push Code Review
+
+The shared rule (see [`AGENTS.md` Post-Task Verification](../../AGENTS.md#post-task-verification))
+expects authors to run `/review-code` against their diff before opening
+a PR. This applies to Gemini CLI sessions too. The skill body is plain
+markdown at [`.claude/skills/review-code/SKILL.md`](../../.claude/skills/review-code/SKILL.md);
+follow its steps as you would any other governance skill.
+
+**Adversarial Specialist is Claude-only** — its dispatch relies on
+Claude Code's `Agent` tool to launch a fresh subagent with no shared
+context. Gemini doesn't expose an equivalent. Run the other specialists
+(Static Analysis, Governance, Plan Drift) and note in the report header
+that Adversarial was skipped because the runtime is Gemini.
+
 
 ## Workflow Skills
 

--- a/.agent/knowledge/inspiration_agent_workspace_digest.md
+++ b/.agent/knowledge/inspiration_agent_workspace_digest.md
@@ -1,21 +1,68 @@
 # Inspiration Digest: agent_workspace
 
 Type: fork
-Last checked: 2026-03-23
-Repo: rolker/agent_workspace @ cebd918bacf69e1651e028c7b4182472e33ba4e1
+Last checked: 2026-04-30
+Repo: rolker/agent_workspace @ c02887e00eecfac31cb442fea47427dc08a02b5c
 
 ## Activity Snapshot
 
-- 14 open issues (mostly enhancements from inspiration runs), 0 open PRs
-- 16 recently merged PRs — active development
-- Notable: gstack-inspired review enhancements (#47-61), workspace UX roadmap (#63, #73),
-  crash recovery (#70), workflow modes (#67), tmux session strategy (#65-66)
+- ~14 open issues (mostly enhancements from inspiration runs), 0 open PRs
+- Active development since the previous digest (2026-03-23): the fork landed
+  the depth-tier review pipeline and the cross-model adversarial dispatch in
+  the meantime.
+- Notable since last refresh: `review_depth_classification.md` knowledge doc,
+  Claude + Gemini Adversarial Specialists in `review-code`, `progress.md`
+  persistence in both `review-code` and `triage-reviews`, and a flexible
+  input set on `review-plan` (PR / file / `--issue <N>`).
 
 ## Pending Review
 
+_None._ Items previously listed here have either been ported or moved to
+the appropriate section below.
+
 ## Roadmapped
 
+_None outstanding._
+
 ## Skipped
+
+_None outstanding._
+
+## Ported
+
+Pieces imported into this workspace via PR #453 (issue #452). All adapted
+for the layered/multi-repo workspace and for Claude-only operation. The
+fork's items remain the upstream source if we later decide to pull more
+of the surrounding tooling.
+
+- **Review depth classification** (`review_depth_classification.md`).
+  Knowledge doc with risk signals, override-trigger files, Light /
+  Standard / Deep tier criteria, and user-override syntax. Adapted to
+  workspace-and-project repo paths and framed **experimental** until
+  thresholds are validated against real PR data.
+- **Adversarial Specialist (Claude-only)** in `review-code`. Fresh-context
+  subagent dispatched at Standard and Deep tiers via `Agent`, with no
+  context from other specialists. Cross-model variant deliberately not
+  ported (see "Not adopted" below).
+- **`review-code` dual-mode + depth dispatch.** Pre-push mode (no arg)
+  diffs against the current repo's default branch; post-PR mode
+  (`<N>` or URL) diffs against the PR base. Specialists dispatched per
+  tier from `review_depth_classification.md`.
+- **`progress.md` persistence** in `review-code` and `triage-reviews`.
+  Both skills append a step entry to
+  `.agent/work-plans/issue-<N>/progress.md` in the issue's owning repo
+  so findings survive across sessions.
+- **`review-plan` flexible inputs.** Accepts `<pr-number>`, a path to a
+  plan file, or `--issue <N>` (resolved to
+  `.agent/work-plans/issue-<N>/plan.md`).
+
+## Not adopted
+
+- **Cross-Model Adversarial Specialist** (`.agent/scripts/cross_model_review.sh`,
+  Gemini/Codex/Copilot tmux dispatch). The workspace doesn't standardize
+  on multi-CLI review yet, and the tmux session machinery adds complexity
+  beyond the highest-leverage subset (Claude-only adversarial). Revisit
+  if multi-CLI review becomes a workflow we actually exercise.
 
 ## Deferred
 

--- a/.agent/knowledge/review_depth_classification.md
+++ b/.agent/knowledge/review_depth_classification.md
@@ -1,0 +1,206 @@
+# Review Depth Classification
+
+**Status: experimental.** Ported from `rolker/agent_workspace` in PR #453.
+The signal-to-tier table below has not yet been validated against real PR
+data in this workspace; thresholds and triggers are expected to churn.
+Promotion to ADR is reserved for after we accumulate enough real-PR
+evidence to commit to specific cut-points.
+
+## Context
+
+PR #448 surfaced a systemic failure mode: 13 review rounds with ~45
+Copilot findings, many of which were consequences of prior fixes that the
+existing specialists missed because their context carried forward across
+rounds. Two design responses, both ported from the fork:
+
+1. A **fresh-context Adversarial Specialist** that re-reads the diff cold.
+2. **Depth tiers** that scale specialist count and review effort to the
+   risk of the change, so small mechanical PRs aren't held up by a full
+   review battery and large/governance-touching PRs reliably get the
+   full set.
+
+This doc covers (2). The Adversarial Specialist itself lives in
+`review-code/SKILL.md` (sub-section 5d).
+
+## Current thinking
+
+### Risk Signals
+
+`review-code` collects these from `gh pr view <N>` output:
+
+| Signal | Source | How to measure |
+|--------|--------|----------------|
+| Lines changed | `additions + deletions` | Total lines added and removed |
+| File count | `files` array length | Number of files in the diff |
+| File types | File paths | Categorize each file (see below) |
+| Override triggers | File paths | Check against override-trigger lists below |
+| Tests included | File paths | Whether the diff includes files in `test/`, `tests/`, or named `test_*`, `*_test.*` — absence of tests for code changes is noted in the report but does not, on its own, change the tier |
+
+#### File type categories
+
+| Category | Examples |
+|----------|---------|
+| Code | `.py`, `.cpp`, `.hpp`, `.sh`, `.js`, `.ts` |
+| Config | `.yaml`, `.yml`, `.json`, `.toml`, `.xml` |
+| Documentation | `.md`, `.rst`, `.txt` |
+| Enforcement | See override-trigger list below |
+| Governance | See override-trigger list below |
+| Test | Files in `test/`, `tests/`, or named `test_*`, `*_test.*` |
+
+### Depth Tiers
+
+#### Light
+
+**Criteria**: All of the following:
+- < 50 changed lines (additions + deletions)
+- ≤ 3 files
+- No override-trigger files
+- No Deep promotion triggers
+
+**Specialists dispatched**:
+- Static Analysis only
+
+**Report format**: Condensed — static analysis findings plus a one-line
+governance note ("No governance concerns for a change of this scope").
+
+#### Standard
+
+**Criteria**: Any of the following (and no Deep triggers):
+- 50–199 changed lines
+- 4–9 files
+- Any override-trigger file present
+
+**Specialists dispatched**:
+- Static Analysis
+- Governance
+- Plan Drift
+- Adversarial (Claude, fresh context)
+
+**Report format**: Full report with all sections.
+
+#### Deep
+
+**Criteria**: Any of the following:
+- 200+ changed lines
+- 10+ files
+- Cross-layer changes (files in both workspace infrastructure and project
+  code in the same PR)
+- Any Deep promotion trigger
+
+**Specialists dispatched**:
+- Same as Standard. The Adversarial Specialist is already running at
+  Standard; Deep adds extra emphasis in the prompt (longer file horizon,
+  explicit security/concurrency/lifecycle checklist) but uses the same
+  fresh-context dispatch mechanism.
+
+**Report format**: Full report with all sections.
+
+> **Note on cross-model adversarial**: The fork runs a Cross-Model
+> Adversarial Specialist at Deep tier (`cross_model_review.sh` —
+> Gemini/Codex/Copilot via tmux). That dispatch is not adopted here (see
+> the "Not adopted" entry in `inspiration_agent_workspace_digest.md`).
+> When we want a second model's read on a Deep PR, run that agent's
+> review-code skill manually.
+
+## Override-Trigger Files
+
+These files have outsized impact relative to their size. Their presence in
+a diff bumps the review to **at least Standard**, regardless of line/file
+count. Lists are split by repo type because a layered workspace has both
+workspace-level and project-level governance and enforcement files.
+
+### Workspace-repo triggers
+
+**Enforcement** (mechanical rules — bypass causes silent drift):
+
+- `.github/workflows/*.yml` (CI)
+- `.pre-commit-config.yaml`
+- `.claude/settings.json`, `.claude/hooks/*`
+- `.repos` (workspace repo manifest)
+- `.agent/scripts/setup_layers.sh` (layer bootstrap)
+- `Makefile` (build/test orchestration)
+- `framework_config.sh` (agent identity defaults)
+
+**Governance** (rules people read and follow):
+
+- `AGENTS.md`, `CLAUDE.md`
+- `.github/copilot-instructions.md`
+- `.agent/instructions/*.md`
+- `docs/PRINCIPLES.md`
+- `docs/decisions/*.md` (ADRs)
+- `.claude/skills/*/SKILL.md` (skill definitions)
+- `.agent/knowledge/*.md` (knowledge docs, including this file)
+- `.agent/templates/*.md` (issue / package / plan templates)
+
+### Project-repo triggers
+
+For PRs in `layers/main/<layer>_ws/src/<project_repo>/`:
+
+- `.agents/README.md` (project orientation)
+- `.agents/review-context.yaml` (compact relevance map)
+- Project-level `PRINCIPLES.md`
+- Project-level `docs/decisions/*.md`
+- Project-level `.agent/work-plans/issue-*/plan.md` (rare — implementation
+  diff usually doesn't include the plan, but a plan-only change is
+  governance-adjacent)
+
+## Deep Promotion Triggers
+
+These signals always bump the review to **Deep**, regardless of other
+signals:
+
+- **Security-relevant changes**: authentication, authorization, permissions,
+  secrets handling, credential management, token storage, command
+  injection surface (any change to a script that takes user input and
+  shells out)
+- **Cross-layer changes**: files modified in both workspace infrastructure
+  (`.agent/`, `.claude/`, `docs/`, root configs) and project code
+  (`layers/main/*/src/`) in the same PR. Cross-layer is harder to review
+  because consequence analysis spans repos.
+- **ADR additions or substantive ADR rewrites**: a new file in
+  `docs/decisions/` or a non-status-bump edit to an existing ADR. Title
+  and "Last reviewed" tweaks don't trigger.
+
+## Tier Promotion Logic
+
+1. Start at Light.
+2. Walk the signals — if any signal meets Standard criteria, promote to
+   Standard.
+3. Walk the signals — if any signal meets Deep criteria (including the
+   Deep promotion triggers above), promote to Deep.
+4. The highest tier triggered wins. There is no mechanism to downgrade.
+
+## User Override
+
+Override automatic classification by appending a depth keyword to the
+`/review-code` invocation:
+
+- `/review-code 42 light` — force Light review
+- `/review-code 42 standard` — force Standard review
+- `/review-code 42 deep` — force Deep review
+
+User overrides take precedence over automatic classification. Useful for
+forcing thorough review on a small change that the author finds risky, or
+a quick review on a large but mechanical change (bulk renames, licence
+header additions).
+
+## Consequences
+
+- **Quality bar follows risk, not size alone.** A 10-line edit to
+  `AGENTS.md` triggers Standard; a 1500-line bulk-rename triggers Deep.
+  Authors should expect adversarial findings on governance edits, not just
+  on big diffs.
+- **`review-code` requires a one-line classification block in its report
+  header.** The tier and the primary signal that determined it are always
+  shown so authors can sanity-check (and override on the next run).
+- **The Adversarial Specialist activates at Standard** — meaning every
+  governance-touching PR gets a fresh-context second pass even if it's
+  small. This is the intended behaviour: governance edits have
+  out-of-proportion blast radius and benefit from a re-read cold.
+- **Trigger lists are workspace-specific.** Adding a new file pattern
+  (e.g., a new `.claude/` directory, a new ADR-equivalent doc) means
+  updating the trigger lists here so the depth classifier sees it.
+- **This doc is experimental.** When the thresholds prove themselves on
+  real PR data, promote the structural decision (depth tiers exist;
+  signals fire as listed) into an ADR. The numeric thresholds can stay in
+  this doc and tune as we learn.

--- a/.agent/knowledge/review_depth_classification.md
+++ b/.agent/knowledge/review_depth_classification.md
@@ -26,15 +26,23 @@ This doc covers (2). The Adversarial Specialist itself lives in
 
 ### Risk Signals
 
-`review-code` collects these from `gh pr view <N>` output:
+`review-code` collects the same set of signals in either mode, but the
+source path differs:
 
-| Signal | Source | How to measure |
-|--------|--------|----------------|
-| Lines changed | `additions + deletions` | Total lines added and removed |
-| File count | `files` array length | Number of files in the diff |
-| File types | File paths | Categorize each file (see below) |
-| Override triggers | File paths | Check against override-trigger lists below |
-| Tests included | File paths | Whether the diff includes files in `test/`, `tests/`, or named `test_*`, `*_test.*` — absence of tests for code changes is noted in the report but does not, on its own, change the tier |
+- **Post-PR mode** (`/review-code <N>` or URL): from `gh pr view <N>`
+  output — `additions`, `deletions`, `files` array, file paths.
+- **Pre-push mode** (`/review-code` with no PR argument): from the
+  local diff — `git diff origin/<base>...HEAD --numstat` (per-file
+  +/- counts) and `--stat` (totals), plus the file list from the
+  diff itself.
+
+| Signal | Post-PR source | Pre-push source | How to measure |
+|--------|----------------|-----------------|----------------|
+| Lines changed | `additions + deletions` from `gh pr view --json` | Sum of insertions+deletions from `git diff --numstat` (or `--stat`) | Total lines added and removed |
+| File count | Length of `files` array | Line count of `git diff --numstat` | Number of files in the diff |
+| File types | File paths from `files` array | File paths from `git diff --numstat` | Categorize each file (see below) |
+| Override triggers | Same file paths | Same file paths | Check against override-trigger lists below |
+| Tests included | Same file paths | Same file paths | Whether the diff includes files in `test/`, `tests/`, or named `test_*`, `*_test.*` — absence of tests for code changes is noted in the report but does not, on its own, change the tier |
 
 #### File type categories
 

--- a/.agent/knowledge/review_depth_classification.md
+++ b/.agent/knowledge/review_depth_classification.md
@@ -127,13 +127,15 @@ workspace-level and project-level governance and enforcement files.
 - `.repos` (workspace repo manifest)
 - `.agent/scripts/setup_layers.sh` (layer bootstrap)
 - `Makefile` (build/test orchestration)
-- `framework_config.sh` (agent identity defaults)
+- `.agent/scripts/framework_config.sh` (agent identity defaults)
 
 **Governance** (rules people read and follow):
 
 - `AGENTS.md`, `CLAUDE.md`
 - `.github/copilot-instructions.md`
+- `.github/instructions/*.md` (per-path Copilot review instructions)
 - `.agent/instructions/*.md`
+- `.agent/AGENT_ONBOARDING.md` (generic-agent onboarding)
 - `docs/PRINCIPLES.md`
 - `docs/decisions/*.md` (ADRs)
 - `.claude/skills/*/SKILL.md` (skill definitions)

--- a/.agent/knowledge/skill_workflows.md
+++ b/.agent/knowledge/skill_workflows.md
@@ -2,13 +2,21 @@
 
 ## Per-Issue Lifecycle
 
-The governance skills follow a sequence from idea exploration through pre-merge code review:
+The governance skills follow a sequence from idea exploration through
+post-PR review triage:
 
 ```
-brainstorm → review-issue → plan-task → review-plan → implement → review-code
+brainstorm → review-issue → plan-task → review-plan → implement
+          → review-code → push / open PR → triage-reviews
 ```
 
-Each step is optional — simple issues can skip straight to `plan-task` or implementation.
+Each step is optional — simple issues can skip straight to `plan-task`
+or implementation. `review-code` runs **before pushing** (pre-push mode,
+no arguments) so static-analysis, governance, plan-drift, and
+adversarial findings get caught while still cheap to fix locally; it
+also accepts a PR number / URL for post-PR review of someone else's
+work. `triage-reviews` runs after a PR has accumulated review comments
+(human + bot) and classifies each against the current code.
 
 ## Skill Index
 
@@ -19,8 +27,9 @@ Each step is optional — simple issues can skip straight to `plan-task` or impl
 | `brainstorm` | Before review-issue | Explore possibilities using research digests and project knowledge |
 | `review-issue` | Before plan-task | Evaluate issue scope, principle alignment, and ADR applicability |
 | `plan-task` | Before implementation | Generate a principles-aware work plan, commit to branch |
-| `review-plan` | After plan-task, before implementation | Independent evaluation of a committed work plan |
-| `review-code` | After implementation | Lead reviewer orchestrating specialist sub-reviews (static analysis, governance, plan drift) |
+| `review-plan` | After plan-task, before implementation | Independent evaluation of a committed work plan (accepts PR / file path / `--issue <N>`) |
+| `review-code` | Between implement and push / open PR (also post-PR for someone else's diff) | Lead reviewer orchestrating specialist sub-reviews (static analysis, governance, plan drift, adversarial). Pre-push mode is the default; depth tiers (Light / Standard / Deep) scale specialist count to change risk |
+| `triage-reviews` | After PR review comments arrive | Classifies each comment (human + bot) against current code, persists triage to `progress.md` |
 
 ### Utility skills (on-demand / periodic)
 

--- a/.agent/knowledge/skill_workflows.md
+++ b/.agent/knowledge/skill_workflows.md
@@ -10,10 +10,15 @@ brainstorm → review-issue → plan-task → review-plan → implement
           → review-code → push / open PR → triage-reviews
 ```
 
-Each step is optional — simple issues can skip straight to `plan-task`
-or implementation. `review-code` runs **before pushing** (pre-push mode,
-no arguments) so static-analysis, governance, plan-drift, and
-adversarial findings get caught while still cheap to fix locally; it
+Most steps are optional — simple issues can skip straight to
+`plan-task` or implementation. **`review-code` is the exception**:
+AGENTS.md Post-Task Verification step 5 makes a pre-push `review-code`
+pass an expected check before opening a PR (the framework adapters in
+`.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`,
+and `.agent/AGENT_ONBOARDING.md` mirror this for non-Claude runtimes
+with the Adversarial-Claude-only caveat). Pre-push mode (no
+arguments) catches static-analysis, governance, plan-drift, and
+Adversarial findings while still cheap to fix locally; `review-code`
 also accepts a PR number / URL for post-PR review of someone else's
 work. `triage-reviews` runs after a PR has accumulated review comments
 (human + bot) and classifies each against the current code.

--- a/.agent/work-plans/PLAN_ISSUE-452.md
+++ b/.agent/work-plans/PLAN_ISSUE-452.md
@@ -14,93 +14,126 @@ existing specialist reviewers causes them to carry forward assumptions from
 previous rounds — they don't re-read the whole diff cold.
 
 The fork `rolker/agent_workspace` has evolved four pieces that directly
-address this: a fresh-context **Adversarial Specialist**, **depth tiers**
-that auto-route to deeper review on risky diffs, **`progress.md`
-persistence** across sessions, and **flexible `review-plan` inputs**
-(file/issue, not only PR number). The `inspiration_agent_workspace_digest.md`
-was last refreshed 2026-03-23 (a month stale); the plan includes a
-refresh step before copying so we track what actually exists in the fork
-today, not a month-old snapshot.
+address this: a fresh-context **Adversarial Specialist** (Claude-only —
+relies on subagent dispatch), **depth tiers** that auto-route to deeper
+review on risky diffs, **`progress.md` persistence** across sessions, and
+**flexible `review-plan` inputs** (file/issue, not only PR number). The
+`inspiration_agent_workspace_digest.md` was last refreshed 2026-03-23 (a
+month stale) and the fork landed these recently — the plan includes a
+refresh step before copying, and treats the design as experimental.
 
-The scope also includes light-touch governance changes to make agents
-actually **run** `/review-code` before pushing — docs-only enforcement
-for now, composite `/ship` skill deferred to a follow-up issue per the
-review-issue findings.
+The scope also includes light-touch governance changes (docs-only
+enforcement) to make agents actually **run** `/review-code` before
+pushing. Composite `/ship` skill deferred to a follow-up issue per the
+review-issue findings. **This is explicitly a soft nudge against the
+"Enforcement over documentation" principle; the PR body will flag it
+as a known deferral.**
+
+A per-issue directory convention (`.agent/work-plans/issue-<N>/`) is
+introduced for new artifacts — plan, progress, review output,
+adversarial findings — without disturbing the 43 legacy flat plans.
+Symlinks bridge legacy plans into the new layout so consumer skills
+only look at one path.
 
 ## Approach
 
-One PR, three logical commit groups. Review-issue recommended this staging
-and warned scope is borderline — if group 1 alone runs long, we split.
+One PR, three logical commit groups. Scope is borderline — if group A
+alone approaches review-fatigue size, split B+C off as a follow-up.
 
-**Commit group A — review-code depth dispatch + Adversarial Specialist + persistence**
+**Commit group A — directory convention, depth dispatch, Adversarial Specialist, persistence**
 
-1. **Refresh the inspiration digest** — re-check the fork at current HEAD
-   and update `inspiration_agent_workspace_digest.md` before copying, so we
-   port what exists today rather than a 2026-03-23 snapshot.
-2. **Add `.agent/knowledge/review_depth_classification.md`** — in
-   ADR-style (Context / Decision / Consequences), documenting the signal
-   table (lines changed, file count, governance-touching paths like
-   `AGENTS.md` / `docs/decisions/` / `.claude/skills/`) and the thresholds
-   that trigger Light / Standard / Deep. Capture the *why* for the
-   thresholds, not just the *what* (per review-issue recommendation 3 and
-   the "Capture decisions" principle).
-3. **Update `review-code/SKILL.md`** to: (a) accept a depth argument
-   `--depth=light|standard|deep` and a pre-push mode selector, (b)
-   dispatch specialists by tier, (c) add the **Adversarial Specialist**
-   sub-section — a fresh-context subagent launched only at Deep tier with
-   no context from other specialists (via `Agent` with a dedicated
-   prompt), and (d) add the `progress.md` append step.
-4. **Dual-mode detection in `review-code`**: argument pattern determines
-   mode — `<number>` or URL → post-PR mode (diff against the PR base);
-   no arg or a branch name → pre-push mode (diff against
-   `origin/<base-branch>`). Document both modes and the detection logic
-   in the SKILL.
+1. **Refresh the inspiration digest** — re-check the fork at current
+   HEAD and update `inspiration_agent_workspace_digest.md` so we port
+   what exists today, not a 2026-03-23 snapshot.
+2. **Introduce per-issue directory convention.**
+   - New plans write to `.agent/work-plans/issue-<N>/plan.md`.
+   - Legacy flat plans (`PLAN_ISSUE-<N>.md`) stay where they are.
+   - Eager migration: create `.agent/work-plans/issue-<N>/plan.md` as
+     a symlink to `../PLAN_ISSUE-<N>.md` for every existing flat plan
+     (~43 files). Single mechanical commit.
+   - After this lands, every issue's plan is reachable at
+     `issue-<N>/plan.md` — skills never branch on legacy vs. new.
+   - Update `plan-task/SKILL.md` to write new plans nested.
+3. **Add `.agent/knowledge/review_depth_classification.md`** — structured
+   as Context / Current thinking / Consequences, leading with
+   **Status: experimental**. Names what we don't yet know (whether
+   thresholds produce the right tier on real PRs). Captures the signal
+   table in two columns: workspace-repo triggers (`AGENTS.md`,
+   `docs/decisions/`, `.claude/skills/`, `.repos`, `setup_layers.sh`,
+   `Makefile`, `framework_config.sh`) and project-repo triggers
+   (`.agents/README.md`, project `PRINCIPLES.md`, project `docs/decisions/`).
+   No ADR — fork landed this recently; we lack experience to commit to
+   ADR-level permanence.
+4. **Update `review-code/SKILL.md`:**
+   - Accept `--depth=light|standard|deep` override; auto-classify when
+     omitted using the signal table from step 3.
+   - Accept pre-push mode: `review-code` (no arg) diffs against the
+     current repo's default branch (`gh repo view --json defaultBranchRef`,
+     fall back to `main`); `--base <branch>` overrides. `review-code <N>`
+     or `<url>` is post-PR mode.
+   - Dispatch specialists by tier; **Adversarial Specialist** at Deep
+     only, launched via `Agent` as a fresh-context subagent with no
+     context from other specialists. Document that Adversarial is
+     **Claude-only** — structural limitation; other frameworks still
+     get depth dispatch + persistence.
+   - Document Adversarial's cross-repo limitation: fresh-context reviewer
+     reads only the diff, so it cannot catch cross-repo consequences in
+     the layered workspace. The Governance Specialist carries that load
+     via the consequences map.
+   - Append findings to `.agent/work-plans/issue-<N>/progress.md` in
+     the owning repo.
+5. **Repo-awareness pass.** The fork is single-repo; its skill text and
+   examples assume one `.agent/work-plans/`, one governance layer. Pass
+   over the ported text (review-code, triage-reviews, review-plan) and
+   generalize: "in the owning repo," repo-aware lookups, per-repo
+   governance paths.
 
 **Commit group B — triage-reviews persistence + review-plan input flex**
 
-5. **Update `triage-reviews/SKILL.md`** to append classification results
-   to the same per-issue `progress.md` (step placement: after step 6 /
-   "Classify and present plan"). Preserve the existing "Justify every
-   false positive" guidance — do not regress it.
-6. **Update `review-plan/SKILL.md`** to accept three input forms: PR
-   number (current), `--issue <N>` (find plan at
-   `.agent/work-plans/PLAN_ISSUE-<N>.md` in the current repo), or a file
-   path. Keep the PR-number path as the default.
+6. **Update `triage-reviews/SKILL.md`** to append classification results
+   to `.agent/work-plans/issue-<N>/progress.md` in the owning repo.
+   **Preserve "Justify every false positive"** — do not regress it when
+   reconciling with the fork's version.
+7. **Update `review-plan/SKILL.md`** to accept three input forms:
+   PR number (current), `--issue <N>` (find plan at the nested path in
+   the current repo; require `--repo <owner/repo>` for cross-repo),
+   or a file path. PR-number path stays default.
 
 **Commit group C — governance and adapter propagation**
 
-7. **Update `AGENTS.md`** Post-Task Verification section to add a "Before
-   opening a PR" bullet: *run `/review-code` against your diff; address
-   findings before pushing*.
-8. **Update `skill_workflows.md`** — insert `review-code` between
-   *implement* and *push/open-PR* in the per-issue lifecycle (today it's
-   positioned "After implementation" which conflates self-review with
-   post-PR review; the new framing supports both modes from step 4).
-9. **Update `plan-task/SKILL.md`** closing "Report to user" to mention
-   `/review-code` as the next step after implementation.
-10. **Propagate to framework adapters** (ADR-0006 + consequences map):
-    mirror the "run `/review-code` before pushing" expectation in
-    `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`,
-    and `.agent/AGENT_ONBOARDING.md`. If any adapter can't invoke the
-    skill the same way (e.g., Copilot review mode), document the
-    deliberate omission instead of silently skipping.
-11. **Mark ported pieces in `inspiration_agent_workspace_digest.md`** —
-    move the four pieces from tracked/pending into a "Ported" section
-    with the PR link, so `inspiration-tracker` doesn't re-flag them.
+8. **Update `AGENTS.md`** Post-Task Verification: add "Before opening a
+   PR" bullet — *run `/review-code` against your diff; address findings
+   before pushing*.
+9. **Update `skill_workflows.md`** — insert `review-code` between
+   *implement* and *push/open-PR* in the per-issue lifecycle.
+10. **Update `plan-task/SKILL.md`** closing "Report to user" to mention
+    `/review-code` as the next step after implementation.
+11. **Propagate to framework adapters** per ADR-0006 — one-line mirror +
+    cross-link to AGENTS.md in `.github/copilot-instructions.md`,
+    `.agent/instructions/gemini-cli.instructions.md`, and
+    `.agent/AGENT_ONBOARDING.md`. Note Adversarial is Claude-only.
+12. **Mark ported pieces in `inspiration_agent_workspace_digest.md`** —
+    move the four pieces into a "Ported" section with PR link.
+
+**Validation (smoke test, not CI):** run `/review-code 448 --depth=deep`
+and confirm (a) Adversarial fires, (b) progress.md is written at
+`.agent/work-plans/issue-448/progress.md`, (c) depth auto-classification
+on a medium PR lands on Standard.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `.agent/knowledge/inspiration_agent_workspace_digest.md` | Refresh to current fork HEAD (step 1); add Ported section (step 11) |
-| `.agent/knowledge/review_depth_classification.md` | **New** — ADR-style depth-tier design + signal table |
-| `.claude/skills/review-code/SKILL.md` | Depth arg, dual-mode detection, Adversarial Specialist, progress persistence |
-| `.claude/skills/triage-reviews/SKILL.md` | Progress persistence step; keep "Justify every false positive" |
+| `.agent/knowledge/inspiration_agent_workspace_digest.md` | Refresh at start (step 1); mark ported (step 12) |
+| `.agent/work-plans/issue-<N>/plan.md` × ~43 | **New** symlinks to legacy flat plans (step 2) |
+| `.agent/knowledge/review_depth_classification.md` | **New** — experimental, repo-aware signal table |
+| `.claude/skills/review-code/SKILL.md` | Depth arg, dual-mode detection, Adversarial (Claude-only), progress persistence |
+| `.claude/skills/triage-reviews/SKILL.md` | Progress persistence; preserve "Justify every false positive" |
 | `.claude/skills/review-plan/SKILL.md` | Accept PR number / `--issue <N>` / file path |
-| `.claude/skills/plan-task/SKILL.md` | Closing hint to run `/review-code` before push |
+| `.claude/skills/plan-task/SKILL.md` | Write nested; closing hint to run `/review-code` |
 | `AGENTS.md` | Post-Task Verification: "Before opening a PR" bullet |
 | `.agent/knowledge/skill_workflows.md` | Lifecycle: review-code between implement and push |
-| `.github/copilot-instructions.md` | Mirror AGENTS.md pre-push expectation (or documented omission) |
+| `.github/copilot-instructions.md` | Mirror AGENTS.md pre-push expectation + Adversarial-Claude-only note |
 | `.agent/instructions/gemini-cli.instructions.md` | Same |
 | `.agent/AGENT_ONBOARDING.md` | Same |
 
@@ -108,68 +141,58 @@ and warned scope is borderline — if group 1 alone runs long, we split.
 
 | Principle | Consideration |
 |---|---|
-| Only what's needed | Scope is explicit about what NOT to port (cross-model adversarial, git-bug fallback, plan-path migration, de-ROS config). Adversarial = highest-leverage subset. |
-| A change includes its consequences | Framework adapter propagation (ADR-0006) is in-scope (step 10). Inspiration digest update (step 11) prevents re-flagging. `skill_workflows.md` + `plan-task` closing hint propagate the lifecycle change. |
-| Enforcement over documentation | **Soft nudge only** — docs-only enforcement for the pre-push expectation. Acceptable incremental step; composite `/ship` skill is explicitly deferred to a follow-up issue. Flag in PR body as known deferral. |
-| Capture decisions, not just implementations | `review_depth_classification.md` structured as Context/Decision/Consequences so the *why* behind thresholds survives (review-issue rec 3). Full ADR-0010-style record deferred unless user prefers. |
-| Improve incrementally | Single scoped slice of the fork's review tooling, not the whole thing. |
-| Primary framework first | Adversarial Specialist uses Claude Code subagent dispatch. Adapters (Copilot/Gemini) get the lifecycle expectation, not the subagent mechanics. |
-| Test what breaks | Prose-heavy Markdown skills have no unit-testable surface. Validation is a smoke test: run `/review-code --depth=deep` on a recent PR and confirm Adversarial fires and `progress.md` is written. Not CI. |
+| Only what's needed | Explicit defer list respected (cross-model adversarial, git-bug fallback, de-ROS config). Adversarial = highest-leverage subset. |
+| A change includes its consequences | Adapter propagation (ADR-0006) in-scope (step 11). Digest refresh (step 1) and mark-ported (step 12) keep inspiration-tracker from re-flagging. Lifecycle update propagated through `skill_workflows.md` and `plan-task` closing hint. Symlink migration keeps legacy paths functional (no broken references). |
+| Enforcement over documentation | **Soft nudge only — flagged as known deferral.** Docs-only enforcement of pre-push `/review-code`. Composite `/ship` is the planned next enforcement layer; PR body calls this out explicitly so the deferral is visible, not silent. |
+| Capture decisions, not just implementations | `review_depth_classification.md` documents the *why* for thresholds. Framed experimental — thresholds expected to churn until we have data. Promotion to ADR reserved for when the structure stabilizes. |
+| Improve incrementally | Single scoped slice of the fork's review tooling. Directory convention introduced without disturbing legacy plans. |
+| Primary framework first | Adversarial Specialist uses Claude Code subagent dispatch — full primary-framework capability. Adapters document the limitation rather than hobble the primary tool. |
+| Test what breaks | Prose skills; validation is smoke-test on PR #448 (the motivating case). No CI surface. |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| 0001 Adopt ADRs | Yes | `review_depth_classification.md` uses Context/Decision/Consequences structure. A separate short ADR is an alternative — see Open Questions. |
-| 0002 Worktree isolation | Yes | Plan is being committed from `.workspace-worktrees/issue-workspace-452`. |
-| 0003 Project-agnostic | Yes | Adversarial Specialist prompt stays generic — no references to specific layers, packages, or domain concepts. |
-| 0004/0005 Enforcement hierarchy | Watch | Docs-only enforcement is the explicit Phase-1 choice. PR body flags this as a deferral; `/ship` composite is the planned next layer. |
-| 0006 Shared AGENTS.md | Yes | Step 10 propagates the AGENTS.md change to Copilot, Gemini, and AGENT_ONBOARDING adapters. |
+| 0001 Adopt ADRs | No | Depth-tier design intentionally not promoted to ADR while experimental. Revisit after real PR data. |
+| 0002 Worktree isolation | Yes | Plan committed from `.workspace-worktrees/issue-workspace-452`. |
+| 0003 Project-agnostic | Yes | Adversarial prompt stays generic; no layer-specific or package-specific references. Repo-awareness pass (step 5) ensures skill text generalizes. |
+| 0004/0005 Enforcement hierarchy | Watch | Docs-only enforcement for pre-push expectation — explicit Phase-1 deferral, flagged in PR body. |
+| 0006 Shared AGENTS.md | Yes | Step 11 propagates to adapters. |
+| 0007 Retain Make | No | No Makefile changes. |
 | 0008 ROS 2 conventions | N/A | No ROS package code touched. |
 
 ## Consequences
 
 | If we change... | Also update... | Included in plan? |
 |---|---|---|
-| `AGENTS.md` | Framework adapters (copilot, gemini-cli, AGENT_ONBOARDING) | **Yes** — step 10 |
-| A framework skill (`.claude/skills/`) | That framework's adapter file | **Yes** — adapters list review-code/triage-reviews/review-plan already; no name changes so no skill-list edit needed, but verify during step 10 |
-| `plan-task` / `review-code` / `triage-reviews` / `review-plan` | `skill_workflows.md` if lifecycle position changes | **Yes** — step 8 |
-| `.agent/knowledge/inspiration_agent_workspace_digest.md` | None — the digest is tracked only by inspiration-tracker skill runs | **Yes** — steps 1 and 11 |
+| `AGENTS.md` | Framework adapters (copilot, gemini-cli, AGENT_ONBOARDING) | **Yes** — step 11 |
+| `plan-task` / `review-code` / `triage-reviews` / `review-plan` | `skill_workflows.md` if lifecycle position changes | **Yes** — step 9 |
+| Plan file layout | Consumer skills that look up plans | **Yes** — symlink migration (step 2) keeps all plans reachable at one path; skills updated in steps 4, 6, 7 |
+| `.agent/knowledge/inspiration_agent_workspace_digest.md` | — (digest is tracked only by inspiration-tracker) | **Yes** — steps 1 and 12 |
 
 ## Open Questions
 
-1. **`progress.md` placement — flat or nested?** Review-issue recommended
-   flat (`.agent/work-plans/PROGRESS_ISSUE-<N>.md`) to stay consistent
-   with the deferred plan-path migration (`PLAN_ISSUE-<N>.md` → nested
-   is tracked separately and out of scope). Plan defaults to flat unless
-   user prefers nested. **Recommend: flat.**
-2. **Depth-tier override keyword syntax.** Options:
-   (a) `/review-code <N> --depth=deep` — extends existing
-   `<pr-number-or-url>` signature cleanly; `--depth=light|standard|deep`.
-   (b) inline magic keyword. **Recommend: (a)** for discoverability.
-3. **Is depth-tier design significant enough for its own ADR?**
-   Review-issue flagged this as a real decision. Alternatives: (i)
-   Context/Decision/Consequences inline in
-   `review_depth_classification.md` (lighter, plan default); (ii) new
-   ADR-0011 that references the knowledge doc for the signal table. If
-   you want ADR-level permanence, we add (ii). **Recommend: (i)** —
-   keep the knowledge doc as the decision record; promote to ADR only
-   if thresholds become contentious.
-4. **Pre-push mode diff base detection.** In post-PR mode the base is
-   the PR base branch. In pre-push mode, we infer base from:
-   `gh repo view --json defaultBranchRef` → fall back to `main`. Is
-   this acceptable, or should pre-push mode require an explicit
-   `--base <branch>` argument? **Recommend: inferred with override
-   flag available.**
-5. **AGENT_ONBOARDING / Copilot propagation depth.** Should the adapter
-   files each get the full pre-push expectation, or a cross-link to
-   AGENTS.md? ADR-0006 says adapters are thin wrappers — leaning
-   toward a brief one-line mention + cross-link rather than full
-   duplication. **Recommend: one-line + cross-link.**
+All resolved during discussion:
+
+1. **Directory convention** → legacy flat plans stay as-is; all new
+   artifacts nest under `.agent/work-plans/issue-<N>/`; eager symlink
+   migration bridges legacy plans so skills only check one path.
+2. **Depth override syntax** → `/review-code <N> --depth=light|standard|deep`.
+3. **ADR vs knowledge doc** → knowledge doc, experimental framing. No
+   ADR until thresholds stabilize with real-PR data.
+4. **Pre-push mode base detection** → inferred from default branch
+   with `--base <branch>` override.
+5. **Adapter propagation depth** → one-line mirror + cross-link to
+   AGENTS.md; adapters note Adversarial is Claude-only.
 
 ## Estimated Scope
 
-**Single PR, staged commits** (A / B / C groups above). Borderline per
-review-issue — if commit group A alone approaches review-fatigue size,
-split B + C off as a follow-up PR against a base branch that includes
-A. No project-repo code touched. Entirely workspace-level.
+**Single PR, staged commits** (A / B / C). Borderline per review-issue.
+If commit group A alone runs long, split B+C off as a follow-up PR
+against a base branch that includes A. No project-repo code touched.
+Entirely workspace-level.
+
+## Implementation Notes
+
+_Rationale for design pivots that aren't obvious from the diffs alone;
+add one-liners here as implementation proceeds. Empty at plan time._

--- a/.agent/work-plans/PLAN_ISSUE-452.md
+++ b/.agent/work-plans/PLAN_ISSUE-452.md
@@ -1,0 +1,175 @@
+# Plan: Port review-skill improvements from agent_workspace + encourage use
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/452
+
+## Context
+
+PR #448 surfaced a systemic failure mode in the current review tooling: 13
+review rounds, ~45 Copilot findings, many of which were **consequences of
+prior fixes** (a round-7 rename broke inbound anchors caught in round 11;
+round-6 path arithmetic flagged in round 9). The shared context of the
+existing specialist reviewers causes them to carry forward assumptions from
+previous rounds — they don't re-read the whole diff cold.
+
+The fork `rolker/agent_workspace` has evolved four pieces that directly
+address this: a fresh-context **Adversarial Specialist**, **depth tiers**
+that auto-route to deeper review on risky diffs, **`progress.md`
+persistence** across sessions, and **flexible `review-plan` inputs**
+(file/issue, not only PR number). The `inspiration_agent_workspace_digest.md`
+was last refreshed 2026-03-23 (a month stale); the plan includes a
+refresh step before copying so we track what actually exists in the fork
+today, not a month-old snapshot.
+
+The scope also includes light-touch governance changes to make agents
+actually **run** `/review-code` before pushing — docs-only enforcement
+for now, composite `/ship` skill deferred to a follow-up issue per the
+review-issue findings.
+
+## Approach
+
+One PR, three logical commit groups. Review-issue recommended this staging
+and warned scope is borderline — if group 1 alone runs long, we split.
+
+**Commit group A — review-code depth dispatch + Adversarial Specialist + persistence**
+
+1. **Refresh the inspiration digest** — re-check the fork at current HEAD
+   and update `inspiration_agent_workspace_digest.md` before copying, so we
+   port what exists today rather than a 2026-03-23 snapshot.
+2. **Add `.agent/knowledge/review_depth_classification.md`** — in
+   ADR-style (Context / Decision / Consequences), documenting the signal
+   table (lines changed, file count, governance-touching paths like
+   `AGENTS.md` / `docs/decisions/` / `.claude/skills/`) and the thresholds
+   that trigger Light / Standard / Deep. Capture the *why* for the
+   thresholds, not just the *what* (per review-issue recommendation 3 and
+   the "Capture decisions" principle).
+3. **Update `review-code/SKILL.md`** to: (a) accept a depth argument
+   `--depth=light|standard|deep` and a pre-push mode selector, (b)
+   dispatch specialists by tier, (c) add the **Adversarial Specialist**
+   sub-section — a fresh-context subagent launched only at Deep tier with
+   no context from other specialists (via `Agent` with a dedicated
+   prompt), and (d) add the `progress.md` append step.
+4. **Dual-mode detection in `review-code`**: argument pattern determines
+   mode — `<number>` or URL → post-PR mode (diff against the PR base);
+   no arg or a branch name → pre-push mode (diff against
+   `origin/<base-branch>`). Document both modes and the detection logic
+   in the SKILL.
+
+**Commit group B — triage-reviews persistence + review-plan input flex**
+
+5. **Update `triage-reviews/SKILL.md`** to append classification results
+   to the same per-issue `progress.md` (step placement: after step 6 /
+   "Classify and present plan"). Preserve the existing "Justify every
+   false positive" guidance — do not regress it.
+6. **Update `review-plan/SKILL.md`** to accept three input forms: PR
+   number (current), `--issue <N>` (find plan at
+   `.agent/work-plans/PLAN_ISSUE-<N>.md` in the current repo), or a file
+   path. Keep the PR-number path as the default.
+
+**Commit group C — governance and adapter propagation**
+
+7. **Update `AGENTS.md`** Post-Task Verification section to add a "Before
+   opening a PR" bullet: *run `/review-code` against your diff; address
+   findings before pushing*.
+8. **Update `skill_workflows.md`** — insert `review-code` between
+   *implement* and *push/open-PR* in the per-issue lifecycle (today it's
+   positioned "After implementation" which conflates self-review with
+   post-PR review; the new framing supports both modes from step 4).
+9. **Update `plan-task/SKILL.md`** closing "Report to user" to mention
+   `/review-code` as the next step after implementation.
+10. **Propagate to framework adapters** (ADR-0006 + consequences map):
+    mirror the "run `/review-code` before pushing" expectation in
+    `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`,
+    and `.agent/AGENT_ONBOARDING.md`. If any adapter can't invoke the
+    skill the same way (e.g., Copilot review mode), document the
+    deliberate omission instead of silently skipping.
+11. **Mark ported pieces in `inspiration_agent_workspace_digest.md`** —
+    move the four pieces from tracked/pending into a "Ported" section
+    with the PR link, so `inspiration-tracker` doesn't re-flag them.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/knowledge/inspiration_agent_workspace_digest.md` | Refresh to current fork HEAD (step 1); add Ported section (step 11) |
+| `.agent/knowledge/review_depth_classification.md` | **New** — ADR-style depth-tier design + signal table |
+| `.claude/skills/review-code/SKILL.md` | Depth arg, dual-mode detection, Adversarial Specialist, progress persistence |
+| `.claude/skills/triage-reviews/SKILL.md` | Progress persistence step; keep "Justify every false positive" |
+| `.claude/skills/review-plan/SKILL.md` | Accept PR number / `--issue <N>` / file path |
+| `.claude/skills/plan-task/SKILL.md` | Closing hint to run `/review-code` before push |
+| `AGENTS.md` | Post-Task Verification: "Before opening a PR" bullet |
+| `.agent/knowledge/skill_workflows.md` | Lifecycle: review-code between implement and push |
+| `.github/copilot-instructions.md` | Mirror AGENTS.md pre-push expectation (or documented omission) |
+| `.agent/instructions/gemini-cli.instructions.md` | Same |
+| `.agent/AGENT_ONBOARDING.md` | Same |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Only what's needed | Scope is explicit about what NOT to port (cross-model adversarial, git-bug fallback, plan-path migration, de-ROS config). Adversarial = highest-leverage subset. |
+| A change includes its consequences | Framework adapter propagation (ADR-0006) is in-scope (step 10). Inspiration digest update (step 11) prevents re-flagging. `skill_workflows.md` + `plan-task` closing hint propagate the lifecycle change. |
+| Enforcement over documentation | **Soft nudge only** — docs-only enforcement for the pre-push expectation. Acceptable incremental step; composite `/ship` skill is explicitly deferred to a follow-up issue. Flag in PR body as known deferral. |
+| Capture decisions, not just implementations | `review_depth_classification.md` structured as Context/Decision/Consequences so the *why* behind thresholds survives (review-issue rec 3). Full ADR-0010-style record deferred unless user prefers. |
+| Improve incrementally | Single scoped slice of the fork's review tooling, not the whole thing. |
+| Primary framework first | Adversarial Specialist uses Claude Code subagent dispatch. Adapters (Copilot/Gemini) get the lifecycle expectation, not the subagent mechanics. |
+| Test what breaks | Prose-heavy Markdown skills have no unit-testable surface. Validation is a smoke test: run `/review-code --depth=deep` on a recent PR and confirm Adversarial fires and `progress.md` is written. Not CI. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0001 Adopt ADRs | Yes | `review_depth_classification.md` uses Context/Decision/Consequences structure. A separate short ADR is an alternative — see Open Questions. |
+| 0002 Worktree isolation | Yes | Plan is being committed from `.workspace-worktrees/issue-workspace-452`. |
+| 0003 Project-agnostic | Yes | Adversarial Specialist prompt stays generic — no references to specific layers, packages, or domain concepts. |
+| 0004/0005 Enforcement hierarchy | Watch | Docs-only enforcement is the explicit Phase-1 choice. PR body flags this as a deferral; `/ship` composite is the planned next layer. |
+| 0006 Shared AGENTS.md | Yes | Step 10 propagates the AGENTS.md change to Copilot, Gemini, and AGENT_ONBOARDING adapters. |
+| 0008 ROS 2 conventions | N/A | No ROS package code touched. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `AGENTS.md` | Framework adapters (copilot, gemini-cli, AGENT_ONBOARDING) | **Yes** — step 10 |
+| A framework skill (`.claude/skills/`) | That framework's adapter file | **Yes** — adapters list review-code/triage-reviews/review-plan already; no name changes so no skill-list edit needed, but verify during step 10 |
+| `plan-task` / `review-code` / `triage-reviews` / `review-plan` | `skill_workflows.md` if lifecycle position changes | **Yes** — step 8 |
+| `.agent/knowledge/inspiration_agent_workspace_digest.md` | None — the digest is tracked only by inspiration-tracker skill runs | **Yes** — steps 1 and 11 |
+
+## Open Questions
+
+1. **`progress.md` placement — flat or nested?** Review-issue recommended
+   flat (`.agent/work-plans/PROGRESS_ISSUE-<N>.md`) to stay consistent
+   with the deferred plan-path migration (`PLAN_ISSUE-<N>.md` → nested
+   is tracked separately and out of scope). Plan defaults to flat unless
+   user prefers nested. **Recommend: flat.**
+2. **Depth-tier override keyword syntax.** Options:
+   (a) `/review-code <N> --depth=deep` — extends existing
+   `<pr-number-or-url>` signature cleanly; `--depth=light|standard|deep`.
+   (b) inline magic keyword. **Recommend: (a)** for discoverability.
+3. **Is depth-tier design significant enough for its own ADR?**
+   Review-issue flagged this as a real decision. Alternatives: (i)
+   Context/Decision/Consequences inline in
+   `review_depth_classification.md` (lighter, plan default); (ii) new
+   ADR-0011 that references the knowledge doc for the signal table. If
+   you want ADR-level permanence, we add (ii). **Recommend: (i)** —
+   keep the knowledge doc as the decision record; promote to ADR only
+   if thresholds become contentious.
+4. **Pre-push mode diff base detection.** In post-PR mode the base is
+   the PR base branch. In pre-push mode, we infer base from:
+   `gh repo view --json defaultBranchRef` → fall back to `main`. Is
+   this acceptable, or should pre-push mode require an explicit
+   `--base <branch>` argument? **Recommend: inferred with override
+   flag available.**
+5. **AGENT_ONBOARDING / Copilot propagation depth.** Should the adapter
+   files each get the full pre-push expectation, or a cross-link to
+   AGENTS.md? ADR-0006 says adapters are thin wrappers — leaning
+   toward a brief one-line mention + cross-link rather than full
+   duplication. **Recommend: one-line + cross-link.**
+
+## Estimated Scope
+
+**Single PR, staged commits** (A / B / C groups above). Borderline per
+review-issue — if commit group A alone approaches review-fatigue size,
+split B + C off as a follow-up PR against a base branch that includes
+A. No project-repo code touched. Entirely workspace-level.

--- a/.agent/work-plans/PLAN_ISSUE-452.md
+++ b/.agent/work-plans/PLAN_ISSUE-452.md
@@ -65,17 +65,21 @@ alone approaches review-fatigue size, split B+C off as a follow-up.
    No ADR — fork landed this recently; we lack experience to commit to
    ADR-level permanence.
 4. **Update `review-code/SKILL.md`:**
-   - Accept `--depth=light|standard|deep` override; auto-classify when
-     omitted using the signal table from step 3.
+   - Accept positional `[light|standard|deep]` depth override (matches
+     the fork verbatim); auto-classify when omitted using the signal
+     table from step 3.
    - Accept pre-push mode: `review-code` (no arg) diffs against the
      current repo's default branch (`gh repo view --json defaultBranchRef`,
      fall back to `main`); `--base <branch>` overrides. `review-code <N>`
      or `<url>` is post-PR mode.
-   - Dispatch specialists by tier; **Adversarial Specialist** at Deep
-     only, launched via `Agent` as a fresh-context subagent with no
-     context from other specialists. Document that Adversarial is
-     **Claude-only** — structural limitation; other frameworks still
-     get depth dispatch + persistence.
+   - Dispatch specialists by tier; **Adversarial Specialist** activates
+     at **Standard + Deep** (Standard prompt covers edge cases /
+     assumptions / subtle bugs / logic; Deep prompt adds security /
+     concurrency / cross-cutting effects), launched via `Agent` as a
+     fresh-context subagent with no context from other specialists.
+     Document that Adversarial is **Claude-only** — structural
+     limitation; other frameworks still get depth dispatch +
+     persistence.
    - Document Adversarial's cross-repo limitation: fresh-context reviewer
      reads only the diff, so it cannot catch cross-repo consequences in
      the layered workspace. The Governance Specialist carries that load

--- a/.agent/work-plans/PLAN_ISSUE-452.md
+++ b/.agent/work-plans/PLAN_ISSUE-452.md
@@ -119,10 +119,14 @@ alone approaches review-fatigue size, split B+C off as a follow-up.
 12. **Mark ported pieces in `inspiration_agent_workspace_digest.md`** —
     move the four pieces into a "Ported" section with PR link.
 
-**Validation (smoke test, not CI):** run `/review-code 448 --depth=deep`
-and confirm (a) Adversarial fires, (b) progress.md is written at
-`.agent/work-plans/issue-448/progress.md`, (c) depth auto-classification
-on a medium PR lands on Standard.
+**Validation (smoke test, not CI):** pick a recent PR whose `Closes
+#<N>` reference is unambiguous (some PRs like #448 close *multiple*
+issues; the smoke test should not assume PR # equals issue #). Run
+`/review-code <pr-num> deep` and confirm (a) Adversarial fires, (b)
+`review-code` resolves the linked issue via `closingIssuesReferences`
+(not by grepping the PR body) and writes progress.md at
+`.agent/work-plans/issue-<linked-N>/progress.md` in the issue's owning
+repo, (c) depth auto-classification on a medium PR lands on Standard.
 
 ## Files to Change
 
@@ -212,7 +216,8 @@ Entirely workspace-level.
   generalizing single-repo language is most cleanly done while
   porting each section. No standalone commit for step 5.
 - **Smoke-test validation deferred to post-merge.** The plan's
-  validation checklist (`/review-code 448 --depth=deep` confirming
-  Adversarial fires, progress.md is written, medium PR lands on
-  Standard) can only be run after this PR merges and the new SKILL
-  is loadable. Will be exercised as part of the next real PR review.
+  validation checklist (Adversarial fires, `closingIssuesReferences`
+  resolution writes progress.md to the right `issue-<N>/` directory,
+  medium PR lands on Standard) can only be run after this PR merges
+  and the new SKILL is loadable. Will be exercised as part of the
+  next real PR review.

--- a/.agent/work-plans/PLAN_ISSUE-452.md
+++ b/.agent/work-plans/PLAN_ISSUE-452.md
@@ -194,5 +194,21 @@ Entirely workspace-level.
 
 ## Implementation Notes
 
-_Rationale for design pivots that aren't obvious from the diffs alone;
-add one-liners here as implementation proceeds. Empty at plan time._
+- **Branch caught up to main before implementation.** Branch was 32
+  commits behind main when implementation began (had been sitting
+  since plan revision on 2026-04-24). Merged `origin/main` in cleanly
+  with no conflicts before starting commit group A.
+- **Steps 1 (digest refresh) and 11 (mark ported) bundled** into a
+  single commit since both touch
+  `inspiration_agent_workspace_digest.md` and the natural rhythm is
+  to write the file once. The PR taken as a whole leaves the digest
+  consistent with merged reality at merge time.
+- **Step 5 (repo-awareness pass) folded inline** into the SKILL.md
+  updates for steps 4 / 6 / 7 rather than a separate sweep, since
+  generalizing single-repo language is most cleanly done while
+  porting each section. No standalone commit for step 5.
+- **Smoke-test validation deferred to post-merge.** The plan's
+  validation checklist (`/review-code 448 --depth=deep` confirming
+  Adversarial fires, progress.md is written, medium PR lands on
+  Standard) can only be run after this PR merges and the new SKILL
+  is loadable. Will be exercised as part of the next real PR review.

--- a/.agent/work-plans/PLAN_ISSUE-452.md
+++ b/.agent/work-plans/PLAN_ISSUE-452.md
@@ -185,7 +185,7 @@ All resolved during discussion:
 1. **Directory convention** → legacy flat plans stay as-is; all new
    artifacts nest under `.agent/work-plans/issue-<N>/`; eager symlink
    migration bridges legacy plans so skills only check one path.
-2. **Depth override syntax** → `/review-code <N> --depth=light|standard|deep`.
+2. **Depth override syntax** → `/review-code <N> light|standard|deep` (positional).
 3. **ADR vs knowledge doc** → knowledge doc, experimental framing. No
    ADR until thresholds stabilize with real-PR data.
 4. **Pre-push mode base detection** → inferred from default branch

--- a/.agent/work-plans/README.md
+++ b/.agent/work-plans/README.md
@@ -17,10 +17,10 @@ Work plans make agent work-in-progress visible on GitHub through draft PRs. Each
 
 1. Create worktree: `.agent/scripts/worktree_create.sh --issue <N> --type workspace`
 2. Enter worktree: `source .agent/scripts/worktree_enter.sh --issue <N>`
-3. Create plan: write `.agent/work-plans/PLAN_ISSUE-<N>.md`
+3. Create plan directory and plan: `mkdir .agent/work-plans/issue-<N> && write .agent/work-plans/issue-<N>/plan.md`
 4. Commit: `git add .agent/work-plans/ && git commit -m "Add work plan for #<N>"`
 5. Push: `git push -u origin HEAD`
-6. Create draft PR: `gh pr create --draft --title "..." --body-file .agent/work-plans/PLAN_ISSUE-<N>.md`
+6. Create draft PR: `gh pr create --draft --title "..." --body-file .agent/work-plans/issue-<N>/plan.md`
 
 ### Updating Plans
 
@@ -32,7 +32,7 @@ As work progresses, update the plan to:
 
 Commit plan updates regularly:
 ```bash
-git add .agent/work-plans/PLAN_ISSUE-<number>.md
+git add .agent/work-plans/issue-<number>/plan.md
 git commit -m "Update work plan for #<number>"
 git push
 ```
@@ -45,10 +45,22 @@ git push
 4. **Context**: Reviewers see approach before reviewing code
 5. **History**: Plans are versioned alongside code changes
 
-## File Naming Convention
+## Directory Layout
 
-- Format: `PLAN_ISSUE-{number}.md`
-- Example: `PLAN_ISSUE-69.md` for issue #69
+Each issue gets its own subdirectory: `.agent/work-plans/issue-<N>/`. The
+plan itself is `issue-<N>/plan.md`. Other per-issue artifacts (progress
+logs, review output, adversarial findings) live alongside it under the
+same directory — one folder per issue, regardless of how many artifacts
+accumulate.
+
+- Format: `issue-<number>/plan.md`
+- Example: `issue-69/plan.md` for issue #69
+
+**Legacy flat plans**: Plans created before the directory convention
+landed remain at `.agent/work-plans/PLAN_ISSUE-<N>.md`. Each one has a
+matching symlink at `issue-<N>/plan.md` so consumer skills can always
+look up plans at the new path. The flat files are the canonical
+storage; the symlinks are the access path.
 
 One plan per issue. Keep plans concise but complete.
 
@@ -85,4 +97,4 @@ The workflow is the same — the only difference is which repo you're committing
 
 - `.agent/templates/ISSUE_PLAN.md` - Plan template
 - `.agent/WORKFORCE_PROTOCOL.md` - Multi-agent coordination
-- `.agent/work-plans/PLAN_ISSUE-69.md` - Example plan
+- `.agent/work-plans/issue-69/plan.md` - Example plan

--- a/.agent/work-plans/README.md
+++ b/.agent/work-plans/README.md
@@ -56,11 +56,17 @@ accumulate.
 - Format: `issue-<number>/plan.md`
 - Example: `issue-69/plan.md` for issue #69
 
+**Authoritative path for agents**: Create, update, and reference plans
+at `.agent/work-plans/issue-<N>/plan.md`. Any older instructions that
+mention only the flat `PLAN_ISSUE-<N>.md` convention should be treated
+as legacy / deprecated guidance, not the current workflow.
+
 **Legacy flat plans**: Plans created before the directory convention
-landed remain at `.agent/work-plans/PLAN_ISSUE-<N>.md`. Each one has a
-matching symlink at `issue-<N>/plan.md` so consumer skills can always
-look up plans at the new path. The flat files are the canonical
-storage; the symlinks are the access path.
+landed remain at `.agent/work-plans/PLAN_ISSUE-<N>.md` for
+compatibility. Each one has a matching symlink at `issue-<N>/plan.md`
+so consumer skills can always look up plans at the new path. The flat
+files are the canonical on-disk storage; the symlinks are the access
+path.
 
 One plan per issue. Keep plans concise but complete.
 

--- a/.agent/work-plans/README.md
+++ b/.agent/work-plans/README.md
@@ -17,7 +17,10 @@ Work plans make agent work-in-progress visible on GitHub through draft PRs. Each
 
 1. Create worktree: `.agent/scripts/worktree_create.sh --issue <N> --type workspace`
 2. Enter worktree: `source .agent/scripts/worktree_enter.sh --issue <N>`
-3. Create plan directory and plan: `mkdir -p .agent/work-plans/issue-<N> && write .agent/work-plans/issue-<N>/plan.md`
+3. Create the plan directory: `mkdir -p .agent/work-plans/issue-<N>`
+   Then author `plan.md` inside it using your editor or your agent's
+   file-write tool. (`write` is a Unix messaging command, not a
+   file-creation command — don't shell-execute it.)
 4. Commit: `git add .agent/work-plans/ && git commit -m "Add work plan for #<N>"`
 5. Push: `git push -u origin HEAD`
 6. Create draft PR: `gh pr create --draft --title "..." --body-file .agent/work-plans/issue-<N>/plan.md`

--- a/.agent/work-plans/README.md
+++ b/.agent/work-plans/README.md
@@ -17,7 +17,7 @@ Work plans make agent work-in-progress visible on GitHub through draft PRs. Each
 
 1. Create worktree: `.agent/scripts/worktree_create.sh --issue <N> --type workspace`
 2. Enter worktree: `source .agent/scripts/worktree_enter.sh --issue <N>`
-3. Create plan directory and plan: `mkdir .agent/work-plans/issue-<N> && write .agent/work-plans/issue-<N>/plan.md`
+3. Create plan directory and plan: `mkdir -p .agent/work-plans/issue-<N> && write .agent/work-plans/issue-<N>/plan.md`
 4. Commit: `git add .agent/work-plans/ && git commit -m "Add work plan for #<N>"`
 5. Push: `git push -u origin HEAD`
 6. Create draft PR: `gh pr create --draft --title "..." --body-file .agent/work-plans/issue-<N>/plan.md`

--- a/.agent/work-plans/issue-212/plan.md
+++ b/.agent/work-plans/issue-212/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-212.md

--- a/.agent/work-plans/issue-215/plan.md
+++ b/.agent/work-plans/issue-215/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-215.md

--- a/.agent/work-plans/issue-225/plan.md
+++ b/.agent/work-plans/issue-225/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-225.md

--- a/.agent/work-plans/issue-230/plan.md
+++ b/.agent/work-plans/issue-230/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-230.md

--- a/.agent/work-plans/issue-272/plan.md
+++ b/.agent/work-plans/issue-272/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-272.md

--- a/.agent/work-plans/issue-284/plan.md
+++ b/.agent/work-plans/issue-284/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-284.md

--- a/.agent/work-plans/issue-302/plan.md
+++ b/.agent/work-plans/issue-302/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-302.md

--- a/.agent/work-plans/issue-303/plan.md
+++ b/.agent/work-plans/issue-303/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-303.md

--- a/.agent/work-plans/issue-304/plan.md
+++ b/.agent/work-plans/issue-304/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-304.md

--- a/.agent/work-plans/issue-305/plan.md
+++ b/.agent/work-plans/issue-305/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-305.md

--- a/.agent/work-plans/issue-308/plan.md
+++ b/.agent/work-plans/issue-308/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-308.md

--- a/.agent/work-plans/issue-310/plan.md
+++ b/.agent/work-plans/issue-310/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-310.md

--- a/.agent/work-plans/issue-315/plan.md
+++ b/.agent/work-plans/issue-315/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-315.md

--- a/.agent/work-plans/issue-320/plan.md
+++ b/.agent/work-plans/issue-320/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-320.md

--- a/.agent/work-plans/issue-322/plan.md
+++ b/.agent/work-plans/issue-322/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-322.md

--- a/.agent/work-plans/issue-324/plan.md
+++ b/.agent/work-plans/issue-324/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-324.md

--- a/.agent/work-plans/issue-325/plan.md
+++ b/.agent/work-plans/issue-325/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-325.md

--- a/.agent/work-plans/issue-332/plan.md
+++ b/.agent/work-plans/issue-332/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-332.md

--- a/.agent/work-plans/issue-336/plan.md
+++ b/.agent/work-plans/issue-336/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-336.md

--- a/.agent/work-plans/issue-343/plan.md
+++ b/.agent/work-plans/issue-343/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-343.md

--- a/.agent/work-plans/issue-347/plan.md
+++ b/.agent/work-plans/issue-347/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-347.md

--- a/.agent/work-plans/issue-349/plan.md
+++ b/.agent/work-plans/issue-349/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-349.md

--- a/.agent/work-plans/issue-352/plan.md
+++ b/.agent/work-plans/issue-352/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-352.md

--- a/.agent/work-plans/issue-356/plan.md
+++ b/.agent/work-plans/issue-356/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-356.md

--- a/.agent/work-plans/issue-364/plan.md
+++ b/.agent/work-plans/issue-364/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-364.md

--- a/.agent/work-plans/issue-366/plan.md
+++ b/.agent/work-plans/issue-366/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-366.md

--- a/.agent/work-plans/issue-367/plan.md
+++ b/.agent/work-plans/issue-367/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-367.md

--- a/.agent/work-plans/issue-370/plan.md
+++ b/.agent/work-plans/issue-370/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-370.md

--- a/.agent/work-plans/issue-376/plan.md
+++ b/.agent/work-plans/issue-376/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-376.md

--- a/.agent/work-plans/issue-381/plan.md
+++ b/.agent/work-plans/issue-381/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-381.md

--- a/.agent/work-plans/issue-384/plan.md
+++ b/.agent/work-plans/issue-384/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-384.md

--- a/.agent/work-plans/issue-386/plan.md
+++ b/.agent/work-plans/issue-386/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-386.md

--- a/.agent/work-plans/issue-391/plan.md
+++ b/.agent/work-plans/issue-391/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-391.md

--- a/.agent/work-plans/issue-393/plan.md
+++ b/.agent/work-plans/issue-393/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-393.md

--- a/.agent/work-plans/issue-396/plan.md
+++ b/.agent/work-plans/issue-396/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-396.md

--- a/.agent/work-plans/issue-418/plan.md
+++ b/.agent/work-plans/issue-418/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-418.md

--- a/.agent/work-plans/issue-422/plan.md
+++ b/.agent/work-plans/issue-422/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-422.md

--- a/.agent/work-plans/issue-425/plan.md
+++ b/.agent/work-plans/issue-425/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-425.md

--- a/.agent/work-plans/issue-432/plan.md
+++ b/.agent/work-plans/issue-432/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-432.md

--- a/.agent/work-plans/issue-449/plan.md
+++ b/.agent/work-plans/issue-449/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-449.md

--- a/.agent/work-plans/issue-452/plan.md
+++ b/.agent/work-plans/issue-452/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-452.md

--- a/.agent/work-plans/issue-452/progress.md
+++ b/.agent/work-plans/issue-452/progress.md
@@ -13,9 +13,9 @@ issue: 452
 **CI**: all-pass (Lint × 2, Validate Documentation × 2)
 
 ### Actions
-- [ ] Fix `<branch-name>` ambiguity in `.claude/skills/review-code/SKILL.md` Usage block (line 16) — either drop the form or document the non-numeric-arg → `--base` mapping (R4-1)
-- [ ] Make pre-push default-branch resolution prefer local `git symbolic-ref refs/remotes/origin/HEAD` over `gh repo view` for field-mode / non-`main` defaults (`.claude/skills/review-code/SKILL.md:91`) (R4-2)
-- [ ] Change `mkdir .agent/work-plans/issue-<N>` to `mkdir -p ...` in `.agent/work-plans/README.md:20` for idempotency (R4-3)
-- [ ] Replace `grep -oE '#[0-9]+' | head -1` linked-issue resolution in `.claude/skills/review-plan/SKILL.md:56` with `gh pr view --json closingIssuesReferences` (matches review-code's round-2 fix) (R4-4)
-- [ ] Update `.agent/work-plans/PLAN_ISSUE-452.md:188` Open Questions entry — strip `--depth=` (the positional form is the final interface) (R4-5)
-- [ ] Decide: keep branch-name extraction in `.claude/skills/triage-reviews/SKILL.md:195` (worktree-aligned, what progress.md location follows), or switch to `closingIssuesReferences` (PR-aligned, may decouple from worktree)? (R4-6)
+- [x] Dropped ambiguous `<branch-name>` Usage form from `.claude/skills/review-code/SKILL.md` (R4-1, commit 33c3be0)
+- [x] Default-branch resolution prefers local `git symbolic-ref refs/remotes/origin/HEAD` (R4-2, commit 3bc9d63)
+- [x] Changed `mkdir` → `mkdir -p` in `.agent/work-plans/README.md` workflow snippet (R4-3, commit 8c5433d)
+- [x] `review-plan` PR-number path uses `closingIssuesReferences` (R4-4, commit 3623c41)
+- [x] Stripped stale `--depth=` from PLAN Open Questions (R4-5, commit a02b180)
+- [x] R4-6 resolved Option A + fail-loud: documented branch-name extraction in `triage-reviews` as deliberate (worktree-aligned, local-first); added explicit error when branch name doesn't match pattern instead of silent fallback (commit 767a53e)

--- a/.agent/work-plans/issue-452/progress.md
+++ b/.agent/work-plans/issue-452/progress.md
@@ -19,3 +19,31 @@ issue: 452
 - [x] `review-plan` PR-number path uses `closingIssuesReferences` (R4-4, commit 3623c41)
 - [x] Stripped stale `--depth=` from PLAN Open Questions (R4-5, commit a02b180)
 - [x] R4-6 resolved Option A + fail-loud: documented branch-name extraction in `triage-reviews` as deliberate (worktree-aligned, local-first); added explicit error when branch name doesn't match pattern instead of silent fallback (commit 767a53e)
+
+## External Review (Round 5–6)
+**Status**: complete
+**When**: 2026-05-15 19:10
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #453 — 2 new review round(s) since b7013e9, 14 new valid, 1 addressed by prior commit (R5-7), 0 false positives, 2 minor Copilot hallucinations noted
+**CI**: all-pass
+
+### Actions
+- [ ] Fix `git symbolic-ref | sed` pipefail bug at `.claude/skills/review-code/SKILL.md:95` — pipeline exits with sed's status, so when `git symbolic-ref` fails the fallback chain is silently skipped and `DEFAULT_BRANCH` becomes empty. Use `REMOTE_HEAD=$(git symbolic-ref ...) && echo "${REMOTE_HEAD#refs/remotes/origin/}"` instead (R5-1 / R6-1)
+- [ ] Fix layer-worktree plan lookup in `.claude/skills/review-plan/SKILL.md:87` — current glob `layers/worktrees/*/issue-*-<N>/.agent/work-plans/...` misses project-repo plans which live at `<layer>_ws/src/<project_repo>/.agent/work-plans/...` (R5-2)
+- [ ] Add `[--repo <owner/repo>]` to `gh pr view` / `gh issue view` examples in `.claude/skills/review-plan/SKILL.md:53,60,104` — `--repo` is advertised but examples don't show its use (R5-3)
+- [ ] Add PR-less variant of no-findings template in `.claude/skills/review-plan/SKILL.md:220-225` — currently uses `## Plan Review: PR #<N>` header which is wrong for `--issue`/file-path modes (R5-4)
+- [ ] Replace `write .agent/work-plans/.../plan.md` in `.agent/work-plans/README.md:20` — `write` is a Unix messaging command, not a file-creation command. Rewrite step 3 to separate `mkdir -p` from "create plan.md using your editor/Write tool" (R5-5)
+- [ ] Narrow `applies_to` in `.github/instructions/work-plans.instructions.md:5` from `.agent/work-plans/**` to plan files specifically, OR rewrite prose to distinguish plan files from companion artifacts (progress.md, review output, adversarial findings) (R5-6 / R6-5)
+- [ ] Disambiguate `<#N>` placeholder in `.claude/skills/review-code/SKILL.md:504` template — currently same `<N>` used for issue path and PR ref. Use `<#PR-or-branch>` or split into separate placeholders (R5-8)
+- [ ] Fix `framework_config.sh` path in `.agent/knowledge/review_depth_classification.md:130` — should be `.agent/scripts/framework_config.sh` to match actual location and other entries' path conventions (R5-9)
+- [ ] Update `.agent/knowledge/skill_workflows.md:13` — "Each step is optional" contradicts AGENTS.md Post-Task Verification step 5 which makes `/review-code` expected pre-push. Qualify or restructure (R5-10)
+- [ ] Resolve fail-loud contradiction in `.claude/skills/triage-reviews/SKILL.md`: line 210-220 says fail loud on branch-name mismatch, line 268-270 (preexisting) says skip persistence silently. Pick one. Per local-first direction, fail-loud wins — delete or rewrite the skip-persistence text (R6-2)
+- [ ] Add `.github/instructions/*.md` and `.agent/AGENT_ONBOARDING.md` to workspace governance trigger list in `.agent/knowledge/review_depth_classification.md` (R6-3)
+- [ ] Remove "and adversarial" from `.github/copilot-instructions.md:27` — pre-push pass cannot catch Adversarial findings because Adversarial is Claude-only (per caveat at line 36) (R6-4)
+- [ ] Reword "offline plan review" in `.claude/skills/review-plan/SKILL.md:28` to "PR-less plan review" — `gh issue view` is still called in step 2, so it's not truly offline. Either reword, or add offline fallback using plan's embedded issue context (R6-6)
+
+### Notes
+- R5-7 (progress.md unchecked items) was self-resolving — commit b7013e9 ticked them off before this round's review-fetch could see it. Already addressed.
+- R6-1 claims the symbolic-ref|sed bug also appears at lines 143 and 232 of review-code/SKILL.md, but those lines contain unrelated code (`gh pr view` and "Dispatch specialists" prose). Treat as Copilot hallucination of additional locations; only line 95 needs the fix.
+- R5-5 claims the `write` issue "also appears on line 33" but line 33 is the `git add ...` block which doesn't reference `write`. Same partial-hallucination pattern.

--- a/.agent/work-plans/issue-452/progress.md
+++ b/.agent/work-plans/issue-452/progress.md
@@ -29,19 +29,19 @@ issue: 452
 **CI**: all-pass
 
 ### Actions
-- [ ] Fix `git symbolic-ref | sed` pipefail bug at `.claude/skills/review-code/SKILL.md:95` — pipeline exits with sed's status, so when `git symbolic-ref` fails the fallback chain is silently skipped and `DEFAULT_BRANCH` becomes empty. Use `REMOTE_HEAD=$(git symbolic-ref ...) && echo "${REMOTE_HEAD#refs/remotes/origin/}"` instead (R5-1 / R6-1)
-- [ ] Fix layer-worktree plan lookup in `.claude/skills/review-plan/SKILL.md:87` — current glob `layers/worktrees/*/issue-*-<N>/.agent/work-plans/...` misses project-repo plans which live at `<layer>_ws/src/<project_repo>/.agent/work-plans/...` (R5-2)
-- [ ] Add `[--repo <owner/repo>]` to `gh pr view` / `gh issue view` examples in `.claude/skills/review-plan/SKILL.md:53,60,104` — `--repo` is advertised but examples don't show its use (R5-3)
-- [ ] Add PR-less variant of no-findings template in `.claude/skills/review-plan/SKILL.md:220-225` — currently uses `## Plan Review: PR #<N>` header which is wrong for `--issue`/file-path modes (R5-4)
-- [ ] Replace `write .agent/work-plans/.../plan.md` in `.agent/work-plans/README.md:20` — `write` is a Unix messaging command, not a file-creation command. Rewrite step 3 to separate `mkdir -p` from "create plan.md using your editor/Write tool" (R5-5)
-- [ ] Narrow `applies_to` in `.github/instructions/work-plans.instructions.md:5` from `.agent/work-plans/**` to plan files specifically, OR rewrite prose to distinguish plan files from companion artifacts (progress.md, review output, adversarial findings) (R5-6 / R6-5)
-- [ ] Disambiguate `<#N>` placeholder in `.claude/skills/review-code/SKILL.md:504` template — currently same `<N>` used for issue path and PR ref. Use `<#PR-or-branch>` or split into separate placeholders (R5-8)
-- [ ] Fix `framework_config.sh` path in `.agent/knowledge/review_depth_classification.md:130` — should be `.agent/scripts/framework_config.sh` to match actual location and other entries' path conventions (R5-9)
-- [ ] Update `.agent/knowledge/skill_workflows.md:13` — "Each step is optional" contradicts AGENTS.md Post-Task Verification step 5 which makes `/review-code` expected pre-push. Qualify or restructure (R5-10)
-- [ ] Resolve fail-loud contradiction in `.claude/skills/triage-reviews/SKILL.md`: line 210-220 says fail loud on branch-name mismatch, line 268-270 (preexisting) says skip persistence silently. Pick one. Per local-first direction, fail-loud wins — delete or rewrite the skip-persistence text (R6-2)
-- [ ] Add `.github/instructions/*.md` and `.agent/AGENT_ONBOARDING.md` to workspace governance trigger list in `.agent/knowledge/review_depth_classification.md` (R6-3)
-- [ ] Remove "and adversarial" from `.github/copilot-instructions.md:27` — pre-push pass cannot catch Adversarial findings because Adversarial is Claude-only (per caveat at line 36) (R6-4)
-- [ ] Reword "offline plan review" in `.claude/skills/review-plan/SKILL.md:28` to "PR-less plan review" — `gh issue view` is still called in step 2, so it's not truly offline. Either reword, or add offline fallback using plan's embedded issue context (R6-6)
+- [x] Fixed `git symbolic-ref | sed` pipefail bug at `.claude/skills/review-code/SKILL.md:95` (R5-1 / R6-1, commit 469ade8)
+- [x] Fixed layer-worktree plan lookup glob in `.claude/skills/review-plan/SKILL.md` (R5-2, commit ade3f45)
+- [x] Added `[--repo <owner/repo>]` to gh examples in `.claude/skills/review-plan/SKILL.md` (R5-3, commit ade3f45)
+- [x] Added PR-less variant of no-findings template in `.claude/skills/review-plan/SKILL.md` (R5-4, commit ade3f45)
+- [x] Rewrote `.agent/work-plans/README.md` plan-creation step — removed `write` non-command (R5-5, commit bc2d1d1)
+- [x] Narrowed `applies_to` in `.github/instructions/work-plans.instructions.md` to plan files only; rewrote prose to exclude companion artifacts (R5-6 / R6-5, commit 3f81087)
+- [x] Disambiguated PR/Branch placeholders in `.claude/skills/review-code/SKILL.md` progress template (R5-8, commit 4266a65)
+- [x] Fixed `framework_config.sh` path in `.agent/knowledge/review_depth_classification.md` (R5-9, commit 2b2b873)
+- [x] Updated `.agent/knowledge/skill_workflows.md` — review-code is the exception to "each step is optional" (R5-10, commit db21056)
+- [x] Resolved fail-loud contradiction in `.claude/skills/triage-reviews/SKILL.md` — fail-loud wins per local-first decision (R6-2, commit c049048)
+- [x] Added `.github/instructions/*.md` and `.agent/AGENT_ONBOARDING.md` to workspace governance trigger list (R6-3, commit 2b2b873)
+- [x] Removed "and adversarial" claim from `.github/copilot-instructions.md` pre-push paragraph (R6-4, commit 1bdc093)
+- [x] Reworded "offline plan review" to "PR-less plan review" in `.claude/skills/review-plan/SKILL.md` (R6-6, commit ade3f45)
 
 ### Notes
 - R5-7 (progress.md unchecked items) was self-resolving — commit b7013e9 ticked them off before this round's review-fetch could see it. Already addressed.

--- a/.agent/work-plans/issue-452/progress.md
+++ b/.agent/work-plans/issue-452/progress.md
@@ -1,0 +1,21 @@
+---
+issue: 452
+---
+
+# Issue #452 — Port review-skill improvements from agent_workspace + encourage use
+
+## External Review
+**Status**: complete
+**When**: 2026-05-15 17:30
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #453 — 4 review round(s), 5 valid, 1 needs discussion, 14 false positives / already addressed
+**CI**: all-pass (Lint × 2, Validate Documentation × 2)
+
+### Actions
+- [ ] Fix `<branch-name>` ambiguity in `.claude/skills/review-code/SKILL.md` Usage block (line 16) — either drop the form or document the non-numeric-arg → `--base` mapping (R4-1)
+- [ ] Make pre-push default-branch resolution prefer local `git symbolic-ref refs/remotes/origin/HEAD` over `gh repo view` for field-mode / non-`main` defaults (`.claude/skills/review-code/SKILL.md:91`) (R4-2)
+- [ ] Change `mkdir .agent/work-plans/issue-<N>` to `mkdir -p ...` in `.agent/work-plans/README.md:20` for idempotency (R4-3)
+- [ ] Replace `grep -oE '#[0-9]+' | head -1` linked-issue resolution in `.claude/skills/review-plan/SKILL.md:56` with `gh pr view --json closingIssuesReferences` (matches review-code's round-2 fix) (R4-4)
+- [ ] Update `.agent/work-plans/PLAN_ISSUE-452.md:188` Open Questions entry — strip `--depth=` (the positional form is the final interface) (R4-5)
+- [ ] Decide: keep branch-name extraction in `.claude/skills/triage-reviews/SKILL.md:195` (worktree-aligned, what progress.md location follows), or switch to `closingIssuesReferences` (PR-aligned, may decouple from worktree)? (R4-6)

--- a/.agent/work-plans/issue-457/plan.md
+++ b/.agent/work-plans/issue-457/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-457.md

--- a/.agent/work-plans/issue-69/plan.md
+++ b/.agent/work-plans/issue-69/plan.md
@@ -1,0 +1,1 @@
+../PLAN_ISSUE-69.md

--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -84,8 +84,10 @@ If a worktree for the issue already exists, just enter it.
 
 ### 5. Generate the plan
 
-Write a plan to `.agent/work-plans/PLAN_ISSUE-<N>.md` (relative to the current
-repo — workspace repo for workspace issues, project repo for project issues):
+Write a plan to `.agent/work-plans/issue-<N>/plan.md` (relative to the
+current repo — workspace repo for workspace issues, project repo for
+project issues). Create the `issue-<N>/` directory first if it doesn't
+exist:
 
 ```markdown
 # Plan: <issue-title>
@@ -143,7 +145,9 @@ repo — workspace repo for workspace issues, project repo for project issues):
 The plan file path is relative to the current repo (workspace or project):
 
 ```bash
-git add .agent/work-plans/PLAN_ISSUE-<N>.md
+mkdir -p .agent/work-plans/issue-<N>
+# (write plan to .agent/work-plans/issue-<N>/plan.md)
+git add .agent/work-plans/issue-<N>/
 git commit -m "Add work plan for #<N>
 
 <one-line summary of the approach>"
@@ -168,7 +172,7 @@ EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json url --jq '.[0].url // "
 # Build PR body: prepend Closes reference, then plan content
 BODY_FILE=$(mktemp /tmp/gh_body.XXXXXX.md)
 printf 'Closes #<N>\n\n' > "$BODY_FILE"
-cat .agent/work-plans/PLAN_ISSUE-<N>.md >> "$BODY_FILE"
+cat .agent/work-plans/issue-<N>/plan.md >> "$BODY_FILE"
 
 if [ -n "$EXISTING_PR" ]; then
     # Update existing PR title and body

--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -193,6 +193,10 @@ Summarize:
 - Link to the draft PR
 - Pointer to the "During implementation" section below, so the
   implementer knows to keep the plan in sync with landed code
+- Reminder that `/review-code` (pre-push mode) is the next step after
+  the implementation is complete and before pushing — it catches
+  static-analysis / governance / plan-drift / adversarial findings
+  while they're still cheap to fix locally
 
 ## During implementation
 

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -85,13 +85,25 @@ Examples:
 #### Pre-push mode
 
 ```bash
-# Repo root and default branch
+# Repo root and base branch — start from the default, override if
+# the invocation included `--base <branch>`.
 REPO_ROOT=$(git rev-parse --show-toplevel)
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+# USER_BASE is set by the caller when `--base <branch>` is parsed off
+# the argument list; otherwise it's empty and the default applies.
 BASE="${USER_BASE:-$DEFAULT_BRANCH}"
 
-# Make sure base is current
-git fetch origin "$BASE" --quiet
+# Try to refresh the base from the remote. Tolerate offline / no-remote
+# cases — fetch failure isn't fatal; we'll use whatever local
+# `origin/$BASE` ref exists.
+if ! git fetch origin "$BASE" --quiet 2>/dev/null; then
+    if git rev-parse --verify "origin/$BASE" &>/dev/null; then
+        echo "⚠️  Could not fetch origin/$BASE; reviewing against the local copy (may be stale)." >&2
+    else
+        echo "Error: no local origin/$BASE ref and fetch failed. Pass --base <branch> or run online." >&2
+        exit 1
+    fi
+fi
 
 # Diff and stats
 git diff "origin/$BASE...HEAD" --stat
@@ -103,9 +115,14 @@ BRANCH=$(git branch --show-current)
 ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+|ISSUE-[0-9]+' | grep -oE '[0-9]+' | head -1)
 ```
 
-If `gh repo view` fails (no GitHub remote, offline), fall back to `main`
-and proceed. If no issue number can be extracted from the branch name,
-note "no linked issue" in the report header — the review still runs but
+`--base <branch>` is parsed from the argument list before the snippet
+runs and exposed as `USER_BASE`. If `gh repo view` fails (no GitHub
+remote, offline) the default falls back to `main`. If `git fetch` then
+also fails and no local `origin/$BASE` ref exists, the snippet stops
+with an error rather than silently diffing against nothing.
+
+If no issue number can be extracted from the branch name, note "no
+linked issue" in the report header — the review still runs but
 plan-drift and progress.md persistence are skipped.
 
 #### Post-PR mode

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -128,14 +128,21 @@ plan-drift and progress.md persistence are skipped.
 #### Post-PR mode
 
 ```bash
-# PR metadata
-gh pr view <N> --json title,body,baseRefName,headRefName,headRefOid,files,additions,deletions,url,comments,reviews
+# PR metadata (includes the parsed list of closing-issue references)
+gh pr view <N> --json title,body,baseRefName,headRefName,headRefOid,files,additions,deletions,url,comments,reviews,closingIssuesReferences
 
 # Full diff
 gh pr diff <N>
 
-# Linked issue (from "Closes #<N>" in PR body)
-gh pr view <N> --json body --jq '.body' | grep -oE '#[0-9]+' | head -1
+# Primary closing-linked issue. Use `closingIssuesReferences` (parsed
+# by GitHub from `Closes #N` / `Fixes #N` / `Resolves #N` keywords) —
+# do NOT just grep `#[0-9]+` from the body. PRs often mention many
+# issue numbers (cross-references, context); only closing-references
+# represent the issue this PR is actually completing. If a PR has
+# multiple closing references, use the first; if none, treat as no
+# linked issue (review still runs, but plan-drift and progress.md
+# persistence are skipped).
+ISSUE_NUM=$(gh pr view <N> --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // empty')
 ```
 
 In both modes, identify:

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -62,12 +62,25 @@ post comments or modify the PR unless the user asks.
 
 ### 1. Detect mode and gather diff context
 
-Determine pre-push vs post-PR mode from the argument:
+Determine pre-push vs post-PR mode from the arguments. Parse out the
+optional depth keyword first (`light` / `standard` / `deep` — positional,
+matching the Usage block above), then classify what remains:
 
-- No arg, or `--base <branch>` → **pre-push mode**
-- Argument is a number or `https://github.com/.../pull/<N>` → **post-PR mode**
-- Argument starts with `--depth=` → strip and re-evaluate (depth applies
-  in either mode)
+- Empty, or only `--base <branch>` → **pre-push mode**
+- A number or `https://github.com/.../pull/<N>` → **post-PR mode**
+
+The depth keyword is positional and may appear after the PR number /
+URL or after `--base <branch>`. The same syntax applies in both modes.
+Examples:
+
+```
+/review-code                       # pre-push, auto-classify
+/review-code deep                  # pre-push, force Deep
+/review-code --base develop        # pre-push, override base
+/review-code --base develop deep   # pre-push with override + force Deep
+/review-code 42                    # post-PR, auto-classify
+/review-code 42 standard           # post-PR, force Standard
+```
 
 #### Pre-push mode
 

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-code
-description: Lead reviewer that orchestrates specialist sub-reviews (static analysis, governance, plan drift) to evaluate a PR. Produces a unified structured report.
+description: Lead reviewer that orchestrates specialist sub-reviews (static analysis, governance, plan drift, adversarial) to evaluate a PR or pre-push diff. Scales review depth to change risk. Produces a unified structured report and persists findings to progress.md.
 ---
 
 # Review Code
@@ -8,71 +8,162 @@ description: Lead reviewer that orchestrates specialist sub-reviews (static anal
 ## Usage
 
 ```
-/review-code <pr-number-or-url>
+/review-code                                # pre-push: diff vs default branch
+/review-code --base <branch>                # pre-push, override default base
+/review-code <pr-number>                    # post-PR: diff vs PR base
+/review-code <pr-url>                       # post-PR
+/review-code <pr-number> [light|standard|deep]   # post-PR with depth override
+/review-code <branch-name>                  # pre-push, force a base override
 ```
+
+The optional depth keyword (`light` / `standard` / `deep`) overrides
+automatic classification.
 
 ## Overview
 
-**Lifecycle position**: review-issue → plan-task → review-plan → implement → **review-code**
+**Lifecycle position**: review-issue → plan-task → review-plan →
+implement → **review-code** → push / open PR → triage-reviews
 
-Multi-specialist code review system. A lead reviewer gathers context, dispatches
-specialist sub-reviews in parallel, collects findings, deduplicates, applies a
-silence filter, and produces a unified report. Does not post comments or modify
-the PR unless the user asks.
+Multi-specialist code review system. A lead reviewer gathers context,
+classifies review depth based on change risk, dispatches specialist
+sub-reviews in parallel, collects findings, deduplicates, applies a
+silence filter, produces a unified report, and appends a step entry to
+the issue's `progress.md` so findings persist across sessions. Does not
+post comments or modify the PR unless the user asks.
 
-**Specialists** (Phase 1):
-- **Static Analysis** — runs linters with ament-aligned configs on changed files
-- **Governance** — evaluates against principles, ADRs, and consequences
-- **Plan Drift** — compares implementation against the work plan (if one exists)
+**Two modes**:
+- **Pre-push** (default, no arg) — diffs against the current repo's
+  default branch. Run before `git push` / opening a PR to catch findings
+  while still locally fixable. No PR-side context (comments, PR body)
+  available.
+- **Post-PR** (`<N>` or URL) — diffs against the PR base branch via
+  `gh pr view`. Includes PR-side context: existing comments, linked
+  issue, plan file referenced in PR body.
+
+**Depth tiers** (see `.agent/knowledge/review_depth_classification.md`):
+- **Light** — Static Analysis only (small, low-risk changes)
+- **Standard** — Static Analysis + Governance + Plan Drift + Claude
+  Adversarial (medium changes or governance-touching files)
+- **Deep** — Same as Standard with Adversarial primed for security /
+  concurrency / lifecycle (large changes, security, or cross-layer)
+
+**Specialists**:
+- **Static Analysis** — runs linters with ament-aligned configs on
+  changed files
+- **Governance** — evaluates against principles, ADRs, and the
+  consequences map
+- **Plan Drift** — compares implementation against the work plan (if one
+  exists)
+- **Adversarial** — fresh-context Claude subagent that re-reads the diff
+  cold (Standard + Deep). Cross-model adversarial is **not** wired in
+  here; see `inspiration_agent_workspace_digest.md` "Not adopted".
 
 ## Steps
 
-### 1. Gather PR context
+### 1. Detect mode and gather diff context
+
+Determine pre-push vs post-PR mode from the argument:
+
+- No arg, or `--base <branch>` → **pre-push mode**
+- Argument is a number or `https://github.com/.../pull/<N>` → **post-PR mode**
+- Argument starts with `--depth=` → strip and re-evaluate (depth applies
+  in either mode)
+
+#### Pre-push mode
+
+```bash
+# Repo root and default branch
+REPO_ROOT=$(git rev-parse --show-toplevel)
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+BASE="${USER_BASE:-$DEFAULT_BRANCH}"
+
+# Make sure base is current
+git fetch origin "$BASE" --quiet
+
+# Diff and stats
+git diff "origin/$BASE...HEAD" --stat
+git diff "origin/$BASE...HEAD"
+git diff "origin/$BASE...HEAD" --numstat   # per-file +/- counts
+
+# Linked issue from branch name (feature/issue-<N> or feature/ISSUE-<N>-...)
+BRANCH=$(git branch --show-current)
+ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+|ISSUE-[0-9]+' | grep -oE '[0-9]+' | head -1)
+```
+
+If `gh repo view` fails (no GitHub remote, offline), fall back to `main`
+and proceed. If no issue number can be extracted from the branch name,
+note "no linked issue" in the report header — the review still runs but
+plan-drift and progress.md persistence are skipped.
+
+#### Post-PR mode
 
 ```bash
 # PR metadata
-gh pr view <N> --json title,body,baseRefName,headRefName,files,additions,deletions,url,comments,reviews
+gh pr view <N> --json title,body,baseRefName,headRefName,headRefOid,files,additions,deletions,url,comments,reviews
 
 # Full diff
 gh pr diff <N>
 
-# Linked issue
-gh pr view <N> --json body --jq '.body' | grep -o '#[0-9]*'
+# Linked issue (from "Closes #<N>" in PR body)
+gh pr view <N> --json body --jq '.body' | grep -oE '#[0-9]+' | head -1
 ```
 
-Identify:
-- What repo the PR targets (workspace or project repo?)
+In both modes, identify:
+- What repo the diff lives in (workspace or project repo?)
 - What files changed and in which directories
-- The linked issue and its requirements
-- Whether a work plan exists (`.agent/work-plans/PLAN_ISSUE-*.md` in the PR's target repo)
+- The linked issue and its requirements (when resolvable)
+- Whether a work plan exists at `.agent/work-plans/issue-<N>/plan.md` in
+  the repo that owns the issue
 
-Read the **full content** of each changed file (not just the diff hunks) to
-understand surrounding context.
+Read the **full content** of each changed file (not just the diff hunks)
+to understand surrounding context.
 
-### 2. Load project context
+### 2. Classify review depth
+
+Load `.agent/knowledge/review_depth_classification.md` and apply the risk
+signals from step 1:
+
+1. Count total lines changed (additions + deletions).
+2. Count files changed.
+3. Check file paths against the workspace-repo and project-repo override
+   trigger lists.
+4. Check Deep promotion triggers (security-relevant, cross-layer, ADR add
+   or substantive ADR rewrite).
+5. Apply tier promotion logic — highest tier wins.
+
+**User override**: If the `/review-code` invocation includes a depth
+keyword (`light`, `standard`, or `deep`), use that tier instead of the
+automatic classification.
+
+Record the tier and the primary signal that determined it for the report
+header.
+
+### 3. Load project context
 
 For project repo PRs:
-- Read `.agents/README.md` for architecture overview, key files, cross-layer
-  dependencies, and pitfalls
-- Check for `.agents/review-context.yaml` — if present, use it for the compact
-  relevance map (packages, topics, dependencies)
+- Read `.agents/README.md` for architecture overview, key files,
+  cross-layer dependencies, and pitfalls.
+- Check for `.agents/review-context.yaml` — if present, use it for the
+  compact relevance map (packages, topics, dependencies).
 - **Staleness check**: If `review-context.yaml` exists, compare its
-  `context_generated_from_sha` field against the current HEAD of the project
-  repo. If they differ, include a warning in the report header:
+  `context_generated_from_sha` field against the current HEAD of the
+  project repo. If they differ, include a warning in the report header:
 
   > ⚠ Review context is stale (generated from `<sha>`; repo HEAD is `<sha>`).
   > Consider running `/gather-project-knowledge` to refresh.
 
-  If `review-context.yaml` does not exist, note this in the report header:
+  If `review-context.yaml` does not exist, note this in the report
+  header:
 
   > ℹ No review-context.yaml found. Review proceeds with .agents/README.md only.
 
-- Read project `PRINCIPLES.md` if it exists
-- Check `.agent/project_knowledge/` symlink for workspace-level project summaries
+- Read project `PRINCIPLES.md` if it exists.
+- Check `.agent/project_knowledge/` symlink for workspace-level project
+  summaries.
 
-### 3. Classify changed files
+### 4. Classify changed files for static analysis
 
-Determine the review profile for each changed file:
+Determine the linter profile for each changed file:
 
 | File location | Language detection | Linter config profile |
 |---|---|---|
@@ -82,29 +173,61 @@ Determine the review profile for each changed file:
 | `.agent/scripts/*.sh` | Shell | workspace (shellcheck --severity=warning) |
 | `*.yaml`, `*.yml` | YAML | yamllint (max-line-length=120) |
 | `*.xml`, `*.launch.xml` | XML | xmllint |
+| `*.md` | Markdown | (no linter — content review only) |
 
 See `.agent/knowledge/review_static_analysis.md` for full tool configs.
 
-### 4. Dispatch specialists
+### 5. Dispatch specialists
 
-Run specialists in parallel (use Task tool with subagents when available,
-otherwise evaluate sequentially):
+Dispatch specialists based on the depth tier from step 2. Run independent
+specialists in parallel — use the `Agent` tool with subagents when
+available so each runs in its own context window; otherwise evaluate
+sequentially.
 
-#### 4a. Static Analysis Specialist
+#### Light tier
 
-Run linters on **changed files only**, using the config profile from step 3.
-See `.agent/knowledge/review_static_analysis.md` for exact commands and flags.
+Run only:
+- **5a. Static Analysis Specialist**
+
+#### Standard tier
+
+Run all of:
+- **5a. Static Analysis Specialist**
+- **5b. Governance Specialist**
+- **5c. Plan Drift Specialist** (if a plan exists)
+- **5d. Adversarial Specialist** (Standard prompt)
+
+#### Deep tier
+
+Same as Standard, but **5d. Adversarial Specialist** runs with the Deep
+prompt (broader file horizon plus an explicit security / concurrency /
+lifecycle checklist).
+
+---
+
+#### 5a. Static Analysis Specialist
+
+Run linters on **changed files only**, using the config profile from
+step 4. See `.agent/knowledge/review_static_analysis.md` for exact
+commands and flags.
+
+If **no linter profile matches any changed file**, report this
+explicitly: "No static analysis profile configured for these file types
+(`.ext1`, `.ext2`)." Don't silently produce an empty findings section —
+the reviewer and user need to know that absence of findings means "not
+checked", not "code is clean."
 
 Report each finding as:
 - File, line number, tool name, message
 - Skip findings on lines not touched by this PR (context-only lines)
 
-#### 4b. Governance Specialist
+#### 5b. Governance Specialist
 
 Load governance context:
 - `.agent/knowledge/principles_review_guide.md` — evaluation criteria
 - `docs/PRINCIPLES.md` — workspace principles
-- `docs/decisions/*.md` — ADRs (scan titles, read those triggered by this change)
+- `docs/decisions/*.md` — ADRs (scan titles, read those triggered by this
+  change)
 - Project-level governance (if applicable)
 
 **Principle evaluation**: For each relevant principle, assess the PR:
@@ -118,62 +241,107 @@ Load governance context:
 
 Skip principles that clearly don't apply.
 
-**ADR compliance**: Using the ADR applicability table, identify triggered ADRs.
-For each: does the PR comply with the key requirement?
+**ADR compliance**: Using the ADR applicability table, identify triggered
+ADRs. For each: does the PR comply with the key requirement?
 
-**Consequence check**: Using the consequences map, check if this PR changes
-something in the "If you change..." column. Are the corresponding "Also update..."
-items addressed? Mark each as Done or Missing.
+**Consequence check**: Using the consequences map, check if this PR
+changes something in the "If you change..." column. Are the corresponding
+"Also update..." items addressed? Mark each as Done or Missing.
 
-**Existing review comments**: Check for unresolved human and bot comments:
+**Existing review comments** (post-PR mode only): Check for unresolved
+human and bot comments:
 
 ```bash
 .agent/scripts/fetch_pr_reviews.sh --pr <N>
 ```
 
-Note unresolved human comments (high priority), valid bot findings, and false
-positives.
+Note unresolved human comments (high priority), valid bot findings, and
+false positives.
 
-#### 4c. Plan Drift Specialist
+#### 5c. Plan Drift Specialist
 
-If a work plan exists (`.agent/work-plans/PLAN_ISSUE-*.md`):
-- Read the plan's "Approach" and "Files to Change" sections
+If a work plan exists at `.agent/work-plans/issue-<N>/plan.md`:
+- Read the plan's "Approach" and "Files to Change" sections.
 - Compare against the actual diff:
   - Files listed in plan but not changed? (incomplete)
   - Files changed but not in plan? (scope creep or oversight)
   - Approach deviations? (different from what was planned)
-- Report deviations as suggestions (not must-fix — plans are guides, not contracts)
+- Report deviations as suggestions (not must-fix — plans are guides, not
+  contracts).
 
 If no work plan exists, skip this specialist.
 
-### 5. Apply silence filter
+#### 5d. Adversarial Specialist
 
-Collect all findings from specialists and filter:
+**Activates at**: Standard, Deep.
 
-1. **Deduplicate** — if static analysis and governance flag the same issue,
-   keep the more specific one
-2. **Drop linter-enforced nits** — if pre-commit or CI already catches it,
-   don't report it again (the author will see it when they commit/push)
-3. **Merge related findings** — group findings about the same logical issue
+Launch as a **fresh Claude subagent** via the `Agent` tool with no
+context from the other specialists. The adversarial reviewer reads the
+diff and full changed files independently — that fresh-context dispatch
+is the whole point. An independent reviewer that agrees with the
+governance specialist is a stronger signal than one told what to look
+for.
+
+**Cross-repo limitation**: the Adversarial Specialist only sees the diff
+and the files it explicitly opens. In a layered workspace, cross-repo
+consequences (a workspace ADR change that affects project repos, a shared
+message-package edit that breaks downstream nodes) won't surface from
+fresh-context reading alone. The Governance Specialist carries that load
+via the consequences map; Adversarial is not a substitute for it.
+
+Standard-tier prompt focus areas:
+- Missed edge cases and boundary conditions
+- Assumption violations (what does the code assume that might not hold?)
+- Subtle bugs (off-by-one, race conditions, resource leaks)
+- Logic errors (does the code actually do what the PR claims?)
+
+Deep-tier prompt adds:
+- Security implications (injection, auth bypass, data exposure)
+- Concurrency / lifecycle (lock ordering, init/destroy ordering, signal
+  handling, shutdown paths)
+- Cross-cutting effects (does this change interact with caching,
+  retries, error propagation, or other system-wide behaviour?)
+
+Report findings in the same format as other specialists (file, line,
+severity, description). The silence filter (step 6) deduplicates overlap
+with other specialists' findings.
+
+> **Cross-model adversarial is intentionally not wired here.** See
+> `inspiration_agent_workspace_digest.md` "Not adopted". When you want
+> a second model's read on a Deep PR, run that agent's review-code
+> manually.
+
+### 6. Apply silence filter
+
+Collect all findings from all dispatched specialists and filter:
+
+1. **Deduplicate** — if multiple specialists flag the same issue (common
+   between adversarial and governance), keep the more specific one.
+2. **Drop linter-enforced nits** — if pre-commit or CI already catches
+   it, don't report it again (the author will see it on commit/push).
+3. **Merge related findings** — group findings about the same logical
+   issue.
 4. **Classify severity**:
    - **Must-fix** — bugs, security issues, principle violations, missing
      consequences
    - **Suggestion** — improvements worth the author's time
-   - Drop anything below suggestion threshold
-5. **Silence check** — if no findings survive the filter, report "No issues
-   found." Do not invent feedback to fill the report. Target: >=85% of
-   reported findings should be actionable.
+   - Drop anything below suggestion threshold.
+5. **Silence check** — if no findings survive the filter, report "No
+   issues found." Don't invent feedback to fill the report. Target: ≥85%
+   of reported findings should be actionable.
 
-### 6. Produce the report
+### 7. Produce the report
 
 ```markdown
-## Code Review: #<N> — <title>
+## Code Review: <#N or branch> — <title>
 
-**PR**: <url>
+**PR**: <url>          (post-PR mode)
+**Branch**: `<branch>` (pre-push mode)
 **Issue**: #<issue> — <issue-title>
 **Repo**: workspace | <project-repo>
 **Files changed**: <count> (+<additions> -<deletions>)
-**Context**: <status of review-context.yaml — fresh / stale / not found>
+**Review depth**: <Light|Standard|Deep> (reason: <primary signal>)
+**Context**: <status of review-context.yaml — fresh / stale / not found / N/A>
 
 ### Must-Fix
 
@@ -207,7 +375,7 @@ Collect all findings from specialists and filter:
 
 ### Existing Review Comments
 
-- <summary of unresolved comments, if any>
+<post-PR mode only — summary of unresolved comments, if any>
 
 ### Summary
 
@@ -218,28 +386,123 @@ Collect all findings from specialists and filter:
 - [ ] <specific action items, if any>
 ```
 
-If no findings exist across all sections, output:
+**Light tier condensed format** — skip Governance, Plan Adherence, and
+Existing Review Comments sections. Use:
 
 ```markdown
-## Code Review: #<N> — <title>
+## Code Review: <#N or branch> — <title>
 
-**PR**: <url>
+**PR / Branch**: ...
+**Review depth**: Light (reason: <primary signal>)
+
+### Static Analysis
+
+| # | File | Line | Finding |
+|---|------|------|---------|
+| 1 | `path` | 42 | Description |
+
+No governance concerns for a change of this scope.
+```
+
+**No findings format** — if no findings exist across all sections:
+
+```markdown
+## Code Review: <#N or branch> — <title>
+
+**PR / Branch**: ...
+**Review depth**: <tier> (reason: <signal>)
 No issues found. LGTM.
 ```
 
+### 8. Persist review summary to progress.md
+
+After outputting the report to the conversation, append a step entry to
+`progress.md` so findings survive across sessions.
+
+**Locate or create progress.md**: Use the issue number resolved in step 1.
+Determine which repo owns the linked issue (workspace repo for workspace
+issues, project repo for project issues). Check
+`.agent/work-plans/issue-<N>/progress.md` in the owning repo's worktree
+first. If it doesn't exist there, check the current worktree. If neither
+exists, create it in the owning repo's worktree (or current worktree if
+no owning worktree exists). Fetch the issue title via:
+
+```bash
+gh issue view <N> --repo <owner/repo> --json title --jq '.title'
+```
+
+Frontmatter for new files:
+
+```yaml
+---
+issue: <N>
+---
+
+# Issue #<N> — <issue title>
+```
+
+Append this step entry:
+
+```markdown
+
+## Local Review
+**Status**: complete
+**When**: <YYYY-MM-DD HH:MM>
+**By**: <agent name> (<model>)
+**Verdict**: <approved|changes-requested>
+
+**PR / Branch**: <#N or branch> at `<short-sha>`
+**Mode**: <pre-push | post-PR>
+**Depth**: <tier> (reason: <signal>)
+**Must-fix**: <count> | **Suggestions**: <count>
+
+### Findings
+- [ ] (must-fix) <one-line summary> — `file:line`
+- [ ] (suggestion) <one-line summary> — `file:line`
+```
+
+If no findings survived the silence filter, set `**Verdict**: approved`,
+`**Must-fix**: 0 | **Suggestions**: 0`, and write `No issues found.
+LGTM.` under Findings.
+
+Key points:
+- Use `- [ ]` checkboxes so findings can be checked off as addressed.
+- Include only the one-line summary and location, not the full
+  description.
+- Commit progress.md after appending. Run `git add` and `git commit` in
+  the worktree where progress.md was found or created (which may differ
+  from the current working directory):
+  ```bash
+  git -C <worktree-path> add .agent/work-plans/issue-<N>/progress.md
+  git -C <worktree-path> commit -m "progress: local review for #<N>"
+  ```
+- If no issue number was resolved in step 1, skip persistence and note
+  this in the report Summary ("Findings not persisted: no linked issue").
+
 ## Guidelines
 
-- **Report, don't act** — output the review in the conversation. The user
-  decides whether to post it as a PR comment, request changes, or act on it.
-- **Be specific** — "Must-fix: null check missing before `result.data` access
-  at line 42" is useful. "Watch: could add more error handling" is not.
-- **Read the code** — don't just check file names. Read full files and the diff
-  to evaluate correctness and principle adherence.
-- **Silence is a feature** — saying nothing when there's nothing to say is
-  better than generating low-value comments. If the code is fine, say so briefly.
-- **Project governance** — for project repo PRs, apply both workspace and project
-  governance. Note conflicts between them if any.
+- **Report first, then persist** — output the review in the conversation,
+  append a step to `progress.md`, and commit it (step 8). The user
+  decides whether to post it as a PR comment, request changes, or act on
+  findings.
+- **Be specific** — "Must-fix: null check missing before `result.data`
+  access at line 42" is useful. "Watch: could add more error handling"
+  is not.
+- **Read the code** — don't just check file names. Read full files and
+  the diff to evaluate correctness and principle adherence.
+- **Silence is a feature** — saying nothing when there's nothing to say
+  is better than generating low-value comments. If the code is fine, say
+  so briefly.
+- **Project governance** — for project repo PRs, apply both workspace and
+  project governance. Note conflicts between them if any.
 - **Severity matters** — every finding must be classified as must-fix or
   suggestion. Unclassified findings are noise.
-- **Context-aware linting** — use ament configs for ROS package code, pre-commit
-  configs for workspace infrastructure code. Never mix them.
+- **Context-aware linting** — use ament configs for ROS package code,
+  pre-commit configs for workspace infrastructure code. Never mix them.
+- **Depth is transparent** — always show the tier and reason in the
+  report header. If the user disagrees with the classification, they can
+  re-run with an explicit depth keyword.
+- **Pre-push mode caveats** — no PR comments, no PR body to extract a
+  plan reference from, no `Closes #` link unless it's already in the
+  branch name. Plan-drift still works (plan is a file in the repo);
+  Existing-Review-Comments doesn't.

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -13,7 +13,6 @@ description: Lead reviewer that orchestrates specialist sub-reviews (static anal
 /review-code <pr-number>                    # post-PR: diff vs PR base
 /review-code <pr-url>                       # post-PR
 /review-code <pr-number> [light|standard|deep]   # post-PR with depth override
-/review-code <branch-name>                  # pre-push, force a base override
 ```
 
 The optional depth keyword (`light` / `standard` / `deep`) overrides

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -505,7 +505,8 @@ Append this step entry:
 **By**: <agent name> (<model>)
 **Verdict**: <approved|changes-requested>
 
-**PR / Branch**: <#N or branch> at `<short-sha>`
+**PR**: #<pr-number> at `<short-sha>`       <!-- post-PR mode; omit in pre-push -->
+**Branch**: <branch-name> at `<short-sha>`  <!-- pre-push mode; omit in post-PR -->
 **Mode**: <pre-push | post-PR>
 **Depth**: <tier> (reason: <signal>)
 **Must-fix**: <count> | **Suggestions**: <count>

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -91,11 +91,15 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 # including non-GitHub field-mode origins and non-`main` defaults like
 # `jazzy` or `master`); fall back to gh on GitHub-origin repos that
 # haven't had `git remote set-head` run; final fallback is `main`.
-DEFAULT_BRANCH=$(
-    git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||' \
-    || gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null \
-    || echo "main"
-)
+# Capture symbolic-ref's exit status BEFORE applying any transformation,
+# because `git symbolic-ref ... | sed ...` exits with sed's status —
+# sed reads an empty pipe successfully when symbolic-ref fails, which
+# would silently leave DEFAULT_BRANCH empty and skip the fallback chain.
+if REMOTE_HEAD=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null); then
+    DEFAULT_BRANCH="${REMOTE_HEAD#refs/remotes/origin/}"
+else
+    DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+fi
 # USER_BASE is set by the caller when `--base <branch>` is parsed off
 # the argument list; otherwise it's empty and the default applies.
 BASE="${USER_BASE:-$DEFAULT_BRANCH}"

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -87,7 +87,15 @@ Examples:
 # Repo root and base branch — start from the default, override if
 # the invocation included `--base <branch>`.
 REPO_ROOT=$(git rev-parse --show-toplevel)
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+# Default branch — try local git first (works for any remote type,
+# including non-GitHub field-mode origins and non-`main` defaults like
+# `jazzy` or `master`); fall back to gh on GitHub-origin repos that
+# haven't had `git remote set-head` run; final fallback is `main`.
+DEFAULT_BRANCH=$(
+    git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||' \
+    || gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null \
+    || echo "main"
+)
 # USER_BASE is set by the caller when `--base <branch>` is parsed off
 # the argument list; otherwise it's empty and the default applies.
 BASE="${USER_BASE:-$DEFAULT_BRANCH}"
@@ -115,10 +123,16 @@ ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+|ISSUE-[0-9]+' | grep -oE '[0
 ```
 
 `--base <branch>` is parsed from the argument list before the snippet
-runs and exposed as `USER_BASE`. If `gh repo view` fails (no GitHub
-remote, offline) the default falls back to `main`. If `git fetch` then
-also fails and no local `origin/$BASE` ref exists, the snippet stops
-with an error rather than silently diffing against nothing.
+runs and exposed as `USER_BASE`. Default-branch resolution prefers
+`git symbolic-ref refs/remotes/origin/HEAD` (the locally cached default
+that `git clone` sets up) so project repos with non-`main` defaults
+(`jazzy`, `master`) and non-GitHub field-mode origins resolve
+correctly without an internet round-trip. If the local symbolic ref is
+missing (older clone, or `git remote set-head` was never run), the
+snippet tries `gh repo view`, then falls back to `main` as a last
+resort. If `git fetch` then also fails and no local `origin/$BASE`
+ref exists, the snippet stops with an error rather than silently
+diffing against nothing.
 
 If no issue number can be extracted from the branch name, note "no
 linked issue" in the report header — the review still runs but

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -16,8 +16,14 @@ description: Independent evaluation of a committed work plan before implementati
 - `<pr-number>` — read the plan from a draft PR (existing behavior)
 - `<path-to-plan.md>` — read the plan directly from a local file
 - `--issue <N>` — resolve to `.agent/work-plans/issue-<N>/plan.md` in
-  the current repo, or in the repo named by `--repo` for cross-repo
-  lookup
+  the current repo's worktree
+
+`--repo <owner/repo>` is an optional adjunct that affects only `gh`
+lookups (issue title, linked PR metadata) — it does **not** change
+where the plan file is read from. To review a plan from a different
+repo, enter that repo's worktree first; `--repo` is for the case where
+the worktree is correct but `gh` would otherwise default to the wrong
+remote.
 
 The file path and `--issue` forms enable offline plan review without a
 PR.
@@ -77,10 +83,12 @@ ls .workspace-worktrees/issue-workspace-<N>/.agent/work-plans/issue-<N>/plan.md 
 ls layers/worktrees/*/issue-*-<N>/.agent/work-plans/issue-<N>/plan.md 2>/dev/null
 ```
 
-For cross-repo plan review (e.g., reviewing a project repo's plan from
-the workspace tree), pass `--repo <owner/repo>` so PR lookups can target
-the right repo. The plan file path is still resolved relative to the
-current repo's worktree.
+**Cross-repo lookups**: `--repo <owner/repo>` redirects only `gh`
+queries (issue title via `gh issue view`, PR metadata via `gh pr view`)
+to the named repo. The plan file is always read from the current
+repo's worktree — there's no cross-repo plan-file resolution. If you
+need to review a plan that lives in a different repo, enter that
+repo's worktree first, then run the skill.
 
 If still not found, stop and inform the user.
 

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -9,30 +9,80 @@ description: Independent evaluation of a committed work plan before implementati
 
 ```
 /review-plan <pr-number>
+/review-plan <path-to-plan.md>
+/review-plan --issue <N> [--repo <owner/repo>]
 ```
+
+- `<pr-number>` — read the plan from a draft PR (existing behavior)
+- `<path-to-plan.md>` — read the plan directly from a local file
+- `--issue <N>` — resolve to `.agent/work-plans/issue-<N>/plan.md` in
+  the current repo, or in the repo named by `--repo` for cross-repo
+  lookup
+
+The file path and `--issue` forms enable offline plan review without a
+PR.
 
 ## Overview
 
 **Lifecycle position**: review-issue → plan-task → **review-plan** → implement → review-code
 
-Independent evaluation of a committed work plan. The planner should not grade
-their own work — this skill provides a second opinion before implementation
-begins. Runs on draft PRs created by `plan-task` (typically prefixed `[PLAN]`).
+Independent evaluation of a committed work plan. The planner should not
+grade their own work — this skill provides a second opinion before
+implementation begins. Accepts draft PRs created by `plan-task`
+(typically prefixed `[PLAN]`), local file paths, or issue numbers.
 
 ## Steps
 
-### 1. Read the plan and PR
+### 1. Read the plan
+
+Determine the input form and locate the plan file. Detection heuristic:
+- Argument starts with `--issue` → issue number form
+- Argument contains `/` or ends with `.md` → file path form
+- Otherwise → PR number form
+
+#### PR number (e.g., `/review-plan 127`)
 
 ```bash
-# PR metadata and body (plan is in the PR body)
+# PR metadata and body (plan is often summarised in the PR body)
 gh pr view <N> --json title,body,baseRefName,headRefName,files,url
 
 # Get the linked issue
-gh pr view <N> --json body --jq '.body' | grep -o '#[0-9]*' | head -1
+gh pr view <N> --json body --jq '.body' | grep -oE '#[0-9]+' | head -1
 ```
 
-Find the plan file in the PR's changed files — it will be at
-`.agent/work-plans/PLAN_ISSUE-*.md`. Read it in full.
+Find the plan file in the PR's changed files. It lives at
+`.agent/work-plans/issue-<N>/plan.md` (or, for plans authored before the
+directory convention landed, the legacy
+`.agent/work-plans/PLAN_ISSUE-<N>.md` file — the symlink at the new path
+resolves to it). Read it in full.
+
+#### File path (e.g., `/review-plan .agent/work-plans/issue-45/plan.md`)
+
+Read the plan file directly. Extract the issue number from the path:
+- New layout: `issue-<N>` directory name
+- Legacy layout: `PLAN_ISSUE-<N>.md` filename
+
+#### Issue number (e.g., `/review-plan --issue 45`)
+
+Resolve to `.agent/work-plans/issue-<N>/plan.md` in the current repo. If
+the file doesn't exist, also check the legacy
+`.agent/work-plans/PLAN_ISSUE-<N>.md`. If neither is present, check for
+an active worktree:
+
+```bash
+# Workspace worktree
+ls .workspace-worktrees/issue-workspace-<N>/.agent/work-plans/issue-<N>/plan.md 2>/dev/null
+
+# Layer worktree (project repo)
+ls layers/worktrees/*/issue-*-<N>/.agent/work-plans/issue-<N>/plan.md 2>/dev/null
+```
+
+For cross-repo plan review (e.g., reviewing a project repo's plan from
+the workspace tree), pass `--repo <owner/repo>` so PR lookups can target
+the right repo. The plan file path is still resolved relative to the
+current repo's worktree.
+
+If still not found, stop and inform the user.
 
 ### 2. Read the issue and any review-issue comments
 
@@ -114,7 +164,7 @@ Assess each dimension and assign a verdict (**Good** / **Needs work** / **Concer
 
 **PR**: <url>
 **Issue**: #<issue> — <issue-title>
-**Plan file**: `.agent/work-plans/PLAN_ISSUE-<N>.md`
+**Plan file**: `.agent/work-plans/issue-<N>/plan.md`
 
 ### Evaluation
 
@@ -140,6 +190,17 @@ Assess each dimension and assign a verdict (**Good** / **Needs work** / **Concer
 ### Recommended Actions
 
 - [ ] <specific action items before implementation begins>
+```
+
+**PR-less format** — when reviewing via `--issue` or a file path (no PR
+exists), replace the PR header:
+
+```markdown
+## Plan Review: #<N> — <title>
+
+**Issue**: #<N> — <issue-title>
+**Plan file**: `.agent/work-plans/issue-<N>/plan.md`
+**Branch**: `<branch-name>` (if in a worktree, otherwise omit)
 ```
 
 If no findings, output:

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -52,8 +52,12 @@ Determine the input form and locate the plan file. Detection heuristic:
 # PR metadata and body (plan is often summarised in the PR body)
 gh pr view <N> --json title,body,baseRefName,headRefName,files,url
 
-# Get the linked issue
-gh pr view <N> --json body --jq '.body' | grep -oE '#[0-9]+' | head -1
+# Primary closing-linked issue (parsed by GitHub from `Closes #N` /
+# `Fixes #N` / `Resolves #N` in the PR body). Mirrors review-code's
+# resolution — a body grep for `#[0-9]+` mis-resolves PRs that mention
+# multiple issues (e.g., #448 closes #247 and #445 but body-grep would
+# return #247).
+ISSUE_NUM=$(gh pr view <N> --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // empty')
 ```
 
 Find the plan file in the PR's changed files. It lives at

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -25,8 +25,11 @@ repo, enter that repo's worktree first; `--repo` is for the case where
 the worktree is correct but `gh` would otherwise default to the wrong
 remote.
 
-The file path and `--issue` forms enable offline plan review without a
-PR.
+The file path and `--issue` forms enable **PR-less** plan review —
+useful before pushing or when working on a plan that won't get a draft
+PR. (Not fully offline: step 2 still calls `gh issue view` to fetch the
+linked issue's body and review-issue comments. The plan file itself is
+read locally.)
 
 ## Overview
 
@@ -49,15 +52,17 @@ Determine the input form and locate the plan file. Detection heuristic:
 #### PR number (e.g., `/review-plan 127`)
 
 ```bash
-# PR metadata and body (plan is often summarised in the PR body)
-gh pr view <N> --json title,body,baseRefName,headRefName,files,url
+# PR metadata and body (plan is often summarised in the PR body).
+# Pass `--repo <owner/repo>` when reviewing a PR from a different repo
+# than the current worktree.
+gh pr view <N> [--repo <owner/repo>] --json title,body,baseRefName,headRefName,files,url
 
 # Primary closing-linked issue (parsed by GitHub from `Closes #N` /
 # `Fixes #N` / `Resolves #N` in the PR body). Mirrors review-code's
 # resolution — a body grep for `#[0-9]+` mis-resolves PRs that mention
 # multiple issues (e.g., #448 closes #247 and #445 but body-grep would
 # return #247).
-ISSUE_NUM=$(gh pr view <N> --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // empty')
+ISSUE_NUM=$(gh pr view <N> [--repo <owner/repo>] --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // empty')
 ```
 
 Find the plan file in the PR's changed files. It lives at
@@ -83,8 +88,11 @@ an active worktree:
 # Workspace worktree
 ls .workspace-worktrees/issue-workspace-<N>/.agent/work-plans/issue-<N>/plan.md 2>/dev/null
 
-# Layer worktree (project repo)
-ls layers/worktrees/*/issue-*-<N>/.agent/work-plans/issue-<N>/plan.md 2>/dev/null
+# Layer worktree (project repo) — plans live inside the project repo,
+# not at the worktree root. The path is
+# `layers/worktrees/issue-<repo>-<N>/<layer>_ws/src/<project_repo>/.agent/work-plans/...`,
+# so glob through the layer-workspace and project-repo tiers:
+ls layers/worktrees/issue-*-<N>/*_ws/src/*/.agent/work-plans/issue-<N>/plan.md 2>/dev/null
 ```
 
 **Cross-repo lookups**: `--repo <owner/repo>` redirects only `gh`
@@ -99,9 +107,9 @@ If still not found, stop and inform the user.
 ### 2. Read the issue and any review-issue comments
 
 ```bash
-# The linked issue
+# The linked issue (pass --repo to target a non-current-worktree repo)
 ISSUE_NUM=<extracted from step 1>
-gh issue view "$ISSUE_NUM" --json title,body,labels,comments,url
+gh issue view "$ISSUE_NUM" [--repo <owner/repo>] --json title,body,labels,comments,url
 ```
 
 Check for `review-issue` comments on the issue — they contain scope assessment,
@@ -215,12 +223,22 @@ exists), replace the PR header:
 **Branch**: `<branch-name>` (if in a worktree, otherwise omit)
 ```
 
-If no findings, output:
+If no findings, output (PR mode):
 
 ```markdown
 ## Plan Review: PR #<N> — <title>
 
 **PR**: <url>
+Plan looks solid. Ready for implementation.
+```
+
+PR-less no-findings variant (`--issue` or file path):
+
+```markdown
+## Plan Review: #<N> — <title>
+
+**Issue**: #<N> — <issue-title>
+**Plan file**: `.agent/work-plans/issue-<N>/plan.md`
 Plan looks solid. Ready for implementation.
 ```
 

--- a/.claude/skills/triage-reviews/SKILL.md
+++ b/.claude/skills/triage-reviews/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-reviews
-description: Evaluate PR review comments (human and bot) against local code, principles, and ADRs. Includes CI check status. Classifies each as valid or false positive and presents a fix plan.
+description: Evaluate PR review comments (human and bot) against local code, principles, and ADRs. Includes CI check status. Classifies each as valid or false positive, presents a fix plan, and persists the triage to progress.md.
 ---
 
 # Triage Reviews
@@ -118,12 +118,13 @@ d. **Assess the comment** against the actual code:
    - Is the concern valid? Does the code actually have the issue flagged?
    - Is it a false positive? (e.g., comparing against stale `main`, or
      misunderstanding the intent)
-   - **Plan files** (`PLAN_ISSUE-*.md`): If the comment targets a file in
-     `.agent/work-plans/`, it is a planning artifact. Check whether the
-     concern is addressed in the implementation files changed in the same PR.
-     If so, classify as "Addressed" and note that the concern is satisfied
-     by the implementation. Plan wording does not need to be updated to
-     match implementation.
+   - **Plan files** (`issue-*/plan.md` or legacy `PLAN_ISSUE-*.md`): If
+     the comment targets a file in `.agent/work-plans/`, it is a
+     planning artifact. Check whether the concern is addressed in the
+     implementation files changed in the same PR. If so, classify as
+     "Addressed" and note that the concern is satisfied by the
+     implementation. Plan wording does not need to be updated to match
+     implementation.
 e. **Evaluate conversation comments** — `conversation_comments` are PR-level
    comments (not attached to specific files or lines). Treat them as general PR
    feedback:
@@ -189,6 +190,59 @@ Output a structured report:
 <1-3 sentence overall assessment>
 ```
 
+### 7. Persist triage to progress.md
+
+Resolve the linked issue number from the PR (same branch-name extraction
+as step 1). Determine which repo owns the linked issue and check
+`.agent/work-plans/issue-<N>/progress.md` in the owning repo's worktree
+first, falling back to the current worktree. If `progress.md` doesn't
+exist in either location, create it in the owning repo's worktree (or
+the current worktree if no owning worktree exists). Fetch the issue
+title from the correct repo via:
+
+```bash
+gh issue view <N> --repo <owner/repo> --json title --jq '.title'
+```
+
+Frontmatter for new files:
+
+```yaml
+---
+issue: <N>
+---
+
+# Issue #<N> — <issue title>
+```
+
+Append this step entry:
+
+```markdown
+
+## External Review
+**Status**: complete
+**When**: <YYYY-MM-DD HH:MM>
+**By**: <agent name> (<model>)
+
+**PR**: #<N> — <total> review(s), <valid-count> valid, <false-positive-count> false positives
+**CI**: <all-pass | failures-noted>
+
+### Actions
+- [ ] <each recommended action from the triage>
+```
+
+Commit `progress.md` after appending. Run `git add` and `git commit` in
+the worktree where progress.md was found or created (which may differ
+from the current working directory):
+
+```bash
+git -C <worktree-path> add .agent/work-plans/issue-<N>/progress.md
+git -C <worktree-path> commit -m "progress: external review for #<N>"
+```
+
+If the PR has no linked issue resolvable from its branch name (rare
+field-mode case), skip persistence and note it in the report Summary
+("Triage not persisted: no linked issue").
+
 ## Guidelines
 
 - **Triage, don't fix** — output the classified plan in the conversation. The user
@@ -218,13 +272,16 @@ Output a structured report:
     about error handling, stale data, or silent failures, classify as Valid unless
     you can prove the failure mode is impossible
   - If you cannot articulate why it's safe, classify as Valid and suggest the fix
-- **No comments posted** — this skill is read-only. It does not post review comments,
-  dismiss reviews, or modify the PR in any way.
+- **No GitHub review actions** — this skill does not post review
+  comments, dismiss reviews, or modify the PR on GitHub. The only
+  side-effect on disk is appending to `progress.md` and committing it
+  (step 7).
 - **Plan-first workflow PRs** — In the plan-first workflow, a PR starts with a
   plan commit and later receives implementation commits. When triaging these PRs:
-  - Comments on `.agent/work-plans/PLAN_ISSUE-*.md` files are low priority —
-    the plan is a pre-implementation artifact and the implementation is the
-    source of truth.
+  - Comments on plan files (`.agent/work-plans/issue-*/plan.md` or
+    legacy `PLAN_ISSUE-*.md`) are low priority — the plan is a
+    pre-implementation artifact and the implementation is the source of
+    truth.
   - Reviews submitted against the plan-only commit (`commit_id` differs from
     `head_sha`) are likely stale once implementation lands. Evaluate the
     reviewer's concern against the current implementation code, not the plan text.

--- a/.claude/skills/triage-reviews/SKILL.md
+++ b/.claude/skills/triage-reviews/SKILL.md
@@ -192,8 +192,34 @@ Output a structured report:
 
 ### 7. Persist triage to progress.md
 
-Resolve the linked issue number from the PR (same branch-name extraction
-as step 1). Determine which repo owns the linked issue and check
+Resolve the linked issue number from the PR branch name (same extraction
+as step 1: `feature/issue-<N>` or `feature/ISSUE-<N>-<description>`).
+This intentionally couples progress.md placement to the worktree's
+plan.md location — both live under `.agent/work-plans/issue-<N>/` in
+the worktree the branch belongs to.
+
+The reviewer's `closingIssuesReferences` is **not** used here, even
+though `review-code`'s post-PR mode and `review-plan`'s PR-number form
+both prefer it. Rationale: those skills resolve an issue to **look up**
+information (the issue body, the plan file); `triage-reviews` resolves
+an issue to **co-locate** the timeline entry with plan.md. Branch-name
+is the right signal because it identifies the worktree, not the
+GitHub-closing semantics — and it works offline / pre-PR, consistent
+with the rest of the local-first skill set.
+
+**Fail loud, don't fall back**: if the branch name doesn't match the
+`feature/issue-<N>` / `feature/ISSUE-<N>-<desc>` pattern, stop with an
+explicit error rather than silently picking a default or attempting a
+GitHub-side lookup. Example message:
+
+```
+Cannot resolve issue number from branch name '<branch>'. Expected
+'feature/issue-<N>' or 'feature/ISSUE-<N>-<description>'. Rename the
+branch to follow the convention, or skip the persistence step manually
+if the worktree intentionally has no associated issue.
+```
+
+Once resolved, determine which repo owns the linked issue and check
 `.agent/work-plans/issue-<N>/progress.md` in the owning repo's worktree
 first, falling back to the current worktree. If `progress.md` doesn't
 exist in either location, create it in the owning repo's worktree (or

--- a/.claude/skills/triage-reviews/SKILL.md
+++ b/.claude/skills/triage-reviews/SKILL.md
@@ -265,9 +265,10 @@ git -C <worktree-path> add .agent/work-plans/issue-<N>/progress.md
 git -C <worktree-path> commit -m "progress: external review for #<N>"
 ```
 
-If the PR has no linked issue resolvable from its branch name (rare
-field-mode case), skip persistence and note it in the report Summary
-("Triage not persisted: no linked issue").
+(The fail-loud rule above already covers the case where the branch
+name doesn't carry an issue number — the skill stops with an error
+rather than silently writing to the wrong path or skipping
+persistence.)
 
 ## Guidelines
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,9 +6,10 @@ That file contains the shared workspace rules for all AI agents.
 ## Code Review Guidelines
 
 This repository uses a plan-first workflow. The first commit on a feature branch
-is often a work plan in `.agent/work-plans/PLAN_ISSUE-<N>.md`. Project repos
-follow the same convention — plans live in whichever repo owns the issue, not
-only in the workspace repo. When reviewing:
+is often a work plan at `.agent/work-plans/issue-<N>/plan.md` (or, for legacy
+plans authored before the directory convention, `PLAN_ISSUE-<N>.md`). Project
+repos follow the same convention — plans live in whichever repo owns the issue,
+not only in the workspace repo. When reviewing:
 
 - If the PR contains only a plan file, review the plan for clarity, completeness,
   and alignment with the principles in `docs/PRINCIPLES.md`.
@@ -17,6 +18,25 @@ only in the workspace repo. When reviewing:
 - Reference `docs/decisions/` for Architecture Decision Records.
 - The principle "Radical simplicity" was renamed to "Only what's needed" — use the
   current name from `docs/PRINCIPLES.md`, not historical references.
+
+## Pre-Push Code Review
+
+The shared rule (see [`AGENTS.md` Post-Task Verification](../AGENTS.md#post-task-verification))
+expects authors to run `/review-code` against their diff before opening a PR.
+This applies to Copilot too when used in **agent / coding-assistant mode** —
+prefer a pre-push pass to catch governance, plan-drift, and adversarial
+findings locally rather than in PR review rounds. See
+[`.claude/skills/review-code/SKILL.md`](../.claude/skills/review-code/SKILL.md).
+
+**Limitation**: when Copilot runs as a **PR reviewer** (the GitHub
+"review by Copilot" surface), it can't invoke local skills, so the
+pre-push check is the human-or-other-agent author's responsibility.
+The Copilot review surface remains complementary, not a substitute.
+
+**Adversarial Specialist is Claude-only** — it dispatches a fresh
+subagent via Claude Code's `Agent` tool, which Copilot doesn't expose.
+Other specialists (Static Analysis, Governance, Plan Drift) are
+framework-agnostic.
 
 ## Environment Setup
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,8 +24,10 @@ not only in the workspace repo. When reviewing:
 The shared rule (see [`AGENTS.md` Post-Task Verification](../AGENTS.md#post-task-verification))
 expects authors to run `/review-code` against their diff before opening a PR.
 This applies to Copilot too when used in **agent / coding-assistant mode** —
-prefer a pre-push pass to catch governance, plan-drift, and adversarial
-findings locally rather than in PR review rounds. See
+prefer a pre-push pass to catch static-analysis, governance, and
+plan-drift findings locally rather than in PR review rounds. (The
+Adversarial Specialist is Claude-only — see caveat below — so Copilot's
+pre-push pass cannot catch adversarial findings.) See
 [`.claude/skills/review-code/SKILL.md`](../.claude/skills/review-code/SKILL.md).
 
 **Limitation**: when Copilot runs as a **PR reviewer** (the GitHub

--- a/.github/instructions/work-plans.instructions.md
+++ b/.github/instructions/work-plans.instructions.md
@@ -7,13 +7,24 @@ applies_to:
 
 # Work Plan Review Instructions
 
-Files in `.agent/work-plans/` are implementation plans, not code. They follow the
-naming convention `PLAN_ISSUE-<N>.md` and are committed as the first step on a
-feature branch — often in a draft PR before implementation begins.
+Files in `.agent/work-plans/` are implementation plans, not code. The
+canonical layout is `.agent/work-plans/issue-<N>/plan.md`, with
+companion artifacts (progress logs, review output, adversarial findings)
+landing alongside under the same per-issue directory. Plans authored
+before the directory convention landed remain at the legacy
+`PLAN_ISSUE-<N>.md` path; each one has a matching symlink at
+`issue-<N>/plan.md` so consumer skills find every plan at the new
+path. Treat the new `issue-<N>/plan.md` form as the authoritative path
+for new work; the flat `PLAN_ISSUE-<N>.md` filename is legacy
+compatibility.
 
-This pattern applies to both the workspace repo and project repos. Plans live in
-whichever repo owns the issue being worked on — project repos maintain their own
-`.agent/work-plans/` directories following the same conventions.
+Plans are committed as the first step on a feature branch — often in a
+draft PR before implementation begins.
+
+This pattern applies to both the workspace repo and project repos.
+Plans live in whichever repo owns the issue being worked on — project
+repos maintain their own `.agent/work-plans/` directories following the
+same conventions.
 
 ## What to Review
 

--- a/.github/instructions/work-plans.instructions.md
+++ b/.github/instructions/work-plans.instructions.md
@@ -2,24 +2,28 @@
 name: work-plan-review
 description: Instructions for reviewing work plans committed as the first step of feature branches
 applies_to:
-  - ".agent/work-plans/**"
+  - ".agent/work-plans/**/plan.md"
+  - ".agent/work-plans/PLAN_ISSUE-*.md"
 ---
 
 # Work Plan Review Instructions
 
-Files in `.agent/work-plans/` are implementation plans, not code. The
-canonical layout is `.agent/work-plans/issue-<N>/plan.md`, with
-companion artifacts (progress logs, review output, adversarial findings)
-landing alongside under the same per-issue directory. Plans authored
-before the directory convention landed remain at the legacy
-`PLAN_ISSUE-<N>.md` path; each one has a matching symlink at
-`issue-<N>/plan.md` so consumer skills find every plan at the new
-path. Treat the new `issue-<N>/plan.md` form as the authoritative path
-for new work; the flat `PLAN_ISSUE-<N>.md` filename is legacy
-compatibility.
+These instructions apply to **plan files** under `.agent/work-plans/`:
+the canonical `.agent/work-plans/issue-<N>/plan.md` form for new work,
+and the legacy `PLAN_ISSUE-<N>.md` form for plans authored before the
+per-issue directory convention landed. Each legacy plan has a matching
+symlink at `issue-<N>/plan.md` so consumer skills find every plan at
+the new path; treat the nested form as authoritative for new work.
 
-Plans are committed as the first step on a feature branch — often in a
-draft PR before implementation begins.
+Companion artifacts (`progress.md`, review output, adversarial
+findings, etc.) live in the same per-issue directory but are **not**
+plan files — they have their own conventions and are not in scope for
+this review skill. The `applies_to` glob above intentionally excludes
+them.
+
+Plan files are implementation plans, not code. They are committed as
+the first step on a feature branch — often in a draft PR before
+implementation begins.
 
 This pattern applies to both the workspace repo and project repos.
 Plans live in whichever repo owns the issue being worked on — project

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,8 +352,15 @@ Before marking a task complete or opening a PR:
 2. Compare changes against requirements
 3. Check consequences: do tests, docs, or dependent references need updating?
 4. List any gaps; complete them or explain in PR description
+5. **Before opening a PR**: run `/review-code` against your diff and
+   address findings before pushing. Catches static-analysis issues,
+   governance gaps, plan drift, and adversarial findings while they're
+   still cheap to fix locally — instead of in PR review rounds. See
+   `.claude/skills/review-code/SKILL.md` (pre-push mode is the default
+   when invoked with no arguments).
 
-**Plan-first workflow**: if the PR opened with a work plan (`.agent/work-plans/PLAN_ISSUE-<N>.md`),
+**Plan-first workflow**: if the PR opened with a work plan (`.agent/work-plans/issue-<N>/plan.md`,
+or legacy `PLAN_ISSUE-<N>.md`),
 the plan is expected to stay in sync with the committed implementation on
 the branch / in the PR as implementation proceeds. Inline edits are the
 default; see the "During implementation" section of


### PR DESCRIPTION
Closes #452

## Summary

Ports four review-skill improvements from `rolker/agent_workspace` and
threads `/review-code` into the per-issue lifecycle so agents actually
run it before pushing. Also introduces a per-issue
`.agent/work-plans/issue-<N>/` directory convention with eager symlink
migration so consumer skills always find plans at one path.

PR #448 surfaced the underlying problem: 13 review rounds with ~45
Copilot findings, many of them consequences of prior fixes that the
existing specialists missed because their context carried forward
across rounds. The two design responses are both ported here:

1. **Fresh-context Adversarial Specialist** that re-reads the diff cold.
2. **Depth tiers** (Light / Standard / Deep) that scale specialist count
   to change risk so small mechanical PRs aren't held up and large /
   governance-touching PRs reliably get the full battery.

Plus `progress.md` persistence and flexible `review-plan` inputs.

## Imports from `rolker/agent_workspace`

| Imported piece | Lands as |
|---|---|
| Review depth classification (Light / Standard / Deep, signal table, override triggers) | New `.agent/knowledge/review_depth_classification.md` — framed **experimental** until thresholds validated against real-PR data |
| Adversarial Specialist (Claude-only, fresh subagent) | `review-code` step 5d, activates at Standard + Deep |
| `review-code` dual-mode + depth dispatch | Pre-push (no arg, diff vs default branch) and post-PR (`<N>` or URL); user override `[light\|standard\|deep]` |
| `progress.md` persistence | New steps in `review-code` (Local Review) and `triage-reviews` (External Review), in the issue's owning repo |
| `review-plan` flexible inputs | Accepts PR number, file path, or `--issue <N>` |

## Adaptations for the layered/multi-repo workspace

- **Cross-Model Adversarial deliberately not ported.** The fork
  dispatches Gemini/Codex/Copilot reviews via `cross_model_review.sh` +
  tmux. Skipped here as out-of-scope — recorded in the digest's
  "Not adopted" section.
- **Workspace-repo and project-repo override-trigger lists kept
  separate** so the depth classifier sees governance/enforcement files
  at their actual locations in each repo type.
- **Cross-layer change is a Deep promotion trigger** (workspace-specific
  vs. fork's single-repo framing) — consequence analysis spans repos in
  this workspace.
- **Repo-awareness pass** folded into all SKILL.md updates: skills talk
  about "the issue's owning repo" rather than assuming workspace.
- **ROS-aware linter table** preserved in `review-code` (workspace-specific,
  better fit than the fork's generic categorization).
- **Adversarial-Claude-only caveat documented** in each framework
  adapter (Copilot review-mode limitation, Gemini no `Agent` tool).

## Per-issue directory convention

A precondition for the persistence work — companion artifacts
(`progress.md`, review output, adversarial findings) need a place to
live alongside the plan.

- New plans write to `.agent/work-plans/issue-<N>/plan.md`.
- Eager symlink migration: 43 existing flat plans get
  `issue-<N>/plan.md → ../PLAN_ISSUE-<N>.md` so skills only check one
  path. Flat files remain canonical.
- `plan-task/SKILL.md` writes nested going forward.

## Lifecycle threading

`/review-code` is now the sanctioned step between implement and push:

- `AGENTS.md` Post-Task Verification gains step 5: "Before opening a
  PR, run `/review-code` against your diff."
- `skill_workflows.md` lifecycle string extended past `review-code` to
  `push / open PR → triage-reviews`.
- `plan-task` step 8 closes with a pointer to `/review-code` as the
  next step before pushing.
- Three framework adapters mirror the AGENTS.md expectation, with
  per-framework caveats (Copilot review-mode limitation;
  Adversarial-Claude-only across all non-Claude runtimes).

Soft-nudge enforcement is the explicit Phase-1 choice — composite
`/ship` skill remains the planned next enforcement layer, deferred to
a follow-up issue.

## Smoke test

The plan's validation checklist (`/review-code 448 --depth=deep`
confirming Adversarial fires, `progress.md` gets written, a medium PR
auto-classifies to Standard) is deferred to **post-merge** — it
requires the new SKILL to be loadable, which only happens after this
PR lands. Will be exercised on the next real PR review.

## Out of scope (deferred to follow-ups)

- Composite `/ship` skill (mechanical pre-push enforcement layer).
- Cross-Model Adversarial Specialist + `cross_model_review.sh`.
- Migrating legacy flat plans to nested storage (currently bridged by
  symlinks; promotion would be a separate cleanup).
- Promoting `review_depth_classification.md` to ADR (deferred until
  thresholds validate against real PR data).

## Test plan

- [x] All commits passed pre-commit hooks (lint, shellcheck, etc.).
- [x] 43 plan symlinks resolve (`cat issue-<N>/plan.md` for sample issues).
- [ ] CI green (Lint + Validate Documentation, currently pending).
- [ ] **Post-merge**: `/review-code 448 --depth=deep` smoke test —
      Adversarial fires, `progress.md` written at
      `.agent/work-plans/issue-448/progress.md`, medium PR auto-classifies
      to Standard.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
