### PR TITLE
review-code: --skip-static / --no-progress / --issue overrides + distinct pre-push header

### DIFF
--- a/.agent/work-plans/issue-460/plan.md
+++ b/.agent/work-plans/issue-460/plan.md
@@ -1,0 +1,144 @@
+# Plan: review-code flag additions + distinct pre-push progress header (#460)
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/460
+
+## Context
+
+PR #453 ported the dual-mode `/review-code` from `rolker/agent_workspace`.
+Upstream PR [rolker/agent_workspace#185](https://github.com/rolker/agent_workspace/pull/185)
+landed afterwards and refined the same skill with four small additions.
+The inspiration-tracker run that produced PR #459 captured these as
+Pending Review in `.agent/knowledge/inspiration_agent_workspace_digest.md`;
+this PR lands them.
+
+All four additions are additive on top of the dual-mode shape we shipped.
+No design unknowns — the upstream implementation answers each. The work
+is small enough that one PR with four atomic commits is the right shape
+(per the workspace's bundle-related-cleanups preference).
+
+## Scope
+
+All edits are in `.claude/skills/review-code/SKILL.md`. No other files
+need to change.
+
+### 1. `--skip-static` flag (both modes)
+
+Suppress the Static Analysis Specialist when set. Useful when pre-commit
+was already clean or the user has run linters separately. Surfaces in
+the report header as `**Static analysis**: skipped (--skip-static)`.
+
+Touch points:
+- **Usage block** — add to both mode lines
+- **Step 1 argument parsing** — recognize and consume the flag, export
+  `SKIP_STATIC=true`
+- **Step 5a** — early-return when `SKIP_STATIC=true`; emit a one-line
+  "skipped (--skip-static)" note for the silence filter and report
+- **Step 7 report headers** — show the skip status when set
+- **Step 7 silence-filter wording** — clarify that at Light tier with
+  `--skip-static`, zero specialists run and the "No findings" path
+  fires automatically
+
+### 2. `--no-progress` flag (pre-push mode)
+
+Explicit opt-out for `progress.md` persistence. Today the skill skips
+persistence silently when no issue can be resolved from the branch
+name; `--no-progress` makes the opt-out user-visible and decouples it
+from the issue-resolution failure path.
+
+Touch points:
+- **Usage block** — add to pre-push line
+- **Step 1 pre-push subsection** — argument parsing; export
+  `NO_PROGRESS=true`
+- **Step 8 entry point** — skip the entire persistence step when
+  `NO_PROGRESS=true`; note "skipped (--no-progress)" in report Summary
+
+This flag does **not** apply to post-PR mode (a PR with no closing
+references is the post-PR equivalent and already handled by step 8's
+fallthrough). Don't add it to the post-PR Usage line.
+
+### 3. `--issue <N>` override (pre-push mode)
+
+Allow explicit issue arg to override the branch-name extraction at
+Step 1 line 113–114. Useful for skill worktrees and one-off branches
+whose names don't carry `issue-<N>`.
+
+Touch points:
+- **Usage block** — add to pre-push line
+- **Step 1 pre-push subsection** — argument parsing; when present,
+  set `ISSUE_NUM=<arg>` and skip the branch-name extraction
+
+The override is mutually exclusive with `--no-progress` only in spirit
+(they both relate to progress.md handling). Don't enforce an error if
+both are passed — `--no-progress` wins (no persistence regardless of
+issue number).
+
+### 4. Distinct `## Local Review (Pre-Push)` vs `## Local Review` headers
+
+Allow pre-push and post-PR entries for the same issue to coexist on
+the timeline.
+
+Touch points:
+- **Step 8 template** — switch header between `## Local Review` and
+  `## Local Review (Pre-Push)` based on mode
+- The `**PR**` / `**Branch**` placeholder split landed in PR #453
+  triage already covers the body; only the header needs updating
+
+## Out of scope
+
+- **Cross-model script `--branch` mode** (upstream PR #185 also touches
+  `cross_model_review.sh`). Not applicable here — we explicitly didn't
+  port cross-model. Recorded under "Not adopted" in the digest.
+- **`_resolve_default_branch.sh` helper**. Equivalent to our existing
+  in-skill resolution (with the pipefail fix from PR #453 triage R5-1).
+  No porting needed.
+
+## Implementation order
+
+Four atomic commits, each independently revertable:
+
+1. `--skip-static` (largest — affects step 1 + step 5a + step 7)
+2. `--no-progress` (step 1 + step 8)
+3. `--issue <N>` override (step 1 + interaction with step 8)
+4. Distinct pre-push header (step 8 template)
+
+## Test plan
+
+The skill is markdown — there's no executable test. Verification is
+manual against the documented behavior:
+
+- [ ] Read each touched section after each commit; confirm the flag
+      is mentioned in Usage and handled in the relevant Step.
+- [ ] After commit 1, confirm `--skip-static` references match across
+      Usage, Step 1, Step 5a, Step 7.
+- [ ] After commit 2, confirm `--no-progress` is only on the pre-push
+      Usage line (not post-PR).
+- [ ] After commit 3, confirm `--issue <N>` argument parsing overrides
+      branch-name extraction in a clear way.
+- [ ] After commit 4, confirm `## Local Review (Pre-Push)` header is
+      conditional on mode, with an example template entry.
+- [ ] Run `/review-code` pre-push on the resulting diff before opening
+      the PR (per AGENTS.md Post-Task Verification step 5).
+
+## Open questions
+
+None. All four items have clear upstream precedent.
+
+## Principles self-check
+
+| Principle | Compliance |
+|---|---|
+| Only what's needed | Yes — four narrow additions, no scope creep. |
+| Human control and transparency | Yes — all four flags are user-facing opt-ins; defaults preserve current behavior. |
+| Test what breaks | Limited — skill is markdown, no automated tests. Manual verification + pre-push self-review covers this. |
+| Capture decisions, not just implementations | Plan + atomic commit messages reference each upstream source. |
+| Bundle related cleanups; don't split | One PR, four atomic commits — matches the bundle preference for this kind of additive port. |
+
+## Consequences
+
+- `.agent/knowledge/inspiration_agent_workspace_digest.md` Pending
+  Review section will need its 4 items moved to "Ported" after merge —
+  the inspiration-tracker skill handles this automatically on the next
+  run, no manual edit needed in this PR.
+- No external surfaces affected. No project repos touched.

--- a/.agent/work-plans/issue-460/progress.md
+++ b/.agent/work-plans/issue-460/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 460
+---
+
+# Issue #460 — review-code: add --skip-static / --no-progress / --issue overrides + distinct pre-push progress header
+
+## External Review
+**Status**: complete
+**When**: 2026-05-18 16:30
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #462 — 2 review(s), 3 valid, 5 plan-file/low-priority
+**CI**: all-pass (8 checks)
+
+### Actions
+- [ ] Fix SKILL.md wording inconsistency: line 520 ("Progress persistence skipped (no linked issue)") vs line 585 ("Findings not persisted: no linked issue") — pick one canonical Summary string.
+- [ ] Add `--skip-static` skip status line to Light condensed format (line 480–496) and No-findings format (line 498–506) so SA-skipped runs are never silent.
+- [ ] Split progress.md template snippet at line 549–552 into two mode-tagged blocks (post-PR vs pre-push) for copy/paste safety.
+- [ ] (Optional) Dismiss the four plan-file Copilot comments — implementation supersedes plan structure.

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -8,15 +8,19 @@ description: Lead reviewer that orchestrates specialist sub-reviews (static anal
 ## Usage
 
 ```
-/review-code                                # pre-push: diff vs default branch
-/review-code --base <branch>                # pre-push, override default base
-/review-code <pr-number>                    # post-PR: diff vs PR base
-/review-code <pr-url>                       # post-PR
-/review-code <pr-number> [light|standard|deep]   # post-PR with depth override
+/review-code [--base <branch>] [--skip-static] [light|standard|deep]
+                                            # pre-push: diff vs default branch
+/review-code <pr-number-or-url> [--skip-static] [light|standard|deep]
+                                            # post-PR: diff vs PR base
 ```
 
-The optional depth keyword (`light` / `standard` / `deep`) overrides
-automatic classification.
+Flags:
+- **depth keyword** (`light` / `standard` / `deep`, positional) overrides
+  automatic classification.
+- **`--base <branch>`** (pre-push only) overrides the default base branch.
+- **`--skip-static`** (both modes) suppresses the Static Analysis
+  Specialist. Useful when pre-commit was already clean or linters were
+  run separately; the report header notes the skip.
 
 ## Overview
 
@@ -61,24 +65,28 @@ post comments or modify the PR unless the user asks.
 
 ### 1. Detect mode and gather diff context
 
-Determine pre-push vs post-PR mode from the arguments. Parse out the
-optional depth keyword first (`light` / `standard` / `deep` — positional,
-matching the Usage block above), then classify what remains:
+Parse the arguments in this order: extract `--skip-static` (sets
+`SKIP_STATIC=true`), then `--base <branch>` (sets `USER_BASE`), then
+the optional depth keyword (`light` / `standard` / `deep` — positional).
+Classify what remains:
 
-- Empty, or only `--base <branch>` → **pre-push mode**
+- Empty → **pre-push mode**
 - A number or `https://github.com/.../pull/<N>` → **post-PR mode**
 
-The depth keyword is positional and may appear after the PR number /
-URL or after `--base <branch>`. The same syntax applies in both modes.
-Examples:
+The depth keyword and `--skip-static` may appear in any order around
+the PR number / URL or `--base <branch>`. The same syntax applies in
+both modes. Examples:
 
 ```
-/review-code                       # pre-push, auto-classify
-/review-code deep                  # pre-push, force Deep
-/review-code --base develop        # pre-push, override base
-/review-code --base develop deep   # pre-push with override + force Deep
-/review-code 42                    # post-PR, auto-classify
-/review-code 42 standard           # post-PR, force Standard
+/review-code                                # pre-push, auto-classify
+/review-code deep                           # pre-push, force Deep
+/review-code --base develop                 # pre-push, override base
+/review-code --base develop deep            # pre-push with override + force Deep
+/review-code --skip-static                  # pre-push, skip static analysis
+/review-code --skip-static light            # pre-push, light + skip static
+/review-code 42                             # post-PR, auto-classify
+/review-code 42 standard                    # post-PR, force Standard
+/review-code 42 --skip-static               # post-PR, skip static analysis
 ```
 
 #### Pre-push mode
@@ -261,9 +269,16 @@ lifecycle checklist).
 
 #### 5a. Static Analysis Specialist
 
-Run linters on **changed files only**, using the config profile from
-step 4. See `.agent/knowledge/review_static_analysis.md` for exact
-commands and flags.
+**Skip if `SKIP_STATIC=true`** (`--skip-static` flag passed in step 1):
+emit no findings for this specialist and note "Static analysis skipped
+(--skip-static)" so the report header can surface it. At Light tier
+with `--skip-static`, zero specialists run and the silence filter
+produces the "No findings" output — that's the documented behavior,
+not a bug.
+
+Otherwise, run linters on **changed files only**, using the config
+profile from step 4. See `.agent/knowledge/review_static_analysis.md`
+for exact commands and flags.
 
 If **no linter profile matches any changed file**, report this
 explicitly: "No static analysis profile configured for these file types
@@ -395,6 +410,7 @@ Collect all findings from all dispatched specialists and filter:
 **Repo**: workspace | <project-repo>
 **Files changed**: <count> (+<additions> -<deletions>)
 **Review depth**: <Light|Standard|Deep> (reason: <primary signal>)
+**Static analysis**: <run | skipped (--skip-static)>
 **Context**: <status of review-context.yaml — fresh / stale / not found / N/A>
 
 ### Must-Fix

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -541,11 +541,15 @@ issue: <N>
 # Issue #<N> — <issue title>
 ```
 
-Append this step entry:
+Append this step entry. Use `## Local Review` in post-PR mode and
+`## Local Review (Pre-Push)` in pre-push mode so the same issue can
+carry both a pre-push and a post-PR entry on its timeline without one
+overwriting the other:
 
 ```markdown
 
-## Local Review
+## Local Review              <!-- post-PR mode -->
+## Local Review (Pre-Push)   <!-- pre-push mode -->
 **Status**: complete
 **When**: <YYYY-MM-DD HH:MM>
 **By**: <agent name> (<model>)

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -8,7 +8,7 @@ description: Lead reviewer that orchestrates specialist sub-reviews (static anal
 ## Usage
 
 ```
-/review-code [--base <branch>] [--skip-static] [light|standard|deep]
+/review-code [--base <branch>] [--skip-static] [--no-progress] [light|standard|deep]
                                             # pre-push: diff vs default branch
 /review-code <pr-number-or-url> [--skip-static] [light|standard|deep]
                                             # post-PR: diff vs PR base
@@ -21,6 +21,11 @@ Flags:
 - **`--skip-static`** (both modes) suppresses the Static Analysis
   Specialist. Useful when pre-commit was already clean or linters were
   run separately; the report header notes the skip.
+- **`--no-progress`** (pre-push only) opts out of `progress.md`
+  persistence. Use for skill worktrees and one-off branches that don't
+  have an associated issue. Does not apply to post-PR mode — a PR with
+  no closing references is already handled by step 8's no-issue
+  fallthrough.
 
 ## Overview
 
@@ -66,9 +71,10 @@ post comments or modify the PR unless the user asks.
 ### 1. Detect mode and gather diff context
 
 Parse the arguments in this order: extract `--skip-static` (sets
-`SKIP_STATIC=true`), then `--base <branch>` (sets `USER_BASE`), then
-the optional depth keyword (`light` / `standard` / `deep` — positional).
-Classify what remains:
+`SKIP_STATIC=true`), `--no-progress` (sets `NO_PROGRESS=true`, pre-push
+only — emit an error if passed in post-PR mode), `--base <branch>`
+(sets `USER_BASE`), then the optional depth keyword (`light` /
+`standard` / `deep` — positional). Classify what remains:
 
 - Empty → **pre-push mode**
 - A number or `https://github.com/.../pull/<N>` → **post-PR mode**
@@ -84,6 +90,7 @@ both modes. Examples:
 /review-code --base develop deep            # pre-push with override + force Deep
 /review-code --skip-static                  # pre-push, skip static analysis
 /review-code --skip-static light            # pre-push, light + skip static
+/review-code --no-progress                  # pre-push, don't write progress.md
 /review-code 42                             # post-PR, auto-classify
 /review-code 42 standard                    # post-PR, force Standard
 /review-code 42 --skip-static               # post-PR, skip static analysis
@@ -488,6 +495,15 @@ No issues found. LGTM.
 
 After outputting the report to the conversation, append a step entry to
 `progress.md` so findings survive across sessions.
+
+**Skip this entire step** when `NO_PROGRESS=true` (`--no-progress` flag,
+pre-push only). Add a one-line note to the report Summary: "Progress
+persistence skipped (--no-progress)." Use this when the review is on a
+skill worktree or one-off branch that doesn't have an associated issue
+and shouldn't accumulate a timeline. Step 8 also no-ops naturally when
+no issue number can be resolved (rare field-mode case) — that's
+distinct from the explicit opt-out and gets a different Summary
+message: "Progress persistence skipped (no linked issue)."
 
 **Locate or create progress.md**: Use the issue number resolved in step 1.
 Determine which repo owns the linked issue (workspace repo for workspace

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -8,7 +8,7 @@ description: Lead reviewer that orchestrates specialist sub-reviews (static anal
 ## Usage
 
 ```
-/review-code [--base <branch>] [--skip-static] [--no-progress] [light|standard|deep]
+/review-code [--base <branch>] [--skip-static] [--no-progress] [--issue <N>] [light|standard|deep]
                                             # pre-push: diff vs default branch
 /review-code <pr-number-or-url> [--skip-static] [light|standard|deep]
                                             # post-PR: diff vs PR base
@@ -26,6 +26,12 @@ Flags:
   have an associated issue. Does not apply to post-PR mode — a PR with
   no closing references is already handled by step 8's no-issue
   fallthrough.
+- **`--issue <N>`** (pre-push only) explicit issue number override.
+  Use when the branch name doesn't match `feature/issue-<N>` /
+  `feature/ISSUE-<N>-…` (e.g., skill worktrees, manually named
+  branches). When passed, the branch-name extraction at step 1 is
+  skipped. Mutually compatible with `--no-progress` — `--no-progress`
+  wins (no persistence regardless of issue number).
 
 ## Overview
 
@@ -72,9 +78,11 @@ post comments or modify the PR unless the user asks.
 
 Parse the arguments in this order: extract `--skip-static` (sets
 `SKIP_STATIC=true`), `--no-progress` (sets `NO_PROGRESS=true`, pre-push
-only — emit an error if passed in post-PR mode), `--base <branch>`
-(sets `USER_BASE`), then the optional depth keyword (`light` /
-`standard` / `deep` — positional). Classify what remains:
+only — emit an error if passed in post-PR mode), `--issue <N>` (sets
+`USER_ISSUE=<N>`, pre-push only — emit an error if passed in post-PR
+mode, where `closingIssuesReferences` is authoritative), `--base
+<branch>` (sets `USER_BASE`), then the optional depth keyword (`light`
+/ `standard` / `deep` — positional). Classify what remains:
 
 - Empty → **pre-push mode**
 - A number or `https://github.com/.../pull/<N>` → **post-PR mode**
@@ -91,6 +99,7 @@ both modes. Examples:
 /review-code --skip-static                  # pre-push, skip static analysis
 /review-code --skip-static light            # pre-push, light + skip static
 /review-code --no-progress                  # pre-push, don't write progress.md
+/review-code --issue 460                    # pre-push, override branch-name issue extraction
 /review-code 42                             # post-PR, auto-classify
 /review-code 42 standard                    # post-PR, force Standard
 /review-code 42 --skip-static               # post-PR, skip static analysis
@@ -136,9 +145,14 @@ git diff "origin/$BASE...HEAD" --stat
 git diff "origin/$BASE...HEAD"
 git diff "origin/$BASE...HEAD" --numstat   # per-file +/- counts
 
-# Linked issue from branch name (feature/issue-<N> or feature/ISSUE-<N>-...)
+# Linked issue: explicit --issue <N> wins; otherwise extract from branch
+# name (feature/issue-<N> or feature/ISSUE-<N>-...).
 BRANCH=$(git branch --show-current)
-ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+|ISSUE-[0-9]+' | grep -oE '[0-9]+' | head -1)
+if [[ -n "$USER_ISSUE" ]]; then
+    ISSUE_NUM="$USER_ISSUE"
+else
+    ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+|ISSUE-[0-9]+' | grep -oE '[0-9]+' | head -1)
+fi
 ```
 
 `--base <branch>` is parsed from the argument list before the snippet

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -485,6 +485,7 @@ Existing Review Comments sections. Use:
 
 **PR / Branch**: ...
 **Review depth**: Light (reason: <primary signal>)
+**Static analysis**: skipped (--skip-static)         <!-- include only when SKIP_STATIC=true -->
 
 ### Static Analysis
 
@@ -495,6 +496,8 @@ Existing Review Comments sections. Use:
 No governance concerns for a change of this scope.
 ```
 
+When `SKIP_STATIC=true` and no other specialists fire (Light + `--skip-static` = zero specialists), drop the `### Static Analysis` table entirely and use the No-findings format below — the `**Static analysis**: skipped` header line carries the only signal that needs to surface.
+
 **No findings format** — if no findings exist across all sections:
 
 ```markdown
@@ -502,6 +505,7 @@ No governance concerns for a change of this scope.
 
 **PR / Branch**: ...
 **Review depth**: <tier> (reason: <signal>)
+**Static analysis**: skipped (--skip-static)         <!-- include only when SKIP_STATIC=true -->
 No issues found. LGTM.
 ```
 
@@ -541,15 +545,15 @@ issue: <N>
 # Issue #<N> — <issue title>
 ```
 
-Append this step entry. Use `## Local Review` in post-PR mode and
-`## Local Review (Pre-Push)` in pre-push mode so the same issue can
-carry both a pre-push and a post-PR entry on its timeline without one
-overwriting the other:
+Append this step entry. The snippet below shows the post-PR header; in
+pre-push mode change just the header to `## Local Review (Pre-Push)` so
+the same issue can carry both a pre-push and a post-PR entry on its
+timeline without one overwriting the other. Append only one header line
+— never both.
 
 ```markdown
 
-## Local Review              <!-- post-PR mode -->
-## Local Review (Pre-Push)   <!-- pre-push mode -->
+## Local Review
 **Status**: complete
 **When**: <YYYY-MM-DD HH:MM>
 **By**: <agent name> (<model>)
@@ -582,7 +586,8 @@ Key points:
   git -C <worktree-path> commit -m "progress: local review for #<N>"
   ```
 - If no issue number was resolved in step 1, skip persistence and note
-  this in the report Summary ("Findings not persisted: no linked issue").
+  this in the report Summary ("Progress persistence skipped (no linked
+  issue)") — the same canonical wording used in the step-8 intro above.
 
 ## Guidelines
 


### PR DESCRIPTION
Closes #460

Draft PR for visibility; implementation will follow in four atomic commits.

## Summary

Ports four upstream `review-code` refinements from `rolker/agent_workspace` ([PR #185](https://github.com/rolker/agent_workspace/pull/185)) that were captured as Pending Review in `.agent/knowledge/inspiration_agent_workspace_digest.md` after PR #453 landed.

All four are additive on top of the dual-mode shape shipped in [#453](https://github.com/rolker/ros2_agent_workspace/pull/453). No design unknowns; one PR with four atomic commits.

Plan: `.agent/work-plans/issue-460/plan.md`

## Items

- [ ] `--skip-static` flag — suppress Static Analysis Specialist
- [ ] `--no-progress` flag (pre-push) — explicit `progress.md` opt-out
- [ ] `--issue <N>` override (pre-push) — explicit issue number
- [ ] Distinct `## Local Review (Pre-Push)` header — coexist with post-PR entries

## Test plan

Skill is markdown — manual verification. See plan's "Test plan" section. Pre-push `/review-code` self-check before push.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
