### PR TITLE
fix: rename content.md → SKILL.md so /import-field-changes actually loads

### DIFF
--- a/.claude/skills/import-field-changes/SKILL.md
+++ b/.claude/skills/import-field-changes/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: import-field-changes
+description: Batch-import field changes from a secondary remote (e.g., gitcloud) back to GitHub for review. For each repo with remote-ahead commits, creates an issue, opens a draft PR, and pre-reviews the diff against the Quality Standard.
+---
+
 # Import Field Changes
 
 ## Usage


### PR DESCRIPTION
## Summary

- Rename `.claude/skills/import-field-changes/content.md` → `SKILL.md`.
- Prepend YAML `name:` / `description:` frontmatter matching sibling skills.

## Why

Claude Code's skill loader only registers skills at `.claude/skills/<name>/SKILL.md` with YAML frontmatter. The file shipped in PR [#440](https://github.com/rolker/ros2_agent_workspace/pull/440) as `content.md` with no frontmatter, so `/import-field-changes` has been unregistered since 2026-04-21 — the skill has been inert for the entire field-reconciliation window it was supposed to cover. Caught tonight when attempting to use it to reconcile a pier session.

Copilot flagged the filename bug five times on PR #440 with no written response or resolve. Issue [#454](https://github.com/rolker/ros2_agent_workspace/issues/454) tracks the process failure that allowed this (triage-reviews should post dismissal rationale to the PR so "evaluated and dismissed" is distinguishable from "skipped unread"). This PR fixes only the symptom.

## Test plan

- [ ] Start a fresh Claude Code session and confirm `/import-field-changes` appears in the available-skills list.
- [ ] Confirm no cross-repo documentation updates are needed — every existing reference (AGENTS.md, WORKTREE_GUIDE.md, ADR-0011, field_mode_hotfix.md, AGENT_ONBOARDING.md, copilot/gemini adapter files) refers to the skill by name only, so the rename is transparent to all of them.

Closes #455.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
