### PR TITLE
worktree_create.sh: layer-type worktree displays workspace repo's issue title when number collides

### DIFF
--- a/.agent/scripts/_worktree_helpers.sh
+++ b/.agent/scripts/_worktree_helpers.sh
@@ -40,7 +40,8 @@ wt_layer_branch() {
 # Use this to find the package repo whose origin / git-bug data should be
 # queried for issue metadata (the issue lives in the package's repo, not
 # the workspace).
-# Returns empty (and exit 1) if no inner git worktree is found.
+# Prints the package dir on stdout (with exit status 0); prints nothing
+# and returns a non-zero status if no inner git worktree is found.
 # Usage: pkg_dir=$(wt_layer_pkg_dir "$worktree_dir")
 wt_layer_pkg_dir() {
     local worktree_dir="$1"
@@ -93,6 +94,35 @@ wt_layer_is_dirty() {
     done
 
     return 1  # clean
+}
+
+# Extract a validated owner/repo slug from a GitHub remote URL.
+# Prints the slug on stdout; prints nothing for non-GitHub or malformed URLs.
+#
+# Supported URL forms:
+#   https://github.com/OWNER/REPO[.git]
+#   https://github.com:PORT/OWNER/REPO[.git]
+#   git@github.com:OWNER/REPO[.git]                        (SCP form)
+#   ssh://[user@]github.com[:PORT]/OWNER/REPO[.git]
+#   ssh://[user@]ssh.github.com:443/OWNER/REPO[.git]       (SSH-over-443)
+#
+# Rejects substring/lookalike hosts (e.g. mygithub.com, gist.github.com)
+# by requiring the host to be preceded by a URL boundary (start, '@', or '/').
+#
+# Usage: slug=$(extract_gh_slug "$url")
+extract_gh_slug() {
+    local url="$1"
+    # Strip a single trailing .git so the regex doesn't have to.
+    local cleaned="${url%.git}"
+    # Boundary: ^, @, or / before host
+    # Host:     optional ssh. prefix, then literal github.com
+    # Port:     optional :NNN
+    # Sep:      / (URL form) or : (SCP form)
+    # Path:     OWNER / REPO  (no slashes or whitespace inside either)
+    local re='(^|[@/])(ssh\.)?github\.com(:[0-9]+)?[/:]([^/[:space:]]+)/([^/[:space:]]+)$'
+    if [[ "$cleaned" =~ $re ]]; then
+        echo "${BASH_REMATCH[4]}/${BASH_REMATCH[5]}"
+    fi
 }
 
 # Find the most recent skill worktree matching a skill name.

--- a/.agent/scripts/_worktree_helpers.sh
+++ b/.agent/scripts/_worktree_helpers.sh
@@ -107,25 +107,32 @@ wt_layer_is_dirty() {
 #   ssh://[user@]ssh.github.com:443/OWNER/REPO[.git]       (SSH-over-443)
 #
 # Rejects substring/lookalike hosts (e.g. mygithub.com, gist.github.com)
-# by requiring the host to be preceded by a URL boundary (start, '@', or '/').
+# and `github.com` appearing inside the URL path by anchoring the match
+# at the start of the string and requiring the host to be at a true URL
+# host position — start, after a single `[user@]` auth section, or after
+# the `://` protocol delimiter.
 #
 # Usage: slug=$(extract_gh_slug "$url")
 extract_gh_slug() {
     local url="$1"
-    # Strip a single trailing .git so the regex doesn't have to.
+    # Strip a single trailing .git so the regexes don't have to.
     local cleaned="${url%.git}"
-    # Boundary: must be at URL host position — start-of-string, an '@'
-    # (auth section), or a '://' (protocol delimiter). A bare '/' is
-    # not a valid boundary; otherwise URLs like
-    # https://example.com/github.com/owner/repo would falsely match
-    # github.com inside the path.
-    # Host:     optional ssh. prefix, then literal github.com
-    # Port:     optional :NNN
-    # Sep:      / (URL form) or : (SCP form)
-    # Path:     OWNER / REPO  (no slashes or whitespace inside either)
-    local re='(^|@|://)(ssh\.)?github\.com(:[0-9]+)?[/:]([^/[:space:]]+)/([^/[:space:]]+)$'
-    if [[ "$cleaned" =~ $re ]]; then
-        echo "${BASH_REMATCH[4]}/${BASH_REMATCH[5]}"
+    # Two anchored patterns covering the officially supported remote URL
+    # forms. Anchoring at ^ rejects lookalike hosts and `@github.com`
+    # appearing inside a URL path (e.g.
+    # `git@example.com:foo@github.com/owner/repo`).
+    #
+    # Form 1: explicit scheme (https, http, ssh).
+    #   ^(https?|ssh)://[user@]?(ssh\.)?github.com[:port]?/OWNER/REPO$
+    local re_url='^(https?|ssh)://([^@/[:space:]]+@)?(ssh\.)?github\.com(:[0-9]+)?/([^/[:space:]]+)/([^/[:space:]]+)$'
+    # Form 2: SCP-style `[user@]host:path` (no scheme, no slash between
+    # host and path).
+    #   ^[user@]?(ssh\.)?github.com:OWNER/REPO$
+    local re_scp='^([^@/[:space:]]+@)?(ssh\.)?github\.com:([^/[:space:]]+)/([^/[:space:]]+)$'
+    if [[ "$cleaned" =~ $re_url ]]; then
+        echo "${BASH_REMATCH[5]}/${BASH_REMATCH[6]}"
+    elif [[ "$cleaned" =~ $re_scp ]]; then
+        echo "${BASH_REMATCH[3]}/${BASH_REMATCH[4]}"
     fi
 }
 

--- a/.agent/scripts/_worktree_helpers.sh
+++ b/.agent/scripts/_worktree_helpers.sh
@@ -114,12 +114,16 @@ extract_gh_slug() {
     local url="$1"
     # Strip a single trailing .git so the regex doesn't have to.
     local cleaned="${url%.git}"
-    # Boundary: ^, @, or / before host
+    # Boundary: must be at URL host position — start-of-string, an '@'
+    # (auth section), or a '://' (protocol delimiter). A bare '/' is
+    # not a valid boundary; otherwise URLs like
+    # https://example.com/github.com/owner/repo would falsely match
+    # github.com inside the path.
     # Host:     optional ssh. prefix, then literal github.com
     # Port:     optional :NNN
     # Sep:      / (URL form) or : (SCP form)
     # Path:     OWNER / REPO  (no slashes or whitespace inside either)
-    local re='(^|[@/])(ssh\.)?github\.com(:[0-9]+)?[/:]([^/[:space:]]+)/([^/[:space:]]+)$'
+    local re='(^|@|://)(ssh\.)?github\.com(:[0-9]+)?[/:]([^/[:space:]]+)/([^/[:space:]]+)$'
     if [[ "$cleaned" =~ $re ]]; then
         echo "${BASH_REMATCH[4]}/${BASH_REMATCH[5]}"
     fi

--- a/.agent/scripts/_worktree_helpers.sh
+++ b/.agent/scripts/_worktree_helpers.sh
@@ -36,6 +36,36 @@ wt_layer_branch() {
     return 1
 }
 
+# Get the directory of the first inner package git worktree in a layer worktree.
+# Use this to find the package repo whose origin / git-bug data should be
+# queried for issue metadata (the issue lives in the package's repo, not
+# the workspace).
+# Returns empty (and exit 1) if no inner git worktree is found.
+# Usage: pkg_dir=$(wt_layer_pkg_dir "$worktree_dir")
+wt_layer_pkg_dir() {
+    local worktree_dir="$1"
+
+    for ws_dir in "$worktree_dir"/*_ws; do
+        [ -d "$ws_dir" ] || continue
+        [ -L "$ws_dir" ] && continue  # skip symlinked layers
+
+        local src_dir="$ws_dir/src"
+        [ -d "$src_dir" ] || continue
+
+        for pkg_dir in "$src_dir"/*; do
+            [ -d "$pkg_dir" ] || continue
+            [ -L "$pkg_dir" ] && continue  # skip symlinked packages
+
+            if git -C "$pkg_dir" rev-parse --git-dir &>/dev/null; then
+                echo "$pkg_dir"
+                return 0
+            fi
+        done
+    done
+
+    return 1
+}
+
 # Check if a layer worktree has uncommitted changes in any inner package git worktree.
 # Ignores symlinked layers/packages and infrastructure directories.
 # Returns 0 (true) if dirty, 1 (false) if clean.

--- a/.agent/scripts/tests/test_worktree_create.sh
+++ b/.agent/scripts/tests/test_worktree_create.sh
@@ -40,6 +40,8 @@ setup_mock_workspace() {
     # Copy the script under test into the mock workspace
     cp "$CREATE_SCRIPT" .agent/scripts/worktree_create.sh
     chmod +x .agent/scripts/worktree_create.sh
+    # worktree_create.sh sources _worktree_helpers.sh; copy it too.
+    cp "$SCRIPT_DIR/../_worktree_helpers.sh" .agent/scripts/_worktree_helpers.sh
 }
 
 # Cleanup test repository
@@ -183,6 +185,8 @@ setup_mock_layer_workspace() {
     # Copy the script under test into the mock workspace
     cp "$CREATE_SCRIPT" .agent/scripts/worktree_create.sh
     chmod +x .agent/scripts/worktree_create.sh
+    # worktree_create.sh sources _worktree_helpers.sh; copy it too.
+    cp "$SCRIPT_DIR/../_worktree_helpers.sh" .agent/scripts/_worktree_helpers.sh
 
     rm -rf "$tmp_clone"
 }
@@ -924,6 +928,65 @@ test_wt_layer_pkg_dir_skips_symlinked_layers() {
     return 0
 }
 run_test "wt_layer_pkg_dir skips symlinked layer dirs" test_wt_layer_pkg_dir_skips_symlinked_layers
+
+# ===== extract_gh_slug tests =====
+#
+# Helper to assert extract_gh_slug returns an exact value (or empty for
+# rejection cases). Sources the helper file once per test for isolation.
+_assert_slug() {
+    local url="$1" expected="$2" label="$3"
+    local actual
+    actual=$(extract_gh_slug "$url")
+    if [ "$actual" = "$expected" ]; then
+        return 0
+    fi
+    echo "    [$label] for url='$url' expected='$expected' got='$actual'"
+    return 1
+}
+
+test_extract_gh_slug_accepts_supported_forms() {
+    source "$SCRIPT_DIR/../_worktree_helpers.sh"
+
+    _assert_slug "https://github.com/owner/repo.git" "owner/repo"     "https with .git"     || return 1
+    _assert_slug "https://github.com/owner/repo"     "owner/repo"     "https no .git"       || return 1
+    _assert_slug "https://github.com:443/owner/repo.git" "owner/repo" "https with port"     || return 1
+    _assert_slug "git@github.com:owner/repo.git"     "owner/repo"     "scp form"            || return 1
+    _assert_slug "git@github.com:owner/repo"         "owner/repo"     "scp form no .git"    || return 1
+    _assert_slug "ssh://git@github.com/owner/repo.git" "owner/repo"   "ssh url"             || return 1
+    _assert_slug "ssh://git@github.com:22/owner/repo.git" "owner/repo" "ssh url with port"  || return 1
+    _assert_slug "ssh://git@ssh.github.com:443/owner/repo.git" "owner/repo" "ssh-over-443"  || return 1
+    _assert_slug "github.com/owner/repo.git"         "owner/repo"     "no protocol"         || return 1
+    _assert_slug "https://github.com/owner/repo.foo.git" "owner/repo.foo" "dotted repo name" || return 1
+    return 0
+}
+run_test "extract_gh_slug accepts all supported URL forms" test_extract_gh_slug_accepts_supported_forms
+
+test_extract_gh_slug_rejects_lookalikes() {
+    source "$SCRIPT_DIR/../_worktree_helpers.sh"
+
+    # Substring/lookalike hosts must NOT match.
+    _assert_slug "https://mygithub.com/owner/repo.git"   "" "mygithub.com"   || return 1
+    _assert_slug "https://notgithub.com/owner/repo.git"  "" "notgithub.com"  || return 1
+    _assert_slug "git@mygithub.com:owner/repo.git"       "" "mygithub.com scp" || return 1
+    # Different host entirely.
+    _assert_slug "https://gitlab.com/owner/repo.git"     "" "gitlab.com"     || return 1
+    # Subdomains of github.com other than 'ssh.' (notably gist.) must not match.
+    _assert_slug "https://gist.github.com/owner/file.git" "" "gist.github.com" || return 1
+    _assert_slug "https://api.github.com/repos/owner/repo" "" "api.github.com" || return 1
+    return 0
+}
+run_test "extract_gh_slug rejects lookalike hosts" test_extract_gh_slug_rejects_lookalikes
+
+test_extract_gh_slug_rejects_malformed() {
+    source "$SCRIPT_DIR/../_worktree_helpers.sh"
+
+    _assert_slug ""                                  "" "empty string"          || return 1
+    _assert_slug "not a url"                         "" "garbage"               || return 1
+    _assert_slug "https://github.com/onlyowner"      "" "owner without repo"    || return 1
+    _assert_slug "https://github.com/owner/repo/extra" "" "trailing path"       || return 1
+    return 0
+}
+run_test "extract_gh_slug rejects empty/malformed input" test_extract_gh_slug_rejects_malformed
 
 # Summary
 echo "========================================"

--- a/.agent/scripts/tests/test_worktree_create.sh
+++ b/.agent/scripts/tests/test_worktree_create.sh
@@ -973,6 +973,12 @@ test_extract_gh_slug_rejects_lookalikes() {
     # Subdomains of github.com other than 'ssh.' (notably gist.) must not match.
     _assert_slug "https://gist.github.com/owner/file.git" "" "gist.github.com" || return 1
     _assert_slug "https://api.github.com/repos/owner/repo" "" "api.github.com" || return 1
+    # github.com appearing inside a URL path (not at host position) must
+    # not match — the boundary class would otherwise pick up the leading
+    # '/' before 'github.com' and accept a non-GitHub remote.
+    _assert_slug "https://example.com/github.com/owner/repo.git" "" "github.com in path"        || return 1
+    _assert_slug "https://gitlab.com/foo/github.com/owner/repo"  "" "github.com deep in path"   || return 1
+    _assert_slug "git@example.com/github.com/owner/repo.git"     "" "github.com in scp-ish path" || return 1
     return 0
 }
 run_test "extract_gh_slug rejects lookalike hosts" test_extract_gh_slug_rejects_lookalikes

--- a/.agent/scripts/tests/test_worktree_create.sh
+++ b/.agent/scripts/tests/test_worktree_create.sh
@@ -955,7 +955,6 @@ test_extract_gh_slug_accepts_supported_forms() {
     _assert_slug "ssh://git@github.com/owner/repo.git" "owner/repo"   "ssh url"             || return 1
     _assert_slug "ssh://git@github.com:22/owner/repo.git" "owner/repo" "ssh url with port"  || return 1
     _assert_slug "ssh://git@ssh.github.com:443/owner/repo.git" "owner/repo" "ssh-over-443"  || return 1
-    _assert_slug "github.com/owner/repo.git"         "owner/repo"     "no protocol"         || return 1
     _assert_slug "https://github.com/owner/repo.foo.git" "owner/repo.foo" "dotted repo name" || return 1
     return 0
 }
@@ -979,6 +978,16 @@ test_extract_gh_slug_rejects_lookalikes() {
     _assert_slug "https://example.com/github.com/owner/repo.git" "" "github.com in path"        || return 1
     _assert_slug "https://gitlab.com/foo/github.com/owner/repo"  "" "github.com deep in path"   || return 1
     _assert_slug "git@example.com/github.com/owner/repo.git"     "" "github.com in scp-ish path" || return 1
+    # Anchored regex must reject `@github.com` appearing mid-URL — e.g.
+    # an SCP-form remote where the path itself contains `@github.com`.
+    # Without the start-of-string anchor, the `@` boundary would let
+    # these match and produce a wrong slug.
+    _assert_slug "git@example.com:foo@github.com/owner/repo.git" "" "@github.com mid-scp"      || return 1
+    _assert_slug "https://user@example.com/foo@github.com/owner/repo.git" "" "@github.com mid-https" || return 1
+    # No-protocol `github.com/owner/repo` is not a real remote URL form
+    # (`git remote get-url` always returns https/ssh/scp). The anchored
+    # regex requires either a scheme or a SCP-style `:` separator.
+    _assert_slug "github.com/owner/repo.git" "" "no protocol (rejected)" || return 1
     return 0
 }
 run_test "extract_gh_slug rejects lookalike hosts" test_extract_gh_slug_rejects_lookalikes

--- a/.agent/scripts/tests/test_worktree_create.sh
+++ b/.agent/scripts/tests/test_worktree_create.sh
@@ -34,6 +34,9 @@ setup_mock_workspace() {
     # Create required directory structure
     mkdir -p .workspace-worktrees
     mkdir -p .agent/scripts
+    # Layer manifest is required by the script's available-layers check
+    mkdir -p configs/manifest
+    echo "core" > configs/manifest/layers.txt
     # Copy the script under test into the mock workspace
     cp "$CREATE_SCRIPT" .agent/scripts/worktree_create.sh
     chmod +x .agent/scripts/worktree_create.sh
@@ -174,6 +177,9 @@ setup_mock_layer_workspace() {
     # Create required directories
     mkdir -p layers/worktrees
     mkdir -p .agent/scripts
+    # Layer manifest is required by the script's available-layers check
+    mkdir -p configs/manifest
+    echo "core" > configs/manifest/layers.txt
     # Copy the script under test into the mock workspace
     cp "$CREATE_SCRIPT" .agent/scripts/worktree_create.sh
     chmod +x .agent/scripts/worktree_create.sh
@@ -445,6 +451,128 @@ test_offline_fallback_message() {
     return 0
 }
 run_test "Offline fallback message when gh fails" test_offline_fallback_message
+
+# ===== git-bug bridge-gating tests (regression for #457) =====
+
+# Install a fake gitbug_helpers.sh next to the copied worktree_create.sh.
+# Behaviour is controlled by env vars:
+#   FAKE_BRIDGE_MODE   = none|workspace_only|project_only|both
+#   FAKE_BUG_WORKSPACE_TITLE / FAKE_BUG_PROJECT_TITLE
+#   FAKE_BUG_WORKSPACE_STATUS / FAKE_BUG_PROJECT_STATUS  (default: open)
+# Workspace vs project repo is distinguished by path: project repos live
+# under .../layers/main/<layer>_ws/src/<pkg>, workspace does not.
+install_fake_gitbug_helpers() {
+    cat > .agent/scripts/gitbug_helpers.sh << 'HELPERS_EOF'
+gitbug_has_bridge() {
+    local repo_dir="$1"
+    case "${FAKE_BRIDGE_MODE:-none}" in
+        workspace_only) [[ "$repo_dir" != *"/layers/main/"*"/src/"* ]] ;;
+        project_only)   [[ "$repo_dir" == *"/layers/main/"*"/src/"* ]] ;;
+        both)           return 0 ;;
+        none|*)         return 1 ;;
+    esac
+}
+gitbug_lookup() {
+    local repo_dir="$1"
+    local field="$3"
+    [ "$field" = "title" ] || [ "$field" = "status" ] || return 1
+    local prefix="WORKSPACE"
+    [[ "$repo_dir" == *"/layers/main/"*"/src/"* ]] && prefix="PROJECT"
+    local field_upper="TITLE"
+    [ "$field" = "status" ] && field_upper="STATUS"
+    local var="FAKE_BUG_${prefix}_${field_upper}"
+    local val="${!var:-}"
+    if [ "$field" = "status" ] && [ -z "$val" ]; then val="open"; fi
+    [ -n "$val" ] && { echo "$val"; return 0; } || return 1
+}
+HELPERS_EOF
+}
+
+# Test: Layer worktree must not show workspace's wrong title when project
+# repo isn't git-bug-bridged (the original #457 collision scenario).
+test_layer_skips_unbridged_project_gitbug() {
+    setup_mock_layer_workspace
+    cd "$WORKSPACE_DIR" || return 1
+    install_fake_gitbug_helpers
+
+    local fake_dir
+    fake_dir=$(setup_fake_gh)
+
+    local output
+    output=$(FAKE_BRIDGE_MODE=workspace_only \
+             FAKE_BUG_WORKSPACE_TITLE="WRONG_TITLE_FROM_WORKSPACE" \
+             FAKE_GH_MODE=open \
+             PATH="$fake_dir:$PATH" \
+        .agent/scripts/worktree_create.sh --issue 999 --type layer --layer core --packages test_pkg 2>&1) || true
+
+    cleanup_mock_layer_workspace
+
+    if [[ "$output" == *"WRONG_TITLE_FROM_WORKSPACE"* ]]; then
+        echo "    Workspace git-bug title leaked into layer worktree banner"
+        echo "    Output: $output"
+        return 1
+    fi
+    if [[ "$output" != *"Fix the widget"* ]]; then
+        echo "    Expected gh-fallback title 'Fix the widget' in output"
+        echo "    Output: $output"
+        return 1
+    fi
+    return 0
+}
+run_test "Layer worktree skips git-bug when project repo unbridged (#457)" test_layer_skips_unbridged_project_gitbug
+
+# Test: Layer worktree must use project repo's git-bug data when it IS
+# bridged, even if the workspace also has data for the same issue number
+# (forward-compat: project repos will eventually get bridges).
+test_layer_uses_project_gitbug_when_bridged() {
+    setup_mock_layer_workspace
+    cd "$WORKSPACE_DIR" || return 1
+    install_fake_gitbug_helpers
+
+    local output
+    output=$(FAKE_BRIDGE_MODE=both \
+             FAKE_BUG_PROJECT_TITLE="RIGHT_TITLE_FROM_PROJECT" \
+             FAKE_BUG_WORKSPACE_TITLE="WRONG_TITLE_FROM_WORKSPACE" \
+        .agent/scripts/worktree_create.sh --issue 888 --type layer --layer core --packages test_pkg 2>&1) || true
+
+    cleanup_mock_layer_workspace
+
+    if [[ "$output" == *"WRONG_TITLE_FROM_WORKSPACE"* ]]; then
+        echo "    Workspace title leaked despite project repo being bridged"
+        echo "    Output: $output"
+        return 1
+    fi
+    if [[ "$output" != *"RIGHT_TITLE_FROM_PROJECT"* ]]; then
+        echo "    Expected project-repo title 'RIGHT_TITLE_FROM_PROJECT' in output"
+        echo "    Output: $output"
+        return 1
+    fi
+    return 0
+}
+run_test "Layer worktree uses project repo's git-bug when bridged (#457 forward-compat)" test_layer_uses_project_gitbug_when_bridged
+
+# Test: Workspace worktree continues to use workspace git-bug when bridged
+# (sanity check that the bridge gate doesn't break the original happy path).
+test_workspace_uses_workspace_gitbug_when_bridged() {
+    setup_mock_workspace
+    cd "$WORKSPACE_DIR" || return 1
+    install_fake_gitbug_helpers
+
+    local output
+    output=$(FAKE_BRIDGE_MODE=workspace_only \
+             FAKE_BUG_WORKSPACE_TITLE="HAPPY_PATH_TITLE" \
+        .agent/scripts/worktree_create.sh --issue 777 --type workspace 2>&1) || true
+
+    cleanup_mock_workspace
+
+    if [[ "$output" != *"HAPPY_PATH_TITLE"* ]]; then
+        echo "    Expected workspace git-bug title in output"
+        echo "    Output: $output"
+        return 1
+    fi
+    return 0
+}
+run_test "Workspace worktree uses workspace git-bug when bridged" test_workspace_uses_workspace_gitbug_when_bridged
 
 # ===== Skill worktree tests =====
 

--- a/.agent/scripts/tests/test_worktree_create.sh
+++ b/.agent/scripts/tests/test_worktree_create.sh
@@ -533,10 +533,20 @@ test_layer_uses_project_gitbug_when_bridged() {
     cd "$WORKSPACE_DIR" || return 1
     install_fake_gitbug_helpers
 
+    # Stub gh so the script's `gh pr view` PR-check call (run whenever
+    # gh is on PATH, even on the git-bug success path) doesn't hit the
+    # network on dev boxes. FAKE_GH_MODE=fail also makes any unexpected
+    # `gh issue view` fall-through return empty rather than the stub's
+    # default `Fix the widget` title — which would mask a regression.
+    local fake_dir
+    fake_dir=$(setup_fake_gh)
+
     local output
     output=$(FAKE_BRIDGE_MODE=both \
              FAKE_BUG_PROJECT_TITLE="RIGHT_TITLE_FROM_PROJECT" \
              FAKE_BUG_WORKSPACE_TITLE="WRONG_TITLE_FROM_WORKSPACE" \
+             FAKE_GH_MODE=fail \
+             PATH="$fake_dir:$PATH" \
         .agent/scripts/worktree_create.sh --issue 888 --type layer --layer core --packages test_pkg 2>&1) || true
 
     cleanup_mock_layer_workspace
@@ -562,9 +572,15 @@ test_workspace_uses_workspace_gitbug_when_bridged() {
     cd "$WORKSPACE_DIR" || return 1
     install_fake_gitbug_helpers
 
+    # Stub gh — same rationale as test_layer_uses_project_gitbug_when_bridged.
+    local fake_dir
+    fake_dir=$(setup_fake_gh)
+
     local output
     output=$(FAKE_BRIDGE_MODE=workspace_only \
              FAKE_BUG_WORKSPACE_TITLE="HAPPY_PATH_TITLE" \
+             FAKE_GH_MODE=fail \
+             PATH="$fake_dir:$PATH" \
         .agent/scripts/worktree_create.sh --issue 777 --type workspace 2>&1) || true
 
     cleanup_mock_workspace

--- a/.agent/scripts/tests/test_worktree_create.sh
+++ b/.agent/scripts/tests/test_worktree_create.sh
@@ -804,6 +804,127 @@ test_find_worktree_by_skill_cross_repo_sort() {
 }
 run_test "find_worktree_by_skill picks newest timestamp across repo slugs" test_find_worktree_by_skill_cross_repo_sort
 
+# ===== wt_layer_pkg_dir tests =====
+
+# Helper: build a minimal layer-worktree shape with controlled inner contents.
+# Creates: <tmpdir>/<layer>_ws/src/<pkg> as either a real git repo, a regular
+# directory, or a symlink, depending on $kind.
+#   kind=git    → directory with a .git subdir (counts as inner git worktree)
+#   kind=plain  → directory without .git
+#   kind=symlink → symlink pointing at /tmp (skipped by the helper)
+_make_layer_pkg() {
+    local layer_root="$1" pkg_name="$2" kind="$3"
+    local pkg_dir="$layer_root/src/$pkg_name"
+    case "$kind" in
+        git)
+            mkdir -p "$pkg_dir"
+            ( cd "$pkg_dir" && git init -q && git config user.email t@e.com && git config user.name t && \
+              git config commit.gpgsign false && echo x > f && git add f && git commit -q -m i ) >/dev/null
+            ;;
+        plain)
+            mkdir -p "$pkg_dir"
+            ;;
+        symlink)
+            mkdir -p "$layer_root/src"
+            ln -s /tmp "$pkg_dir"
+            ;;
+    esac
+}
+
+test_wt_layer_pkg_dir_finds_first_git_worktree() {
+    local tmpdir; tmpdir=$(mktemp -d)
+    source "$SCRIPT_DIR/../_worktree_helpers.sh"
+
+    # Layer with one git package
+    mkdir -p "$tmpdir/core_ws"
+    _make_layer_pkg "$tmpdir/core_ws" "real_pkg" git
+
+    local result rc
+    result=$(wt_layer_pkg_dir "$tmpdir" 2>/dev/null); rc=$?
+    rm -rf "$tmpdir"
+
+    if [ $rc -ne 0 ]; then
+        echo "    Expected wt_layer_pkg_dir to succeed"
+        return 1
+    fi
+    if [[ "$result" != *"core_ws/src/real_pkg" ]]; then
+        echo "    Expected core_ws/src/real_pkg, got: $result"
+        return 1
+    fi
+    return 0
+}
+run_test "wt_layer_pkg_dir finds first inner git worktree" test_wt_layer_pkg_dir_finds_first_git_worktree
+
+test_wt_layer_pkg_dir_skips_symlinks_and_plain_dirs() {
+    local tmpdir; tmpdir=$(mktemp -d)
+    source "$SCRIPT_DIR/../_worktree_helpers.sh"
+
+    # Plain dir and symlink come first lexicographically; git package comes last.
+    # Helper must skip the first two and return the git one.
+    mkdir -p "$tmpdir/core_ws"
+    _make_layer_pkg "$tmpdir/core_ws" "a_plain" plain
+    _make_layer_pkg "$tmpdir/core_ws" "b_symlink" symlink
+    _make_layer_pkg "$tmpdir/core_ws" "z_real" git
+
+    local result rc
+    result=$(wt_layer_pkg_dir "$tmpdir" 2>/dev/null); rc=$?
+    rm -rf "$tmpdir"
+
+    if [ $rc -ne 0 ]; then
+        echo "    Expected wt_layer_pkg_dir to succeed"
+        return 1
+    fi
+    if [[ "$result" != *"core_ws/src/z_real" ]]; then
+        echo "    Expected core_ws/src/z_real (skipping plain + symlink), got: $result"
+        return 1
+    fi
+    return 0
+}
+run_test "wt_layer_pkg_dir skips symlinks and plain dirs" test_wt_layer_pkg_dir_skips_symlinks_and_plain_dirs
+
+test_wt_layer_pkg_dir_returns_failure_with_no_git_inner() {
+    local tmpdir; tmpdir=$(mktemp -d)
+    source "$SCRIPT_DIR/../_worktree_helpers.sh"
+
+    mkdir -p "$tmpdir/core_ws"
+    _make_layer_pkg "$tmpdir/core_ws" "only_plain" plain
+
+    local result rc
+    result=$(wt_layer_pkg_dir "$tmpdir" 2>/dev/null); rc=$?
+    rm -rf "$tmpdir"
+
+    if [ $rc -eq 0 ]; then
+        echo "    Expected wt_layer_pkg_dir to fail with no inner git worktree"
+        return 1
+    fi
+    return 0
+}
+run_test "wt_layer_pkg_dir returns failure with no inner git worktree" test_wt_layer_pkg_dir_returns_failure_with_no_git_inner
+
+test_wt_layer_pkg_dir_skips_symlinked_layers() {
+    local tmpdir; tmpdir=$(mktemp -d)
+    # Put the backing layer in its own directory so it doesn't get picked up
+    # by the *_ws glob inside $tmpdir.
+    local backing; backing=$(mktemp -d)
+    source "$SCRIPT_DIR/../_worktree_helpers.sh"
+
+    # The whole layer dir is a symlink — the helper must skip it.
+    mkdir -p "$backing/real_layer_ws/src"
+    _make_layer_pkg "$backing/real_layer_ws" "a_pkg" git
+    ln -s "$backing/real_layer_ws" "$tmpdir/core_ws"
+
+    local result rc
+    result=$(wt_layer_pkg_dir "$tmpdir" 2>/dev/null); rc=$?
+    rm -rf "$tmpdir" "$backing"
+
+    if [ $rc -eq 0 ]; then
+        echo "    Expected wt_layer_pkg_dir to fail (only symlinked layer present)"
+        return 1
+    fi
+    return 0
+}
+run_test "wt_layer_pkg_dir skips symlinked layer dirs" test_wt_layer_pkg_dir_skips_symlinked_layers
+
 # Summary
 echo "========================================"
 echo "TEST RESULTS"

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -600,7 +600,13 @@ if [ -n "$ISSUE_NUM" ]; then
         _BUG_FIRST_PKG="${_BUG_FIRST_PKG#"${_BUG_FIRST_PKG%%[![:space:]]*}"}"
         _BUG_FIRST_PKG="${_BUG_FIRST_PKG%"${_BUG_FIRST_PKG##*[![:space:]]}"}"
         _BUG_PKG_PATH="$ROOT_DIR/layers/main/${TARGET_LAYER}_ws/src/${_BUG_FIRST_PKG}"
-        if [ -d "$_BUG_PKG_PATH" ] && git -C "$_BUG_PKG_PATH" remote get-url origin &>/dev/null; then
+        # Use the package repo's dir whenever it's a git worktree, even
+        # if it has no `origin` remote configured. Origin is only needed
+        # for slug derivation (handled elsewhere), not for routing
+        # git-bug to the right repo. Tying this guard to origin would
+        # silently fall back to the workspace and reintroduce the #457
+        # collision for origin-less but otherwise valid project repos.
+        if [ -d "$_BUG_PKG_PATH" ] && git -C "$_BUG_PKG_PATH" rev-parse --git-dir &>/dev/null; then
             BUG_QUERY_DIR="$_BUG_PKG_PATH"
         fi
     fi

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -591,22 +591,46 @@ fi
 ISSUE_TITLE=""
 ISSUE_STATE=""
 if [ -n "$ISSUE_NUM" ]; then
-    # Try git-bug first for issue title and state (offline-capable)
+    # Determine which repo's git-bug cache to query for this issue.
+    # Issues live in the same repo as the code being modified:
+    #   - workspace/skill worktrees → workspace repo
+    #   - layer worktrees           → the project repo (first --packages entry)
+    # Querying the wrong repo's git-bug returns wrong-repo data when issue
+    # numbers collide (see #457). The bridge check below also makes this
+    # forward-compatible: project repos that aren't bridged today fall
+    # through to gh; once they are bridged, the same path picks them up.
+    BUG_QUERY_DIR="$ROOT_DIR"
+    if [ "$WORKTREE_TYPE" = "layer" ] && [ -n "$TARGET_PACKAGES" ]; then
+        _BUG_FIRST_PKG="${TARGET_PACKAGES%%,*}"
+        _BUG_FIRST_PKG="${_BUG_FIRST_PKG#"${_BUG_FIRST_PKG%%[![:space:]]*}"}"
+        _BUG_FIRST_PKG="${_BUG_FIRST_PKG%"${_BUG_FIRST_PKG##*[![:space:]]}"}"
+        _BUG_PKG_PATH="$ROOT_DIR/layers/main/${TARGET_LAYER}_ws/src/${_BUG_FIRST_PKG}"
+        if [ -d "$_BUG_PKG_PATH" ] && git -C "$_BUG_PKG_PATH" remote get-url origin &>/dev/null; then
+            BUG_QUERY_DIR="$_BUG_PKG_PATH"
+        fi
+    fi
+
+    # Try git-bug first for issue title and state (offline-capable),
+    # but only when the target repo actually has a git-bug bridge.
     _GITBUG_HELPERS="$(dirname "${BASH_SOURCE[0]}")/gitbug_helpers.sh"
     if [ -f "$_GITBUG_HELPERS" ]; then
         # shellcheck source=gitbug_helpers.sh
         source "$_GITBUG_HELPERS"
     fi
     _BUG_TITLE=""
-    if declare -F gitbug_lookup &>/dev/null; then
-        _BUG_TITLE=$(gitbug_lookup "$ROOT_DIR" "$ISSUE_NUM" title 2>/dev/null || echo "")
+    _GITBUG_ATTEMPTED=false
+    if declare -F gitbug_lookup &>/dev/null && \
+       declare -F gitbug_has_bridge &>/dev/null && \
+       gitbug_has_bridge "$BUG_QUERY_DIR"; then
+        _GITBUG_ATTEMPTED=true
+        _BUG_TITLE=$(gitbug_lookup "$BUG_QUERY_DIR" "$ISSUE_NUM" title 2>/dev/null || echo "")
     fi
     if [ -n "$_BUG_TITLE" ]; then
         ISSUE_TITLE="$_BUG_TITLE"
-        _BUG_STATE=$(gitbug_lookup "$ROOT_DIR" "$ISSUE_NUM" status 2>/dev/null || echo "")
+        _BUG_STATE=$(gitbug_lookup "$BUG_QUERY_DIR" "$ISSUE_NUM" status 2>/dev/null || echo "")
         [[ "${_BUG_STATE,,}" == "closed" ]] && ISSUE_STATE="CLOSED"
         [[ "${_BUG_STATE,,}" == "open" ]] && ISSUE_STATE="OPEN"
-    elif command -v git-bug &>/dev/null; then
+    elif [ "$_GITBUG_ATTEMPTED" = true ] && command -v git-bug &>/dev/null; then
         if command -v gh &>/dev/null; then
             echo "⚠️  git-bug lookup failed for #$ISSUE_NUM, falling back to gh API" >&2
         else

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -593,8 +593,10 @@ ISSUE_STATE=""
 if [ -n "$ISSUE_NUM" ]; then
     # Determine which repo's git-bug cache to query for this issue.
     # Issues live in the same repo as the code being modified:
-    #   - workspace/skill worktrees → workspace repo
-    #   - layer worktrees           → the project repo (first --packages entry)
+    #   - workspace worktrees → workspace repo
+    #   - layer worktrees     → the project repo (first --packages entry)
+    # (Skill worktrees set SKILL_NAME instead of ISSUE_NUM and fall into
+    # the else branch below — they don't reach this block.)
     # Querying the wrong repo's git-bug returns wrong-repo data when issue
     # numbers collide (see #457). The bridge check below also makes this
     # forward-compatible: project repos that aren't bridged today fall

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -32,23 +32,16 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
+# Shared helpers: extract_gh_slug, wt_layer_pkg_dir, find_worktree_by_skill, etc.
+# shellcheck source=_worktree_helpers.sh
+source "$SCRIPT_DIR/_worktree_helpers.sh"
+
 # Try to fetch a specific branch from origin.
 # Returns 0 on successful fetch, non-zero otherwise.
 fetch_remote_branch() {
     local git_path="$1"
     local branch="$2"
     git -C "$git_path" fetch --quiet origin -- "$branch" 2>/dev/null
-}
-
-# Extract a validated owner/repo slug from a GitHub remote URL.
-# Prints the slug on stdout; prints nothing for non-GitHub or malformed URLs.
-extract_gh_slug() {
-    local url="$1"
-    local slug
-    slug=$(echo "$url" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
-    if [[ "$slug" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
-        echo "$slug"
-    fi
 }
 
 # Resolve the .repos version (branch/tag) for a package name.

--- a/.agent/scripts/worktree_enter.sh
+++ b/.agent/scripts/worktree_enter.sh
@@ -247,13 +247,13 @@ else
     fi
 
     # Derive the GitHub slug of the issue's repo for gh --repo.
+    # extract_gh_slug (from _worktree_helpers.sh, sourced above) handles
+    # all supported URL forms — HTTPS, SCP, SSH, SSH-over-443 — and
+    # rejects substring/lookalike hosts.
     _GH_SLUG=""
     _BUG_REMOTE=$(git -C "$_BUG_QUERY_DIR" remote get-url origin 2>/dev/null || echo "")
-    if [[ -n "$_BUG_REMOTE" && "$_BUG_REMOTE" == *"github.com"* ]]; then
-        _GH_SLUG=$(echo "$_BUG_REMOTE" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
-        if ! [[ "$_GH_SLUG" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
-            _GH_SLUG=""
-        fi
+    if [ -n "$_BUG_REMOTE" ] && declare -F extract_gh_slug &>/dev/null; then
+        _GH_SLUG=$(extract_gh_slug "$_BUG_REMOTE")
     fi
 
     # Try git-bug first (offline-capable, fast), but only when the

--- a/.agent/scripts/worktree_enter.sh
+++ b/.agent/scripts/worktree_enter.sh
@@ -233,18 +233,46 @@ else
     # Fetch and display issue title so agents can verify they're on the right issue
     _ISSUE_TITLE=""
 
-    # Try git-bug first (offline-capable, fast)
+    # Determine which repo this issue belongs to (and therefore which
+    # repo's git-bug + gh queries should target). For workspace
+    # worktrees this is the workspace; for layer worktrees it's the
+    # first inner package's repo. Querying the wrong repo returns
+    # workspace data on issue-number collisions (see #457).
+    _BUG_QUERY_DIR="$ROOT_DIR"
+    if [ "$WORKTREE_TYPE" = "layer" ] && declare -F wt_layer_pkg_dir &>/dev/null; then
+        _PKG_DIR=$(wt_layer_pkg_dir "$WORKTREE_DIR" 2>/dev/null || echo "")
+        if [ -n "$_PKG_DIR" ]; then
+            _BUG_QUERY_DIR="$_PKG_DIR"
+        fi
+    fi
+
+    # Derive the GitHub slug of the issue's repo for gh --repo.
+    _GH_SLUG=""
+    _BUG_REMOTE=$(git -C "$_BUG_QUERY_DIR" remote get-url origin 2>/dev/null || echo "")
+    if [[ -n "$_BUG_REMOTE" && "$_BUG_REMOTE" == *"github.com"* ]]; then
+        _GH_SLUG=$(echo "$_BUG_REMOTE" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
+        if ! [[ "$_GH_SLUG" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
+            _GH_SLUG=""
+        fi
+    fi
+
+    # Try git-bug first (offline-capable, fast), but only when the
+    # target repo actually has a git-bug bridge configured.
     _GITBUG_HELPERS="$(dirname "${BASH_SOURCE[0]}")/gitbug_helpers.sh"
     if [ -f "$_GITBUG_HELPERS" ]; then
         # shellcheck source=gitbug_helpers.sh
         source "$_GITBUG_HELPERS"
     fi
-    if declare -F gitbug_lookup &>/dev/null; then
-        _ISSUE_TITLE=$(gitbug_lookup "$ROOT_DIR" "$ISSUE_NUM" title 2>/dev/null || echo "")
+    _GITBUG_ATTEMPTED=false
+    if declare -F gitbug_lookup &>/dev/null && \
+       declare -F gitbug_has_bridge &>/dev/null && \
+       gitbug_has_bridge "$_BUG_QUERY_DIR"; then
+        _GITBUG_ATTEMPTED=true
+        _ISSUE_TITLE=$(gitbug_lookup "$_BUG_QUERY_DIR" "$ISSUE_NUM" title 2>/dev/null || echo "")
     fi
 
-    # Fall back to gh API if git-bug didn't return a title
-    if [ -z "$_ISSUE_TITLE" ]; then
+    # Fall back to gh API if git-bug didn't return a title (and was attempted)
+    if [ -z "$_ISSUE_TITLE" ] && [ "$_GITBUG_ATTEMPTED" = true ]; then
         if command -v git-bug &>/dev/null; then
             if command -v gh &>/dev/null; then
                 echo "  ⚠️  git-bug lookup failed for #$ISSUE_NUM, falling back to gh API" >&2
@@ -254,17 +282,11 @@ else
         fi
     fi
     if [ -z "$_ISSUE_TITLE" ] && command -v gh &>/dev/null; then
-        _ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq '.title' 2>/dev/null || echo "")
-        # Layer worktrees cd into package repos where gh context may differ;
-        # retry with the workspace repo if the first attempt fails
-        if [ -z "$_ISSUE_TITLE" ]; then
-            _WS_REMOTE=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null || echo "")
-            if [[ -n "$_WS_REMOTE" && "$_WS_REMOTE" == *"github.com"* ]]; then
-                _WS_SLUG=$(echo "$_WS_REMOTE" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
-                if [[ "$_WS_SLUG" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
-                    _ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --repo "$_WS_SLUG" --json title --jq '.title' 2>/dev/null || echo "")
-                fi
-            fi
+        if [ -n "$_GH_SLUG" ]; then
+            _ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --repo "$_GH_SLUG" --json title --jq '.title' 2>/dev/null || echo "")
+        else
+            # No usable slug: best-effort using cwd's gh context
+            _ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq '.title' 2>/dev/null || echo "")
         fi
     fi
     export WORKTREE_ISSUE_TITLE="$_ISSUE_TITLE"

--- a/.agent/work-plans/PLAN_ISSUE-457.md
+++ b/.agent/work-plans/PLAN_ISSUE-457.md
@@ -97,7 +97,7 @@ whether it happens to be the workspace.
 |------|--------|
 | `.agent/scripts/worktree_create.sh` | Add `BUG_QUERY_DIR` resolution; gate `gitbug_lookup` on `gitbug_has_bridge`; pass `BUG_QUERY_DIR` to `gitbug_lookup` for both title and status; add short explanatory comment. |
 | `.agent/scripts/worktree_enter.sh` | Same fix pattern: resolve `_BUG_QUERY_DIR` per worktree type (uses new `wt_layer_pkg_dir` helper for layer worktrees), gate `gitbug_lookup` on `gitbug_has_bridge`, derive the right GitHub slug for `gh issue view --repo` (drop the workspace-fallback retry that was the gh-side bug). |
-| `.agent/scripts/_worktree_helpers.sh` | Add `wt_layer_pkg_dir` helper — finds the first inner package git worktree in a layer worktree dir. Mirrors `wt_layer_branch`'s iteration pattern. |
+| `.agent/scripts/_worktree_helpers.sh` | Add `wt_layer_pkg_dir` helper — finds the first inner package git worktree in a layer worktree dir. Mirrors `wt_layer_branch`'s iteration pattern. Also moves `extract_gh_slug` here (from `worktree_create.sh`) and hardens it: now correctly handles HTTPS, SCP-form, SSH URL, and SSH-over-443 (`ssh.github.com:443`) remotes, and rejects substring/lookalike hosts (`mygithub.com`, `gist.github.com`, etc.). Both worktree scripts share this implementation. |
 | `.agent/scripts/tests/test_worktree_create.sh` | Add three regression tests (collision, forward-compat, workspace sanity) for `worktree_create.sh` plus a fake-helpers installer; add unit tests for new `wt_layer_pkg_dir` helper (alongside existing `find_worktree_by_skill` tests, matching the file's existing convention of co-locating helper tests); also fix the pre-existing missing-manifest gap in `setup_mock_workspace` / `setup_mock_layer_workspace` (without it, no script-invoking test could run — see Implementation Notes). |
 
 ## Principles Self-Check
@@ -177,3 +177,24 @@ and one test file. No ADR touches, no doc updates.
   the `wt_layer_pkg_dir` helper to `_worktree_helpers.sh` so
   `worktree_enter.sh` can find the package's repo dir from the
   worktree at enter-time (where `--packages` is no longer in scope).
+- **`extract_gh_slug` hardening brought into scope after round-3
+  review**: Copilot pointed out two latent bugs in the existing
+  `extract_gh_slug` (defined in `worktree_create.sh`): (1) substring
+  host matching — `mygithub.com` was incorrectly accepted; (2) the
+  `sed`-based parser produced an invalid 3-segment slug for
+  `ssh://git@ssh.github.com:443/OWNER/REPO.git` (an officially
+  supported form per `AGENTS.md` and `field_mode.sh`'s allowlist),
+  causing validation to fail and leaving `GH_REPO_SLUG` empty. With
+  the new bridge gating, an empty slug means `gh issue view` runs
+  without `--repo`, which can fall back to the workspace repo via
+  cwd inference — re-introducing the wrong-repo bug. Fix: move
+  `extract_gh_slug` to `_worktree_helpers.sh` (single source of truth
+  for both worktree scripts) and replace the `sed` chain with a
+  bash regex anchored on URL boundaries that handles all officially
+  supported forms and rejects lookalike hosts. Quality Standard's
+  "fix it completely" applies: this is the same code path being
+  changed, the SSH-over-443 form is a documented workspace
+  capability, and the test mocks already exercise non-GitHub URLs
+  (so the regression risk is observable). 10 new unit tests cover
+  HTTPS / SCP / SSH / SSH-over-443, dotted repo names,
+  substring-host rejection, and malformed input.

--- a/.agent/work-plans/PLAN_ISSUE-457.md
+++ b/.agent/work-plans/PLAN_ISSUE-457.md
@@ -58,21 +58,23 @@ whether it happens to be the workspace.
    the constraint isn't being recorded in an ADR — the script comment +
    regression test + PR description carry the breadcrumb.
 
-5. **Regression test.** Add a focused test to
+5. **Regression tests.** Add focused tests to
    `.agent/scripts/tests/test_worktree_create.sh` covering:
    - Collision scenario: layer-type worktree, project repo unbridged,
-     stub `gitbug_lookup` to return a wrong-repo title — assert the gh
+     fake `gitbug_lookup` returns a wrong-repo title — assert the gh
      fallback path runs and the right title is reported.
    - Forward-compat scenario: layer-type worktree, project repo *is*
-     bridged (mocked) — assert `gitbug_lookup` is called against the
+     bridged (mocked) — assert `gitbug_lookup` is queried against the
      project repo's dir, not the workspace.
+   - Sanity scenario: workspace-type worktree, workspace bridged —
+     assert the original happy path still uses workspace git-bug data.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
 | `.agent/scripts/worktree_create.sh` | Add `BUG_QUERY_DIR` resolution; gate `gitbug_lookup` on `gitbug_has_bridge`; pass `BUG_QUERY_DIR` to `gitbug_lookup` for both title and status; add short explanatory comment. |
-| `.agent/scripts/tests/test_worktree_create.sh` | Add collision-scenario regression test and forward-compat (bridged-project-repo) test. |
+| `.agent/scripts/tests/test_worktree_create.sh` | Add three regression tests (collision, forward-compat, workspace sanity) plus a fake-helpers installer; also fix the pre-existing missing-manifest gap in `setup_mock_workspace` / `setup_mock_layer_workspace` (without it, no script-invoking test could run — see Implementation Notes). |
 
 ## Principles Self-Check
 
@@ -122,3 +124,22 @@ Single PR. Changes are localized to one script and one test file. No
 ADR touches, no doc updates. Estimate: ~30 lines of script change
 (`BUG_QUERY_DIR` resolution + gating + helper call updates), ~50–60
 lines of test (two scenarios with mocking).
+
+## Implementation Notes
+
+- **Test infrastructure fix**: `setup_mock_workspace` and
+  `setup_mock_layer_workspace` did not create
+  `configs/manifest/layers.txt`, which the script now requires (early
+  fatal exit). Every script-invoking test in the file (16/20) was
+  silently failing on `main`. Fixed by adding two lines to each setup
+  function. Without this, the new #457 regression tests could not run.
+  This is in scope under the Quality Standard's "fix it completely"
+  guidance — the pre-existing test gap actively blocks the new tests
+  this PR adds, and the fix is a one-line-per-function change.
+- **Third regression test added**: a workspace-type sanity test was
+  added beyond the two listed in the approach. Without it, the
+  bridge-gating change had no positive assertion that the workspace
+  happy path (the original ADR-0010 contract) still works — only
+  negative assertions that wrong data doesn't leak. The added test
+  costs ~15 lines and protects against silently disabling git-bug for
+  the workspace.

--- a/.agent/work-plans/PLAN_ISSUE-457.md
+++ b/.agent/work-plans/PLAN_ISSUE-457.md
@@ -17,9 +17,18 @@ _BUG_TITLE=$(gitbug_lookup "$ROOT_DIR" "$ISSUE_NUM" title 2>/dev/null || echo ""
 For layer-type worktrees, the issue lives in a project repo, not the
 workspace — so this returns the workspace repo's issue with the same
 number when one exists, populating both `ISSUE_TITLE` (line 605) and
-`ISSUE_STATE` (lines 606–608) from the wrong source. The `gh` fallback at
-line 632 only engages when both fields are empty, so once git-bug returns
-*anything* the wrong-repo data sticks.
+`ISSUE_STATE` (lines 606–608) from the wrong source. The `gh` fallback
+at line 632 engages only when at least one of those fields is empty
+(`[ -z "$ISSUE_TITLE" ] || [ -z "$ISSUE_STATE" ]`); in the collision
+case git-bug fills both fields with wrong-repo data, so neither is
+empty and the fallback never runs.
+
+The same defect exists in `worktree_enter.sh` (line 243): its
+`gitbug_lookup "$ROOT_DIR" ...` call is hardcoded to the workspace,
+and its `gh` fallback (lines 257–268) explicitly forces
+`--repo "$_WS_SLUG"` so even when git-bug isn't bridged the layer
+worktree's "Title:" line still shows workspace data. This PR fixes
+both scripts.
 
 The actual git work (branch, push, PR target) is unaffected — those paths
 correctly use `GH_REPO_SLUG`. The defect is in the human-facing metadata
@@ -33,14 +42,16 @@ whether it happens to be the workspace.
 
 ## Approach
 
-1. **Resolve the git-bug target dir per worktree type.** Add a
-   `BUG_QUERY_DIR` variable that points at the repo whose git-bug cache
-   should be queried for this issue:
-   - `workspace` and `skill` types → `$ROOT_DIR`
-   - `layer` type with `TARGET_PACKAGES` → the first package's repo dir
-     (`$ROOT_DIR/layers/main/${TARGET_LAYER}_ws/src/${FIRST_PKG}`, the
-     same path the slug-resolution block already computes at lines 533
-     and 577)
+1. **Resolve the git-bug target dir per worktree type, in both scripts.**
+   Add a `BUG_QUERY_DIR` variable that points at the repo whose git-bug
+   cache should be queried for this issue:
+   - `workspace` (and `skill`, in `worktree_create.sh`) → `$ROOT_DIR`
+   - `layer` worktrees → the first package's repo dir
+     - In `worktree_create.sh`: derived from `--packages` (the same path
+       the slug-resolution block already computes at lines 533 and 577).
+     - In `worktree_enter.sh`: derived from the worktree itself via the
+       new `wt_layer_pkg_dir` helper, which iterates `<wt>/*_ws/src/*`
+       and returns the first inner git worktree.
 
 2. **Gate the `gitbug_lookup` call on bridge presence.** Use the existing
    `gitbug_has_bridge "$BUG_QUERY_DIR"` helper from `gitbug_helpers.sh`.
@@ -50,15 +61,23 @@ whether it happens to be the workspace.
    automatically.
 
 3. **Pass `BUG_QUERY_DIR` to `gitbug_lookup`** instead of the hardcoded
-   `$ROOT_DIR`. Both the title call (line 602) and the status call
-   (line 606) need this change.
+   `$ROOT_DIR`. Covers both title and status fields.
 
-4. **Add a short comment** at the top of the gating block explaining why
-   the bridge check matters (collision scenario from #457). Per Option C,
-   the constraint isn't being recorded in an ADR — the script comment +
-   regression test + PR description carry the breadcrumb.
+4. **Fix the gh fallback in `worktree_enter.sh`.** The pre-fix code first
+   tried `gh issue view` without `--repo` (uses cwd's git context), then
+   on failure forced `--repo "$_WS_SLUG"` to the workspace — wrong for
+   layer worktrees. Replace with: derive the right slug from
+   `BUG_QUERY_DIR`'s origin once, pass it as `--repo` from the start. No
+   workspace-fallback retry. (`worktree_create.sh`'s `gh` fallback was
+   already correct — it uses `--repo "$GH_REPO_SLUG"` which is resolved
+   per worktree type at lines 549/580/584.)
 
-5. **Regression tests.** Add focused tests to
+5. **Add a short comment** at the top of each gating block explaining
+   why the bridge check matters (collision scenario from #457). Per
+   Option C, the constraint isn't being recorded in an ADR — the script
+   comments + regression tests + PR description carry the breadcrumb.
+
+6. **Regression tests.** Add focused tests to
    `.agent/scripts/tests/test_worktree_create.sh` covering:
    - Collision scenario: layer-type worktree, project repo unbridged,
      fake `gitbug_lookup` returns a wrong-repo title — assert the gh
@@ -68,13 +87,18 @@ whether it happens to be the workspace.
      project repo's dir, not the workspace.
    - Sanity scenario: workspace-type worktree, workspace bridged —
      assert the original happy path still uses workspace git-bug data.
+   - Unit tests for the new `wt_layer_pkg_dir` helper: finds the first
+     inner git worktree, skips plain dirs and symlinks, fails when no
+     inner worktree exists, skips symlinked layer dirs.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
 | `.agent/scripts/worktree_create.sh` | Add `BUG_QUERY_DIR` resolution; gate `gitbug_lookup` on `gitbug_has_bridge`; pass `BUG_QUERY_DIR` to `gitbug_lookup` for both title and status; add short explanatory comment. |
-| `.agent/scripts/tests/test_worktree_create.sh` | Add three regression tests (collision, forward-compat, workspace sanity) plus a fake-helpers installer; also fix the pre-existing missing-manifest gap in `setup_mock_workspace` / `setup_mock_layer_workspace` (without it, no script-invoking test could run — see Implementation Notes). |
+| `.agent/scripts/worktree_enter.sh` | Same fix pattern: resolve `_BUG_QUERY_DIR` per worktree type (uses new `wt_layer_pkg_dir` helper for layer worktrees), gate `gitbug_lookup` on `gitbug_has_bridge`, derive the right GitHub slug for `gh issue view --repo` (drop the workspace-fallback retry that was the gh-side bug). |
+| `.agent/scripts/_worktree_helpers.sh` | Add `wt_layer_pkg_dir` helper — finds the first inner package git worktree in a layer worktree dir. Mirrors `wt_layer_branch`'s iteration pattern. |
+| `.agent/scripts/tests/test_worktree_create.sh` | Add three regression tests (collision, forward-compat, workspace sanity) for `worktree_create.sh` plus a fake-helpers installer; add unit tests for new `wt_layer_pkg_dir` helper (alongside existing `find_worktree_by_skill` tests, matching the file's existing convention of co-locating helper tests); also fix the pre-existing missing-manifest gap in `setup_mock_workspace` / `setup_mock_layer_workspace` (without it, no script-invoking test could run — see Implementation Notes). |
 
 ## Principles Self-Check
 
@@ -112,18 +136,17 @@ the architecture already accommodates this without an ADR change.
 
 ## Open Questions
 
-- **File a follow-up issue for the ADR-0004 enforcement-hierarchy gap?**
-  The "verify issue matches before first commit" rule in AGENTS.md is
-  currently doc-only. A follow-up could propose a mechanical check
-  (e.g., a one-shot helper invoked at first-commit time). Open it now
-  or after this PR lands?
+None outstanding. (Decisions taken during plan iteration: Option C for
+the ADR question — no ADR touch — and skip the ADR-0004
+enforcement-hierarchy follow-up issue. Decision taken during review
+triage: fix `worktree_enter.sh` in this same PR rather than splitting
+to a follow-up issue.)
 
 ## Estimated Scope
 
-Single PR. Changes are localized to one script and one test file. No
-ADR touches, no doc updates. Estimate: ~30 lines of script change
-(`BUG_QUERY_DIR` resolution + gating + helper call updates), ~50–60
-lines of test (two scenarios with mocking).
+Single PR. Changes touch two scripts (`worktree_create.sh`,
+`worktree_enter.sh`), one shared helpers file (`_worktree_helpers.sh`),
+and one test file. No ADR touches, no doc updates.
 
 ## Implementation Notes
 
@@ -143,3 +166,14 @@ lines of test (two scenarios with mocking).
   negative assertions that wrong data doesn't leak. The added test
   costs ~15 lines and protects against silently disabling git-bug for
   the workspace.
+- **`worktree_enter.sh` brought into scope after triage**: Copilot's
+  bot review flagged the same defect class in `worktree_enter.sh`
+  (line 243's hardcoded `gitbug_lookup "$ROOT_DIR" ...` plus a worse
+  gh-side bug at line 265 that explicitly forces `--repo "$_WS_SLUG"`
+  for the workspace, so even unbridged layer worktrees got workspace
+  data). User decision: fix in same PR rather than splitting — fixing
+  half would leave the post-create banner correct but the
+  worktree_enter.sh "Title:" line still misleading. Required adding
+  the `wt_layer_pkg_dir` helper to `_worktree_helpers.sh` so
+  `worktree_enter.sh` can find the package's repo dir from the
+  worktree at enter-time (where `--packages` is no longer in scope).

--- a/.agent/work-plans/PLAN_ISSUE-457.md
+++ b/.agent/work-plans/PLAN_ISSUE-457.md
@@ -1,0 +1,106 @@
+# Plan: worktree_create.sh — gate git-bug lookup on workspace-repo target
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/457
+
+## Context
+
+`worktree_create.sh` resolves the issue title (and state) in two stages —
+git-bug first, `gh` as fallback. The git-bug call at line 602 is hardcoded
+to query `$ROOT_DIR` (the workspace) regardless of `WORKTREE_TYPE`:
+
+```bash
+_BUG_TITLE=$(gitbug_lookup "$ROOT_DIR" "$ISSUE_NUM" title 2>/dev/null || echo "")
+```
+
+For layer-type worktrees, the issue lives in a project repo, not the
+workspace — so this returns the workspace repo's issue with the same
+number when one exists, populating both `ISSUE_TITLE` (line 605) and
+`ISSUE_STATE` (lines 606–608) from the wrong source. The `gh` fallback at
+line 632 only engages when both fields are empty, so once git-bug returns
+*anything* the wrong-repo data sticks.
+
+The actual git work (branch, push, PR target) is unaffected — those paths
+correctly use `GH_REPO_SLUG`. The defect is in the human-facing metadata
+display only.
+
+## Approach
+
+1. **Capture the workspace's GitHub slug once.** Add `WORKSPACE_GH_SLUG`
+   resolution near the existing `GH_REPO_SLUG` logic (around lines 547–567),
+   pulling from `$ROOT_DIR`'s origin via `extract_gh_slug`. This becomes
+   the canonical "where git-bug data lives" identifier.
+
+2. **Gate the git-bug lookup.** At line 601, only call `gitbug_lookup`
+   when `GH_REPO_SLUG` is empty (best-effort fallback for unresolved
+   targets) **or** equals `WORKSPACE_GH_SLUG`. Mirrors the existing
+   cross-repo precedent at line 1192–1193.
+
+3. **No change to the `gh` fallback.** Lines 632–642 already correctly use
+   `--repo "$GH_REPO_SLUG"`. With git-bug gated, the fallback engages
+   automatically for project-repo issues and returns the right data.
+
+4. **Regression test.** Add a focused test to
+   `.agent/scripts/tests/test_worktree_create.sh` that simulates the
+   collision: stub `gitbug_lookup` to return a fake title, set
+   `GH_REPO_SLUG` to a non-workspace value, and assert the gh-fallback
+   path is taken (not the git-bug result).
+
+5. **ADR-0010 cross-reference addendum.** Add a References section to
+   ADR-0010 noting that `gitbug_lookup` is only valid against the bridged
+   (workspace) repo, with a link to #457 / this PR. Permitted under
+   ADR-0012 (cross-reference addendums).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/worktree_create.sh` | Add `WORKSPACE_GH_SLUG` resolution; gate `gitbug_lookup` call on `GH_REPO_SLUG = WORKSPACE_GH_SLUG` (or empty). |
+| `.agent/scripts/tests/test_worktree_create.sh` | Add collision-scenario regression test. |
+| `docs/decisions/0010-adopt-git-bug-for-local-issue-tracking.md` | References-section addendum (ADR-0012-style) noting the workspace-only validity. |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Banner stops misleading agents about which task they're on — direct improvement to a transparency surface. |
+| Enforcement over documentation | The doc-only "verify issue matches before first commit" rule survives this fix; the supporting tooling no longer lies. Mechanical enforcement of the verification rule itself is tracked separately (out of scope). |
+| Only what's needed | One gating condition + one slug capture; no new abstractions or helper functions beyond what already exists. |
+| Test what breaks | Regression test added for the exact collision scenario — the kind of "hard to find in the field" defect that justifies a permanent guard. |
+| A change includes its consequences | ADR-0010 addendum captures the workspace-only constraint for future scripts. AGENTS.md script-reference table needs no update (no signature change). |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | Decision unchanged; only the metadata-display path of an existing enforcement script. |
+| 0010 — git-bug for local issue tracking | Yes | Lookup priority preserved (git-bug → gh), but constrained to bridged repo. Addendum makes the constraint explicit for future maintainers. |
+| 0012 — Cross-reference addendums | Yes | Used as the mechanism for the ADR-0010 References-section update. |
+| 0004 — Enforcement hierarchy | Watch (deferred) | The doc-only "verify issue matches" rule is a separate enforcement-layer gap. Out of scope here; see Open Questions for follow-up. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `.agent/scripts/worktree_create.sh` | AGENTS.md script reference table; Makefile target | Not needed — invocation signature and Makefile integration unchanged. |
+| ADR in `docs/decisions/` | Review guide ADR table | Not needed — addendum only adds References, does not change ADR scope or decision. |
+| Worktree scripts | `.agent/WORKTREE_GUIDE.md`; AGENTS.md worktree section | Not needed — no behavior change visible to script users; only the displayed title becomes correct. |
+
+## Open Questions
+
+- **Land the ADR-0010 addendum in this PR, or split?** Recommend **same PR**:
+  it's a one-paragraph cross-reference change, ADR-0012-permitted, and
+  avoids a follow-up doc-only PR.
+- **File a separate issue for the ADR-0004 enforcement-hierarchy gap?**
+  The "verify issue matches before first commit" rule is currently
+  doc-only. Worth a follow-up issue proposing a mechanical check (e.g.,
+  a one-shot helper invoked at first-commit time). Should I open that
+  issue when this PR lands, or now?
+
+## Estimated Scope
+
+Single PR. Changes are localized to one script, one test file, and a
+References-section addendum on one ADR. No coordinated rollout, no
+migration. Estimate: ~30 lines of script change, ~40 lines of test,
+~10 lines of ADR addendum.

--- a/.agent/work-plans/PLAN_ISSUE-457.md
+++ b/.agent/work-plans/PLAN_ISSUE-457.md
@@ -177,6 +177,15 @@ and one test file. No ADR touches, no doc updates.
   the `wt_layer_pkg_dir` helper to `_worktree_helpers.sh` so
   `worktree_enter.sh` can find the package's repo dir from the
   worktree at enter-time (where `--packages` is no longer in scope).
+- **`extract_gh_slug` boundary tightened after round-4 review**:
+  Round-4 Copilot review caught that the initial hardening's boundary
+  class `(^|[@/])` still allowed `github.com` to appear inside a URL
+  path (e.g. `https://example.com/github.com/owner/repo.git` would
+  match the `/` before `github.com` and produce a false-positive
+  slug). Tightened the boundary to `(^|@|://)` so the host must be at
+  a true URL host position (start, after `@` auth section, or after
+  `://` protocol delimiter). Added regression cases for the
+  path-component scenarios.
 - **`extract_gh_slug` hardening brought into scope after round-3
   review**: Copilot pointed out two latent bugs in the existing
   `extract_gh_slug` (defined in `worktree_create.sh`): (1) substring

--- a/.agent/work-plans/PLAN_ISSUE-457.md
+++ b/.agent/work-plans/PLAN_ISSUE-457.md
@@ -1,4 +1,4 @@
-# Plan: worktree_create.sh — gate git-bug lookup on workspace-repo target
+# Plan: worktree_create.sh — query the right repo's git-bug, gate on bridge presence
 
 ## Issue
 
@@ -25,40 +25,54 @@ The actual git work (branch, push, PR target) is unaffected — those paths
 correctly use `GH_REPO_SLUG`. The defect is in the human-facing metadata
 display only.
 
+**Forward-compat constraint**: project repos are not currently git-bug-bridged,
+but they will be eventually. The fix must point `gitbug_lookup` at the
+*right* repo for the worktree type (not always the workspace) and must
+fall through to `gh` based on whether *that* repo is bridged — not based on
+whether it happens to be the workspace.
+
 ## Approach
 
-1. **Capture the workspace's GitHub slug once.** Add `WORKSPACE_GH_SLUG`
-   resolution near the existing `GH_REPO_SLUG` logic (around lines 547–567),
-   pulling from `$ROOT_DIR`'s origin via `extract_gh_slug`. This becomes
-   the canonical "where git-bug data lives" identifier.
+1. **Resolve the git-bug target dir per worktree type.** Add a
+   `BUG_QUERY_DIR` variable that points at the repo whose git-bug cache
+   should be queried for this issue:
+   - `workspace` and `skill` types → `$ROOT_DIR`
+   - `layer` type with `TARGET_PACKAGES` → the first package's repo dir
+     (`$ROOT_DIR/layers/main/${TARGET_LAYER}_ws/src/${FIRST_PKG}`, the
+     same path the slug-resolution block already computes at lines 533
+     and 577)
 
-2. **Gate the git-bug lookup.** At line 601, only call `gitbug_lookup`
-   when `GH_REPO_SLUG` is empty (best-effort fallback for unresolved
-   targets) **or** equals `WORKSPACE_GH_SLUG`. Mirrors the existing
-   cross-repo precedent at line 1192–1193.
+2. **Gate the `gitbug_lookup` call on bridge presence.** Use the existing
+   `gitbug_has_bridge "$BUG_QUERY_DIR"` helper from `gitbug_helpers.sh`.
+   If the target repo has no bridge, skip git-bug entirely and let the
+   `gh` fallback handle it. This is forward-compatible: when project
+   repos start getting bridged, the same code path picks them up
+   automatically.
 
-3. **No change to the `gh` fallback.** Lines 632–642 already correctly use
-   `--repo "$GH_REPO_SLUG"`. With git-bug gated, the fallback engages
-   automatically for project-repo issues and returns the right data.
+3. **Pass `BUG_QUERY_DIR` to `gitbug_lookup`** instead of the hardcoded
+   `$ROOT_DIR`. Both the title call (line 602) and the status call
+   (line 606) need this change.
 
-4. **Regression test.** Add a focused test to
-   `.agent/scripts/tests/test_worktree_create.sh` that simulates the
-   collision: stub `gitbug_lookup` to return a fake title, set
-   `GH_REPO_SLUG` to a non-workspace value, and assert the gh-fallback
-   path is taken (not the git-bug result).
+4. **Add a short comment** at the top of the gating block explaining why
+   the bridge check matters (collision scenario from #457). Per Option C,
+   the constraint isn't being recorded in an ADR — the script comment +
+   regression test + PR description carry the breadcrumb.
 
-5. **ADR-0010 cross-reference addendum.** Add a References section to
-   ADR-0010 noting that `gitbug_lookup` is only valid against the bridged
-   (workspace) repo, with a link to #457 / this PR. Permitted under
-   ADR-0012 (cross-reference addendums).
+5. **Regression test.** Add a focused test to
+   `.agent/scripts/tests/test_worktree_create.sh` covering:
+   - Collision scenario: layer-type worktree, project repo unbridged,
+     stub `gitbug_lookup` to return a wrong-repo title — assert the gh
+     fallback path runs and the right title is reported.
+   - Forward-compat scenario: layer-type worktree, project repo *is*
+     bridged (mocked) — assert `gitbug_lookup` is called against the
+     project repo's dir, not the workspace.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `.agent/scripts/worktree_create.sh` | Add `WORKSPACE_GH_SLUG` resolution; gate `gitbug_lookup` call on `GH_REPO_SLUG = WORKSPACE_GH_SLUG` (or empty). |
-| `.agent/scripts/tests/test_worktree_create.sh` | Add collision-scenario regression test. |
-| `docs/decisions/0010-adopt-git-bug-for-local-issue-tracking.md` | References-section addendum (ADR-0012-style) noting the workspace-only validity. |
+| `.agent/scripts/worktree_create.sh` | Add `BUG_QUERY_DIR` resolution; gate `gitbug_lookup` on `gitbug_has_bridge`; pass `BUG_QUERY_DIR` to `gitbug_lookup` for both title and status; add short explanatory comment. |
+| `.agent/scripts/tests/test_worktree_create.sh` | Add collision-scenario regression test and forward-compat (bridged-project-repo) test. |
 
 ## Principles Self-Check
 
@@ -66,41 +80,45 @@ display only.
 |---|---|
 | Human control and transparency | Banner stops misleading agents about which task they're on — direct improvement to a transparency surface. |
 | Enforcement over documentation | The doc-only "verify issue matches before first commit" rule survives this fix; the supporting tooling no longer lies. Mechanical enforcement of the verification rule itself is tracked separately (out of scope). |
-| Only what's needed | One gating condition + one slug capture; no new abstractions or helper functions beyond what already exists. |
-| Test what breaks | Regression test added for the exact collision scenario — the kind of "hard to find in the field" defect that justifies a permanent guard. |
-| A change includes its consequences | ADR-0010 addendum captures the workspace-only constraint for future scripts. AGENTS.md script-reference table needs no update (no signature change). |
+| Only what's needed | One new variable + one bridge check + correct argument to existing helpers; no new abstractions. Reuses `gitbug_has_bridge` which already exists. |
+| Test what breaks | Two regression tests: one for the current collision scenario, one for the forward-compat case where project repos become bridged. Catches regressions in both directions. |
+| A change includes its consequences | No doc updates required (no signature change, no ADR touch by design — see Option C decision below). PR description carries the architectural context. |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
 | 0002 — Worktree isolation | Yes | Decision unchanged; only the metadata-display path of an existing enforcement script. |
-| 0010 — git-bug for local issue tracking | Yes | Lookup priority preserved (git-bug → gh), but constrained to bridged repo. Addendum makes the constraint explicit for future maintainers. |
-| 0012 — Cross-reference addendums | Yes | Used as the mechanism for the ADR-0010 References-section update. |
+| 0010 — git-bug for local issue tracking | Yes (no change required) | The "lookup priority" rule is preserved as-is. The fix queries the *right* repo and falls through to `gh` when no bridge is present — both consistent with the ADR's existing language about graceful degradation. ADR text not modified (Option C, decided in planning). |
 | 0004 — Enforcement hierarchy | Watch (deferred) | The doc-only "verify issue matches" rule is a separate enforcement-layer gap. Out of scope here; see Open Questions for follow-up. |
+
+**ADR change decision (Option C)**: The constraint *"git-bug lookups must
+target the right repo and respect bridge presence"* lives in the script
+code (with an explanatory comment), the regression tests, and the PR
+description. No ADR addendum, no superseding ADR. Rationale: this is an
+implementation invariant, not a workspace-level architectural decision.
+The expectation that project repos may eventually be bridged is exactly
+why the gate is bridge-presence-based rather than workspace-only —
+the architecture already accommodates this without an ADR change.
 
 ## Consequences
 
 | If we change... | Also update... | Included in plan? |
 |---|---|---|
 | `.agent/scripts/worktree_create.sh` | AGENTS.md script reference table; Makefile target | Not needed — invocation signature and Makefile integration unchanged. |
-| ADR in `docs/decisions/` | Review guide ADR table | Not needed — addendum only adds References, does not change ADR scope or decision. |
 | Worktree scripts | `.agent/WORKTREE_GUIDE.md`; AGENTS.md worktree section | Not needed — no behavior change visible to script users; only the displayed title becomes correct. |
 
 ## Open Questions
 
-- **Land the ADR-0010 addendum in this PR, or split?** Recommend **same PR**:
-  it's a one-paragraph cross-reference change, ADR-0012-permitted, and
-  avoids a follow-up doc-only PR.
-- **File a separate issue for the ADR-0004 enforcement-hierarchy gap?**
-  The "verify issue matches before first commit" rule is currently
-  doc-only. Worth a follow-up issue proposing a mechanical check (e.g.,
-  a one-shot helper invoked at first-commit time). Should I open that
-  issue when this PR lands, or now?
+- **File a follow-up issue for the ADR-0004 enforcement-hierarchy gap?**
+  The "verify issue matches before first commit" rule in AGENTS.md is
+  currently doc-only. A follow-up could propose a mechanical check
+  (e.g., a one-shot helper invoked at first-commit time). Open it now
+  or after this PR lands?
 
 ## Estimated Scope
 
-Single PR. Changes are localized to one script, one test file, and a
-References-section addendum on one ADR. No coordinated rollout, no
-migration. Estimate: ~30 lines of script change, ~40 lines of test,
-~10 lines of ADR addendum.
+Single PR. Changes are localized to one script and one test file. No
+ADR touches, no doc updates. Estimate: ~30 lines of script change
+(`BUG_QUERY_DIR` resolution + gating + helper call updates), ~50–60
+lines of test (two scenarios with mocking).


### PR DESCRIPTION
Closes #457

## Summary

Fixes incorrect issue-title/state reporting in worktree banners on
**layer**-type worktrees when the same issue number exists in both
the workspace repo and the target project repo. Aligns the
human-facing metadata lookup with the actual target repo, leaving
the underlying git/PR targeting unchanged.

The root cause was that `gitbug_lookup` in both `worktree_create.sh`
and `worktree_enter.sh` was hardcoded to query the workspace repo's
git-bug cache. When git-bug returned wrong-repo data for a colliding
number, the gh fallback never ran — so the wrong title stuck.

## Changes

- **`.agent/scripts/worktree_create.sh`**: Add `BUG_QUERY_DIR`
  resolution that points at the workspace for workspace-type
  worktrees and at the first `--packages` entry for layer-type
  worktrees. Gate `gitbug_lookup` behind `gitbug_has_bridge` —
  forward-compatible: when project repos start getting bridged, the
  same code path picks them up automatically.
- **`.agent/scripts/worktree_enter.sh`**: Same fix pattern using the
  new `wt_layer_pkg_dir` helper (which finds the inner package
  worktree at enter-time, where `--packages` is no longer in scope).
  Drops the gh-side workspace-fallback retry (`--repo "$_WS_SLUG"`)
  that was the symmetrical bug on the enter path.
- **`.agent/scripts/_worktree_helpers.sh`**: New `wt_layer_pkg_dir`
  helper. Also moves `extract_gh_slug` here from `worktree_create.sh`
  and hardens it: handles HTTPS / SCP / SSH / SSH-over-443
  (`ssh.github.com:443`); rejects substring/lookalike hosts
  (`mygithub.com`, `gist.github.com`); regex anchored at start of
  string so `@github.com` mid-URL can't false-positive.
- **`.agent/scripts/tests/test_worktree_create.sh`**: Three regression
  tests for #457 (collision, forward-compat-bridged, workspace
  sanity); unit tests for `wt_layer_pkg_dir`; ten unit tests for the
  hardened `extract_gh_slug` covering the supported forms,
  lookalike-host rejection, and the `@github.com` mid-URL case. Also
  fixes a pre-existing test-harness gap: `setup_mock_workspace` /
  `setup_mock_layer_workspace` did not create the layer manifest the
  script requires, silently failing 16/20 script-invoking tests.
- **`.agent/work-plans/PLAN_ISSUE-457.md`**: The work plan, kept in
  sync with the implementation.

## Out of Scope

- ADR-0010 text is not modified — the constraint *"git-bug lookups
  must target the right repo and respect bridge presence"* lives in
  script comments, regression tests, and this PR description. The
  ADR's "graceful degradation when git-bug is unavailable" language
  already accommodates the bridge-presence gate.
- The doc-only "verify issue matches before first commit" rule is a
  separate enforcement-layer gap (ADR-0004 hierarchy). Out of scope
  here.

## Test plan

- [x] `bash .agent/scripts/tests/test_worktree_create.sh` — all 30
      tests pass.
- [x] Lint hooks pass on every commit.
- [x] Manual: layer-type worktree on a project repo with a colliding
      issue number now displays the project repo's title, not the
      workspace's.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
