### PR TITLE
[PLAN] Scope a Copilot-only cross-model adversarial review (revisit "Not adopted")

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -56,10 +56,12 @@ a PR. The skill body is plain markdown at
 [`.claude/skills/review-code/SKILL.md`](../.claude/skills/review-code/SKILL.md);
 follow its steps regardless of framework.
 
-**Adversarial Specialist is Claude-only** — its dispatch relies on
-Claude Code's `Agent` tool. Other frameworks should run the remaining
-specialists (Static Analysis, Governance, Plan Drift) and note that
-Adversarial was skipped due to the runtime.
+**Claude Adversarial Specialist is Claude-only** — its dispatch
+relies on Claude Code's `Agent` tool. Other frameworks should run the
+remaining specialists (Static Analysis, Governance, Plan Drift,
+**Copilot Adversarial** — provided the `copilot` CLI is installed and
+authenticated) and note that Claude Adversarial was skipped due to
+the runtime.
 
 ## Workflow Skills
 

--- a/.agent/instructions/gemini-cli.instructions.md
+++ b/.agent/instructions/gemini-cli.instructions.md
@@ -28,11 +28,13 @@ a PR. This applies to Gemini CLI sessions too. The skill body is plain
 markdown at [`.claude/skills/review-code/SKILL.md`](../../.claude/skills/review-code/SKILL.md);
 follow its steps as you would any other governance skill.
 
-**Adversarial Specialist is Claude-only** — its dispatch relies on
-Claude Code's `Agent` tool to launch a fresh subagent with no shared
-context. Gemini doesn't expose an equivalent. Run the other specialists
-(Static Analysis, Governance, Plan Drift) and note in the report header
-that Adversarial was skipped because the runtime is Gemini.
+**Claude Adversarial Specialist is Claude-only** — its dispatch
+relies on Claude Code's `Agent` tool to launch a fresh subagent with
+no shared context. Gemini doesn't expose an equivalent. Run the other
+specialists (Static Analysis, Governance, Plan Drift, **Copilot
+Adversarial** — provided the `copilot` CLI is installed and
+authenticated) and note in the report header that Claude Adversarial
+was skipped because the runtime is Gemini.
 
 
 ## Workflow Skills

--- a/.agent/knowledge/inspiration_agent_workspace_digest.md
+++ b/.agent/knowledge/inspiration_agent_workspace_digest.md
@@ -57,10 +57,10 @@ of the surrounding tooling.
   Standard / Deep tier criteria, and user-override syntax. Adapted to
   workspace-and-project repo paths and framed **experimental** until
   thresholds are validated against real PR data.
-- **Adversarial Specialist (Claude-only)** in `review-code`. Fresh-context
+- **Adversarial Specialist (Claude)** in `review-code`. Fresh-context
   subagent dispatched at Standard and Deep tiers via `Agent`, with no
-  context from other specialists. Cross-model variant deliberately not
-  ported (see "Not adopted" below).
+  context from other specialists. A Copilot-only slice of the upstream
+  cross-model variant is also ported — see "Partially adopted" below.
 - **`review-code` dual-mode + depth dispatch.** Pre-push mode (no arg)
   diffs against the current repo's default branch; post-PR mode
   (`<N>` or URL) diffs against the PR base. Specialists dispatched per
@@ -73,16 +73,41 @@ of the surrounding tooling.
   plan file, or `--issue <N>` (resolved to
   `.agent/work-plans/issue-<N>/plan.md`).
 
-## Not adopted
+## Partially adopted
 
-- **Cross-Model Adversarial Specialist** (`.agent/scripts/cross_model_review.sh`,
-  Gemini/Codex/Copilot tmux dispatch). The workspace doesn't standardize
-  on multi-CLI review yet, and the tmux session machinery adds complexity
-  beyond the highest-leverage subset (Claude-only adversarial). Revisit
-  if multi-CLI review becomes a workflow we actually exercise.
+- **Copilot Adversarial Specialist** (`review-code` step 5e). Ported in
+  PR #464 (issue #461). Synchronous Copilot CLI dispatch (`copilot -p ""
+  --allow-all-tools < prompt`), no tmux, default-on at Light + Standard
+  + Deep, opt-out via `--no-copilot`, graceful skip when the CLI is
+  missing or unauthenticated (covers field hosts gabby/salmon). The
+  v1 context choice is the Copilot CLI default (~25.5k token floor) —
+  scheduled for evaluation against real-PR cost data; see the
+  cost-evaluation follow-up issue
+  ([#467](https://github.com/rolker/ros2_agent_workspace/issues/467)).
+  Light-tier activation produces a deliberate resource inversion (a
+  trivial PR's Light review now consumes more external token budget
+  than yesterday's Standard) — accepted as a v1 tradeoff for the
+  cross-model second-read signal, revisited once cost data is in.
+- **What remains unadopted**: the tmux-orchestrated multi-CLI dispatch
+  in `cross_model_review.sh` and the Gemini/Codex specialists. The
+  tmux session machinery adds complexity beyond the highest-leverage
+  subset and the workspace doesn't standardize on Gemini or Codex.
+  Revisit if multi-CLI parallel review (beyond Claude + Copilot)
+  becomes a workflow we actually exercise.
   - **Update 2026-05-15**: upstream extended the script with `--branch`
     mode and a `_resolve_default_branch.sh` helper (PR #185). Still not
-    applicable here for the same reason — the script itself isn't ported.
+    applicable to the unadopted slice — the script itself isn't ported,
+    only the Copilot single-CLI invocation pattern was lifted.
+  - **Upstream invocation report**:
+    [rolker/agent_workspace#212](https://github.com/rolker/agent_workspace/issues/212)
+    flags that upstream's `copilot -p < prompt` likely misses
+    `-p ""` and `--allow-all-tools`; the Copilot dispatch may be
+    silently broken or version-dependent. Decoupled from this
+    workspace's adoption.
+
+## Not adopted
+
+_None outstanding._
 
 ## Deferred
 

--- a/.agent/knowledge/inspiration_agent_workspace_digest.md
+++ b/.agent/knowledge/inspiration_agent_workspace_digest.md
@@ -57,7 +57,7 @@ of the surrounding tooling.
   Standard / Deep tier criteria, and user-override syntax. Adapted to
   workspace-and-project repo paths and framed **experimental** until
   thresholds are validated against real PR data.
-- **Adversarial Specialist (Claude)** in `review-code`. Fresh-context
+- **Claude Adversarial Specialist** in `review-code`. Fresh-context
   subagent dispatched at Standard and Deep tiers via `Agent`, with no
   context from other specialists. A Copilot-only slice of the upstream
   cross-model variant is also ported — see "Partially adopted" below.

--- a/.agent/knowledge/review_depth_classification.md
+++ b/.agent/knowledge/review_depth_classification.md
@@ -66,10 +66,14 @@ source path differs:
 - No Deep promotion triggers
 
 **Specialists dispatched**:
-- Static Analysis only
+- Static Analysis
+- Copilot Adversarial (synchronous Copilot CLI; skipped with notice if
+  unavailable; suppressed entirely by `--no-copilot`)
 
-**Report format**: Condensed — static analysis findings plus a one-line
-governance note ("No governance concerns for a change of this scope").
+**Report format**: Condensed — static analysis findings, Copilot
+Adversarial findings (or a one-line skip notice / omitted entirely
+when `--no-copilot` was used), plus a one-line governance note
+("No governance concerns for a change of this scope").
 
 #### Standard
 
@@ -82,7 +86,9 @@ governance note ("No governance concerns for a change of this scope").
 - Static Analysis
 - Governance
 - Plan Drift
-- Adversarial (Claude, fresh context)
+- Claude Adversarial (fresh context)
+- Copilot Adversarial (synchronous Copilot CLI; skipped with notice if
+  unavailable; suppressed entirely by `--no-copilot`)
 
 **Report format**: Full report with all sections.
 
@@ -96,19 +102,21 @@ governance note ("No governance concerns for a change of this scope").
 - Any Deep promotion trigger
 
 **Specialists dispatched**:
-- Same as Standard. The Adversarial Specialist is already running at
-  Standard; Deep adds extra emphasis in the prompt (longer file horizon,
-  explicit security/concurrency/lifecycle checklist) but uses the same
-  fresh-context dispatch mechanism.
+- Same as Standard. Both adversarial specialists (Claude and Copilot)
+  are already running at Standard; Deep adds extra emphasis in the
+  prompt (longer file horizon, explicit security/concurrency/lifecycle
+  checklist) but uses the same fresh-context dispatch mechanism.
 
 **Report format**: Full report with all sections.
 
-> **Note on cross-model adversarial**: The fork runs a Cross-Model
-> Adversarial Specialist at Deep tier (`cross_model_review.sh` —
-> Gemini/Codex/Copilot via tmux). That dispatch is not adopted here (see
-> the "Not adopted" entry in `inspiration_agent_workspace_digest.md`).
-> When we want a second model's read on a Deep PR, run that agent's
-> review-code skill manually.
+> **Note on cross-model adversarial**: The Copilot-only slice of
+> upstream's Cross-Model Adversarial Specialist is wired in as
+> `review-code` step 5e (synchronous Copilot CLI, no tmux,
+> default-on at all tiers, `--no-copilot` opt-out) — see the
+> "Partially adopted" entry in `inspiration_agent_workspace_digest.md`.
+> The Gemini/Codex tmux dispatch from upstream `cross_model_review.sh`
+> remains unadopted. When you want a third or fourth model's read on a
+> Deep PR, run that agent's review-code skill manually.
 
 ## Override-Trigger Files
 

--- a/.agent/knowledge/skill_workflows.md
+++ b/.agent/knowledge/skill_workflows.md
@@ -19,9 +19,11 @@ and `.agent/AGENT_ONBOARDING.md` mirror this for non-Claude runtimes;
 the Claude Adversarial Specialist still requires Claude Code's `Agent`
 tool, but the Copilot Adversarial Specialist runs from any runtime
 that has the `copilot` CLI available). Pre-push mode (no arguments)
-catches static-analysis, governance, plan-drift, and Adversarial
-findings while still cheap to fix locally; `review-code` also accepts
-a PR number / URL for post-PR review of someone else's work.
+catches issues while still cheap to fix locally; the specialists that
+actually run depend on the auto-classified depth tier — Light runs
+Static Analysis + Copilot Adversarial only, while Standard and Deep
+add Governance, Plan Drift, and Claude Adversarial. `review-code` also
+accepts a PR number / URL for post-PR review of someone else's work.
 `triage-reviews` runs after a PR has accumulated review comments
 (human + bot) and classifies each against the current code.
 

--- a/.agent/knowledge/skill_workflows.md
+++ b/.agent/knowledge/skill_workflows.md
@@ -15,12 +15,14 @@ Most steps are optional — simple issues can skip straight to
 AGENTS.md Post-Task Verification step 5 makes a pre-push `review-code`
 pass an expected check before opening a PR (the framework adapters in
 `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`,
-and `.agent/AGENT_ONBOARDING.md` mirror this for non-Claude runtimes
-with the Adversarial-Claude-only caveat). Pre-push mode (no
-arguments) catches static-analysis, governance, plan-drift, and
-Adversarial findings while still cheap to fix locally; `review-code`
-also accepts a PR number / URL for post-PR review of someone else's
-work. `triage-reviews` runs after a PR has accumulated review comments
+and `.agent/AGENT_ONBOARDING.md` mirror this for non-Claude runtimes;
+the Claude Adversarial Specialist still requires Claude Code's `Agent`
+tool, but the Copilot Adversarial Specialist runs from any runtime
+that has the `copilot` CLI available). Pre-push mode (no arguments)
+catches static-analysis, governance, plan-drift, and Adversarial
+findings while still cheap to fix locally; `review-code` also accepts
+a PR number / URL for post-PR review of someone else's work.
+`triage-reviews` runs after a PR has accumulated review comments
 (human + bot) and classifies each against the current code.
 
 ## Skill Index

--- a/.agent/work-plans/issue-461/plan.md
+++ b/.agent/work-plans/issue-461/plan.md
@@ -83,10 +83,13 @@ acceptance-criteria questions were resolved 2026-05-18:
 
 | File | Change |
 |------|--------|
-| `.claude/skills/review-code/SKILL.md` | Add 5e Copilot Adversarial subsection (Standard prompt reused on Light + Deep adds existing Deep focus areas); add `--no-copilot` to Usage + arg parser; update step-5 tier dispatch to fire 5e on all tiers; update Light condensed report format (lines 444–459) to include Copilot findings slot; replace 5d cross-model-not-wired note with pointer to 5e |
-| `.agent/knowledge/inspiration_agent_workspace_digest.md` | Move Cross-Model entry from "Not adopted" → new "Partially adopted" entry; preserve non-Copilot non-adoption rationale; fix line ~62 ("Ported → Adversarial Specialist") stale "Cross-model variant deliberately not ported" sentence |
+| `.claude/skills/review-code/SKILL.md` | Add 5e Copilot Adversarial subsection (Standard prompt reused on Light + Deep adds existing Deep focus areas); add `--no-copilot` to Usage + arg parser; update step-5 tier dispatch to fire 5e on all tiers; update Light condensed report format to include Copilot findings slot; rename 5d to "Claude Adversarial Specialist"; replace 5d cross-model-not-wired note with pointer to 5e |
+| `.agent/knowledge/inspiration_agent_workspace_digest.md` | Move Cross-Model entry from "Not adopted" → new "Partially adopted" entry; preserve non-Copilot non-adoption rationale; fix the "Ported → Adversarial Specialist" stale "Cross-model variant deliberately not ported" sentence |
 | `.agent/knowledge/review_depth_classification.md` | Add Copilot Adversarial to Light/Standard/Deep specialist lists; invert the "Note on cross-model adversarial" block; add Copilot slot to Light condensed report description |
-| `.agent/knowledge/skill_workflows.md` | Reword or remove line 18 "Adversarial-Claude-only caveat" reference |
+| `.agent/knowledge/skill_workflows.md` | Reword the "Adversarial-Claude-only caveat" reference to "the Claude Adversarial Specialist still requires Claude Code's `Agent` tool, but the Copilot Adversarial Specialist runs from any runtime that has the `copilot` CLI" |
+| `.github/copilot-instructions.md` | Rename "Adversarial Specialist is Claude-only" to "Claude Adversarial Specialist is Claude-only"; add Copilot Adversarial to framework-agnostic list; update the pre-push caveat (Copilot's pre-push pass cannot catch *Claude*-side adversarial findings — Copilot Adversarial runs natively) |
+| `.agent/instructions/gemini-cli.instructions.md` | Same rename + Copilot Adversarial addition pattern as the Copilot adapter |
+| `.agent/AGENT_ONBOARDING.md` | Same rename + Copilot Adversarial addition pattern as the Copilot adapter |
 
 No new script file. The invocation is small enough (3–4 lines: probe,
 call, strip trailing block) to live inline in SKILL.md as part of step
@@ -120,7 +123,7 @@ call, strip trailing block) to live inline in SKILL.md as part of step
 |---|---|---|
 | `review-code` specialist set (add 5e) | `inspiration_agent_workspace_digest.md` "Not adopted" → "Partially adopted" | Yes — Step 5 |
 | `review-code` Usage (`--no-copilot`) | None — `review-code` is invoked as a skill; no other consumers of its CLI surface | Verify via workspace grep before commit |
-| `review-code` specialist set | `AGENTS.md` / `CLAUDE.md` references to review-code | Workspace grep planned during implementation (no specialist-list enumeration found in earlier passes) |
+| `review-code` specialist set | Framework adapters that reference "Adversarial Specialist is Claude-only" | Yes — Files-to-Change row added during implementation for `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md`. The original plan said "no specialist-list enumeration found"; that was wrong — three adapters carried the stale phrasing |
 | Cross-model "not adopted" / "Claude-only" prose in knowledge docs | `review_depth_classification.md`, `skill_workflows.md`, `inspiration_agent_workspace_digest.md` (line ~62 in "Ported" section) | Yes — listed in Files to Change + Step 5a/5b |
 | Default-on Premium-request consumption | Cost-evaluation follow-up issue | Yes — Step 7 |
 | Upstream `cross_model_review.sh` invocation suspected broken | Issue filed on `rolker/agent_workspace` | Yes — Step 6 |
@@ -140,6 +143,19 @@ derived questions that the original four didn't directly address:
 
 ## Estimated Scope
 
-Single PR. Two file edits + two new issues filed (one upstream, one
-follow-up). No new scripts unless inline shell exceeds ~15 lines
-during implementation.
+Single PR. Four-plus knowledge/skill file edits, three framework-adapter
+edits, and two new issues filed (one upstream, one follow-up). No new
+scripts — inline shell stayed under 15 lines as anticipated.
+
+## Implementation Notes
+
+- **Framework adapters carried stale "Claude-only" phrasing.** Plan-time
+  workspace grep was scoped narrowly; in-flight grep
+  (`grep -rln -E "cross-model|cross_model|Claude.{0,5}only|..."`) found
+  three additional consumers: `.github/copilot-instructions.md`,
+  `.agent/instructions/gemini-cli.instructions.md`, and
+  `.agent/AGENT_ONBOARDING.md`. All three said "Adversarial Specialist
+  is Claude-only" — actively wrong after this PR. Folded into the same
+  knowledge-doc commit since the prose change is identical
+  (rename to "Claude Adversarial Specialist", add Copilot Adversarial
+  as framework-agnostic).

--- a/.agent/work-plans/issue-461/plan.md
+++ b/.agent/work-plans/issue-461/plan.md
@@ -35,14 +35,26 @@ acceptance-criteria questions were resolved 2026-05-18:
    lifecycle / cross-cutting effects). Update the Light condensed
    report format (review-code SKILL.md lines 444–459) to include a
    Copilot Adversarial findings slot.
-2. **Implement availability detection.** Before invoking, probe with
-   `command -v copilot` and a quick auth check
-   (`copilot --version` succeeds without prompting). On failure, emit a
-   one-line `Copilot Adversarial skipped: <reason>` finding and
-   continue. No flag needed.
+2. **Implement availability detection + post-invocation guard.**
+   Before invoking, probe with `command -v copilot` and a sanity check
+   `copilot --version` (presence-only — explicitly not an auth check;
+   real auth detection happens after the call). After invoking, route
+   timeout (exit 124), non-zero exit, empty output, or auth-error
+   text in the output to the skipped-with-notice path so
+   unauthenticated hosts never surface as silent zero-finding reviews.
+   Wrap the invocation in `timeout 300` so a hung CLI cannot block
+   the whole review. (Post-review hardening; see Implementation Notes.)
+2a. **Implement untrusted-PR safety gate** (post-PR mode only). Before
+    dispatching 5e, check whether the PR head is from a fork or the
+    author lacks OWNER/MEMBER/COLLABORATOR association. If so, route to
+    the skipped-with-notice path unless `--allow-untrusted-copilot` is
+    set. Rationale: `--allow-all-tools` exposes file/shell access to
+    Copilot, and an external contributor's diff is attacker-controlled
+    prompt content. (Post-review hardening; see Implementation Notes.)
 3. **Add `--no-copilot` flag** to the `review-code` Usage block and
    argument parser. When set, skip dispatch entirely without the
-   "skipped" notice.
+   "skipped" notice. Also add `--allow-untrusted-copilot` (post-PR only)
+   as the explicit bypass for step 2a's gate.
 4. **Update the Specialists overview** in step 5 to list 5a–5e and
    remove the "Cross-model adversarial is intentionally not wired here"
    note from 5d (replace with a pointer to 5e).
@@ -83,19 +95,23 @@ acceptance-criteria questions were resolved 2026-05-18:
 
 | File | Change |
 |------|--------|
-| `.claude/skills/review-code/SKILL.md` | Add 5e Copilot Adversarial subsection (Standard prompt reused on Light + Deep adds existing Deep focus areas); add `--no-copilot` to Usage + arg parser; update step-5 tier dispatch to fire 5e on all tiers; update Light condensed report format to include Copilot findings slot; rename 5d to "Claude Adversarial Specialist"; replace 5d cross-model-not-wired note with pointer to 5e |
+| `.claude/skills/review-code/SKILL.md` | Add 5e Copilot Adversarial subsection (Standard prompt reused on Light + Deep adds existing Deep focus areas); add `--no-copilot` and `--allow-untrusted-copilot` to Usage + arg parser; update step-5 tier dispatch to fire 5e on all tiers; update Light condensed report format to include Copilot findings slot; rename 5d to "Claude Adversarial Specialist"; replace 5d cross-model-not-wired note with pointer to 5e. Post-review hardening: `timeout 300` wrapper, post-invocation guard (empty / auth-error / non-zero exit / timeout → skipped path), untrusted-PR safety gate, `**Copilot Adversarial**:` parallel header line in both standard and Light condensed report templates, qualified "Light + --skip-static = zero specialists" predicate to require Copilot also suppressed. |
 | `.agent/knowledge/inspiration_agent_workspace_digest.md` | Move Cross-Model entry from "Not adopted" → new "Partially adopted" entry; preserve non-Copilot non-adoption rationale; fix the "Ported → Adversarial Specialist" stale "Cross-model variant deliberately not ported" sentence |
 | `.agent/knowledge/review_depth_classification.md` | Add Copilot Adversarial to Light/Standard/Deep specialist lists; invert the "Note on cross-model adversarial" block; add Copilot slot to Light condensed report description |
-| `.agent/knowledge/skill_workflows.md` | Reword the "Adversarial-Claude-only caveat" reference to "the Claude Adversarial Specialist still requires Claude Code's `Agent` tool, but the Copilot Adversarial Specialist runs from any runtime that has the `copilot` CLI" |
-| `.github/copilot-instructions.md` | Rename "Adversarial Specialist is Claude-only" to "Claude Adversarial Specialist is Claude-only"; add Copilot Adversarial to framework-agnostic list; update the pre-push caveat (Copilot's pre-push pass cannot catch *Claude*-side adversarial findings — Copilot Adversarial runs natively) |
+| `.agent/knowledge/skill_workflows.md` | Reword the "Adversarial-Claude-only caveat" reference to "the Claude Adversarial Specialist still requires Claude Code's `Agent` tool, but the Copilot Adversarial Specialist runs from any runtime that has the `copilot` CLI"; qualify the pre-push coverage claim by tier (Light = SA+Copilot only; Standard/Deep add Governance + Plan Drift + Claude Adversarial). |
+| `.github/copilot-instructions.md` | Rename "Adversarial Specialist is Claude-only" to "Claude Adversarial Specialist is Claude-only"; add Copilot Adversarial to framework-agnostic list; update the pre-push caveat (Copilot's pre-push pass cannot catch *Claude*-side adversarial findings — Copilot Adversarial runs natively); qualify the pre-push coverage claim by tier. |
 | `.agent/instructions/gemini-cli.instructions.md` | Same rename + Copilot Adversarial addition pattern as the Copilot adapter |
 | `.agent/AGENT_ONBOARDING.md` | Same rename + Copilot Adversarial addition pattern as the Copilot adapter |
 
-No new script file. The invocation is small enough (3–4 lines: probe,
-call, strip trailing block) to live inline in SKILL.md as part of step
-5e, matching how 5a–5d are documented. If the inline shell grows past
-~15 lines during implementation, factor into
-`.agent/scripts/run_copilot_adversarial.sh`.
+No new script file. The inline shell in SKILL.md grew past the
+original ~15-line threshold during post-review hardening (now ~60
+lines across probe + gate + invocation + post-call guard), but the
+content is kept inline rather than factored to
+`.agent/scripts/run_copilot_adversarial.sh` because the security model
+(`--allow-all-tools` + the untrusted-PR gate) needs to be visible to
+the next agent reading 5e — not buried behind a script reference.
+Revisit the factor-out decision if 5e accumulates non-security
+elaboration in a future change.
 
 ## Principles Self-Check
 
@@ -144,8 +160,11 @@ derived questions that the original four didn't directly address:
 ## Estimated Scope
 
 Single PR. Four-plus knowledge/skill file edits, three framework-adapter
-edits, and two new issues filed (one upstream, one follow-up). No new
-scripts — inline shell stayed under 15 lines as anticipated.
+edits, and two new issues filed (one upstream, one follow-up). Inline
+shell grew past the original ~15-line threshold during post-review
+hardening (timeout + post-invocation guard + untrusted-PR gate) but
+is kept inline; see the note under "Files to Change" and Implementation
+Notes for rationale.
 
 ## Implementation Notes
 
@@ -159,3 +178,33 @@ scripts — inline shell stayed under 15 lines as anticipated.
   knowledge-doc commit since the prose change is identical
   (rename to "Claude Adversarial Specialist", add Copilot Adversarial
   as framework-agnostic).
+
+- **Untrusted-PR safety gate added during post-PR review pass.**
+  The original Step 2 only covered availability detection (binary
+  missing / auth failure). Post-PR review of PR #464 surfaced that
+  `--allow-all-tools` + post-PR mode on contributor diffs grants
+  Copilot file/shell access to prompt content that originated outside
+  the repo's trust boundary. User chose the "explicit confirmation
+  gate" option: external PRs (fork head OR author association below
+  COLLABORATOR) route to the skipped path unless
+  `--allow-untrusted-copilot` is passed. Implemented as a new step 2a
+  in 5e between the availability probe and the invocation. The flag
+  is post-PR only (an error if passed in pre-push, where the gate
+  doesn't apply).
+
+- **Post-invocation guard formalized.** Step 2's original prose said
+  "post-call empty findings or auth-text routes to skipped-notice
+  path" but the snippet didn't actually enforce that. Post-PR review
+  flagged this as a discrepancy between the documented contract and
+  the shown code. The hardened snippet now includes explicit checks
+  for timeout (exit 124), non-zero exit, empty findings file, and
+  auth-error grep patterns — each routes to the skipped path with a
+  specific reason. Plus a `timeout 300` wrapper so a hung CLI cannot
+  block the whole review (field-mode-relevant when connectivity is
+  flaky).
+
+- **Light-tier zero-specialist predicate corrected.** With 5e firing
+  at Light, the prior "Light + --skip-static = zero specialists"
+  predicate became conditional on Copilot also being suppressed. Both
+  the Step 5a comment and the Step 7 report-format guidance updated
+  to reflect the new precondition.

--- a/.agent/work-plans/issue-461/plan.md
+++ b/.agent/work-plans/issue-461/plan.md
@@ -28,9 +28,13 @@ acceptance-criteria questions were resolved 2026-05-18:
    Synchronous call, no tmux. Invocation:
    `copilot -p "" --allow-all-tools < prompt > findings 2>&1`. Strip
    the trailing `Changes / Requests / Tokens` metadata block.
-   Activates on Light + Standard + Deep. Prompt mirrors Claude
-   Adversarial's tier-appropriate focus areas (Light reuses the
-   Standard prompt body since Claude Adversarial doesn't run on Light).
+   Activates on Light + Standard + Deep. **Light tier reuses the
+   Standard prompt body** (settled 2026-05-18 after review-plan
+   flagged this as an unsurfaced design choice); Deep tier adds the
+   existing Deep-prompt focus areas (security / concurrency /
+   lifecycle / cross-cutting effects). Update the Light condensed
+   report format (review-code SKILL.md lines 444–459) to include a
+   Copilot Adversarial findings slot.
 2. **Implement availability detection.** Before invoking, probe with
    `command -v copilot` and a quick auth check
    (`copilot --version` succeeds without prompting). On failure, emit a
@@ -46,6 +50,25 @@ acceptance-criteria questions were resolved 2026-05-18:
    Cross-Model entry from "Not adopted" to a new "Partially adopted"
    section: Copilot-only synchronous dispatch ported; tmux machinery
    and Gemini/Codex remain non-adopted with the existing rationale.
+   Also edit the "Ported → Adversarial Specialist" entry (line ~62)
+   which currently states "Cross-model variant deliberately not
+   ported" — that sentence directly contradicts the new partial
+   adoption.
+
+5a. **Update `.agent/knowledge/review_depth_classification.md`.** Three
+    sites go stale on merge:
+    - Light / Standard / Deep specialist lists (~lines 68–69, 81–86,
+      98–102) — add Copilot Adversarial to all three.
+    - "Note on cross-model adversarial" block (~lines 106–111) — its
+      "not adopted here" framing inverts after this PR.
+    - Light condensed report description (~lines 71–72) — needs a
+      slot or pointer for Copilot findings to match the SKILL.md
+      Light report shape.
+
+5b. **Update `.agent/knowledge/skill_workflows.md` line 18.** The
+    "Adversarial-Claude-only caveat" reference (applied to non-Claude
+    framework adapters) becomes stale once Copilot Adversarial is
+    in-tree on all tiers. Reword or remove.
 6. **File the upstream invocation report** on
    `rolker/agent_workspace` as a discrete step. Title: "cross_model_review.sh:
    Copilot invocation likely missing `-p \"\"` and `--allow-all-tools`".
@@ -60,8 +83,10 @@ acceptance-criteria questions were resolved 2026-05-18:
 
 | File | Change |
 |------|--------|
-| `.claude/skills/review-code/SKILL.md` | Add 5e Copilot Adversarial subsection; add `--no-copilot` to Usage + arg parser; update step-5 tier table to dispatch 5e on all tiers; replace 5d cross-model-not-wired note with pointer to 5e |
-| `.agent/knowledge/inspiration_agent_workspace_digest.md` | Move Cross-Model entry from "Not adopted" → new "Partially adopted" entry; preserve non-Copilot non-adoption rationale |
+| `.claude/skills/review-code/SKILL.md` | Add 5e Copilot Adversarial subsection (Standard prompt reused on Light + Deep adds existing Deep focus areas); add `--no-copilot` to Usage + arg parser; update step-5 tier dispatch to fire 5e on all tiers; update Light condensed report format (lines 444–459) to include Copilot findings slot; replace 5d cross-model-not-wired note with pointer to 5e |
+| `.agent/knowledge/inspiration_agent_workspace_digest.md` | Move Cross-Model entry from "Not adopted" → new "Partially adopted" entry; preserve non-Copilot non-adoption rationale; fix line ~62 ("Ported → Adversarial Specialist") stale "Cross-model variant deliberately not ported" sentence |
+| `.agent/knowledge/review_depth_classification.md` | Add Copilot Adversarial to Light/Standard/Deep specialist lists; invert the "Note on cross-model adversarial" block; add Copilot slot to Light condensed report description |
+| `.agent/knowledge/skill_workflows.md` | Reword or remove line 18 "Adversarial-Claude-only caveat" reference |
 
 No new script file. The invocation is small enough (3–4 lines: probe,
 call, strip trailing block) to live inline in SKILL.md as part of step
@@ -74,7 +99,7 @@ call, strip trailing block) to live inline in SKILL.md as part of step
 | Principle | Consideration |
 |---|---|
 | Human control and transparency | `--no-copilot` flag + "skipped" notice in report + tier table in SKILL.md make it visible when Copilot runs, when it doesn't, and how to suppress it. Default-on is "tight by default, relaxable as confidence grows." |
-| Only what's needed | Copilot-only, synchronous, no tmux, no `--add-dir` plumbing. Inline shell in SKILL.md rather than a new script unless complexity demands it. |
+| Only what's needed | Copilot-only, synchronous, no tmux, no `--add-dir` plumbing. Inline shell in SKILL.md rather than a new script unless complexity demands it. **Tradeoff acknowledged**: all-tier activation produces a Light-tier resource inversion — a trivial PR's Light review now consumes ~25k Copilot tokens + 1 Premium request, more *external* cost than yesterday's Standard. The cost-evaluation follow-up issue (Step 7) is the data path to revisit, but the asymmetry is named here rather than papered over. |
 | A change includes its consequences | Digest entry updated; follow-up evaluation issue filed so the v1 context choice has an owner; upstream invocation report filed; no schema changes to progress.md / review-context.yaml. |
 | Capture decisions, not just implementations | Acceptance-criteria answers recorded on #461; rationale repeated in SKILL.md prose under 5e; "Partially adopted" entry captures the cross-model design split. |
 | Improve incrementally | v1 ships default context + all-tier activation; tier-scoping and context-tightening deferred to the follow-up issue once we have cost data. |
@@ -95,13 +120,23 @@ call, strip trailing block) to live inline in SKILL.md as part of step
 |---|---|---|
 | `review-code` specialist set (add 5e) | `inspiration_agent_workspace_digest.md` "Not adopted" → "Partially adopted" | Yes — Step 5 |
 | `review-code` Usage (`--no-copilot`) | None — `review-code` is invoked as a skill; no other consumers of its CLI surface | Verify via workspace grep before commit |
-| `review-code` specialist set | `AGENTS.md` / `CLAUDE.md` references to review-code | Workspace grep planned; spot-check during implementation |
+| `review-code` specialist set | `AGENTS.md` / `CLAUDE.md` references to review-code | Workspace grep planned during implementation (no specialist-list enumeration found in earlier passes) |
+| Cross-model "not adopted" / "Claude-only" prose in knowledge docs | `review_depth_classification.md`, `skill_workflows.md`, `inspiration_agent_workspace_digest.md` (line ~62 in "Ported" section) | Yes — listed in Files to Change + Step 5a/5b |
 | Default-on Premium-request consumption | Cost-evaluation follow-up issue | Yes — Step 7 |
 | Upstream `cross_model_review.sh` invocation suspected broken | Issue filed on `rolker/agent_workspace` | Yes — Step 6 |
 
 ## Open Questions
 
-None — acceptance-criteria answers (#461 comments) cover all four.
+None remaining. The four issue-comment acceptance answers settled the
+top-level decisions; review-plan (PR #464, 2026-05-18) surfaced two
+derived questions that the original four didn't directly address:
+
+- **Light-tier prompt body** — resolved 2026-05-18: reuse the Standard
+  prompt body (simplest one-prompt-per-tier-pair shape). Documented in
+  Step 1.
+- **Light-tier Premium-request asymmetry** — acknowledged as an
+  intentional tradeoff in the "Only what's needed" self-check row;
+  data-driven revisit deferred to the Step 7 follow-up issue.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-461/plan.md
+++ b/.agent/work-plans/issue-461/plan.md
@@ -1,0 +1,110 @@
+# Plan: Scope a Copilot-only cross-model adversarial review
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/461
+
+## Context
+
+PR #453 ported the review-skill from `rolker/agent_workspace` but
+deliberately did not adopt its `cross_model_review.sh` (tmux dispatch +
+Gemini/Codex/Copilot). The 2026-05-15 scoping comment on #461 settled
+the design for a slimmed-down, Copilot-only revisit. The four
+acceptance-criteria questions were resolved 2026-05-18:
+
+1. Activate on **all tiers** (Light + Standard + Deep), `--no-copilot`
+   opt-out per invocation.
+2. **Graceful skip with notice** when `copilot` binary missing or
+   unauthenticated (covers field hosts gabby/salmon).
+3. **Default Copilot context** for v1 (~25.5k token floor accepted);
+   evaluate after a few real runs and tighten via `--add-dir` or
+   isolated `-C` if Premium burn is unacceptable.
+4. **File an issue on `rolker/agent_workspace`** about its likely-broken
+   `copilot -p < prompt` invocation; decoupled from this PR.
+
+## Approach
+
+1. **Add Copilot Adversarial as a new specialist (5e) in `review-code` SKILL.md.**
+   Synchronous call, no tmux. Invocation:
+   `copilot -p "" --allow-all-tools < prompt > findings 2>&1`. Strip
+   the trailing `Changes / Requests / Tokens` metadata block.
+   Activates on Light + Standard + Deep. Prompt mirrors Claude
+   Adversarial's tier-appropriate focus areas (Light reuses the
+   Standard prompt body since Claude Adversarial doesn't run on Light).
+2. **Implement availability detection.** Before invoking, probe with
+   `command -v copilot` and a quick auth check
+   (`copilot --version` succeeds without prompting). On failure, emit a
+   one-line `Copilot Adversarial skipped: <reason>` finding and
+   continue. No flag needed.
+3. **Add `--no-copilot` flag** to the `review-code` Usage block and
+   argument parser. When set, skip dispatch entirely without the
+   "skipped" notice.
+4. **Update the Specialists overview** in step 5 to list 5a–5e and
+   remove the "Cross-model adversarial is intentionally not wired here"
+   note from 5d (replace with a pointer to 5e).
+5. **Update `inspiration_agent_workspace_digest.md`.** Move the
+   Cross-Model entry from "Not adopted" to a new "Partially adopted"
+   section: Copilot-only synchronous dispatch ported; tmux machinery
+   and Gemini/Codex remain non-adopted with the existing rationale.
+6. **File the upstream invocation report** on
+   `rolker/agent_workspace` as a discrete step. Title: "cross_model_review.sh:
+   Copilot invocation likely missing `-p \"\"` and `--allow-all-tools`".
+   Body: our verified local invocation + smoke-test repro. Not a
+   blocker for this PR.
+7. **Open a follow-up issue** for the v1 context-strategy evaluation
+   ("Evaluate Copilot Adversarial context cost; tighten if needed").
+   Link it from the digest entry and from `review-code` SKILL.md so the
+   v1 choice doesn't silently calcify.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.claude/skills/review-code/SKILL.md` | Add 5e Copilot Adversarial subsection; add `--no-copilot` to Usage + arg parser; update step-5 tier table to dispatch 5e on all tiers; replace 5d cross-model-not-wired note with pointer to 5e |
+| `.agent/knowledge/inspiration_agent_workspace_digest.md` | Move Cross-Model entry from "Not adopted" → new "Partially adopted" entry; preserve non-Copilot non-adoption rationale |
+
+No new script file. The invocation is small enough (3–4 lines: probe,
+call, strip trailing block) to live inline in SKILL.md as part of step
+5e, matching how 5a–5d are documented. If the inline shell grows past
+~15 lines during implementation, factor into
+`.agent/scripts/run_copilot_adversarial.sh`.
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | `--no-copilot` flag + "skipped" notice in report + tier table in SKILL.md make it visible when Copilot runs, when it doesn't, and how to suppress it. Default-on is "tight by default, relaxable as confidence grows." |
+| Only what's needed | Copilot-only, synchronous, no tmux, no `--add-dir` plumbing. Inline shell in SKILL.md rather than a new script unless complexity demands it. |
+| A change includes its consequences | Digest entry updated; follow-up evaluation issue filed so the v1 context choice has an owner; upstream invocation report filed; no schema changes to progress.md / review-context.yaml. |
+| Capture decisions, not just implementations | Acceptance-criteria answers recorded on #461; rationale repeated in SKILL.md prose under 5e; "Partially adopted" entry captures the cross-model design split. |
+| Improve incrementally | v1 ships default context + all-tier activation; tier-scoping and context-tightening deferred to the follow-up issue once we have cost data. |
+| Workspace vs project separation | Workspace tooling; no project-repo coupling. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 worktree isolation | Yes | Plan + implementation land on `feature/issue-461` workspace worktree |
+| 0003 workspace infra is project-agnostic | Yes | `review-code` and the new specialist are generic ROS 2 / workspace tooling; no project-specific assumptions |
+| 0004 enforcement hierarchy | Yes | `--no-copilot` opt-out is a user-facing escape hatch; default-on enforces the cross-model second-read by default |
+| 0011 field mode | Yes | Graceful skip when Copilot unavailable covers field-mode hosts (gabby/salmon) without a separate code path |
+
+## Consequences
+
+| If we change… | Also update… | Included in plan? |
+|---|---|---|
+| `review-code` specialist set (add 5e) | `inspiration_agent_workspace_digest.md` "Not adopted" → "Partially adopted" | Yes — Step 5 |
+| `review-code` Usage (`--no-copilot`) | None — `review-code` is invoked as a skill; no other consumers of its CLI surface | Verify via workspace grep before commit |
+| `review-code` specialist set | `AGENTS.md` / `CLAUDE.md` references to review-code | Workspace grep planned; spot-check during implementation |
+| Default-on Premium-request consumption | Cost-evaluation follow-up issue | Yes — Step 7 |
+| Upstream `cross_model_review.sh` invocation suspected broken | Issue filed on `rolker/agent_workspace` | Yes — Step 6 |
+
+## Open Questions
+
+None — acceptance-criteria answers (#461 comments) cover all four.
+
+## Estimated Scope
+
+Single PR. Two file edits + two new issues filed (one upstream, one
+follow-up). No new scripts unless inline shell exceeds ~15 lines
+during implementation.

--- a/.agent/work-plans/issue-461/progress.md
+++ b/.agent/work-plans/issue-461/progress.md
@@ -4,7 +4,7 @@ issue: 461
 
 # Issue #461 — Scope a Copilot-only cross-model adversarial review (revisit "Not adopted")
 
-## Local Review
+## Local Review (Pre-Push)
 **Status**: complete
 **When**: 2026-05-18 14:41
 **By**: Claude Code Agent (Claude Opus 4.7 (1M context))
@@ -32,14 +32,14 @@ issue: 461
 **Must-fix**: 0 | **Suggestions**: 8
 
 ### Findings
-- [ ] (suggestion) Light + --skip-static = zero-specialist predicate is stale post-5e — `.claude/skills/review-code/SKILL.md:629` and `:316-317`
-- [ ] (suggestion) No timeout on synchronous Copilot invocation — `.claude/skills/review-code/SKILL.md:484`
-- [ ] (suggestion) Post-invocation auth/empty-output detection in prose but not in snippet — `.claude/skills/review-code/SKILL.md:461-466`
-- [ ] (suggestion) Pre-push progress.md entry header mismatch (`## Local Review` vs `(Pre-Push)`) — `.agent/work-plans/issue-461/progress.md:15`
-- [ ] (suggestion) Pre-push coverage over-claim (tier semantics) — `.agent/knowledge/skill_workflows.md:24`, `.github/copilot-instructions.md:32`
-- [ ] (suggestion) Naming inconsistency "Adversarial Specialist (Claude)" vs "Claude Adversarial Specialist" — `.agent/knowledge/inspiration_agent_workspace_digest.md:60`
-- [ ] (suggestion) No `**Copilot Adversarial**:` parallel header line in Standard/Deep full report format — `.claude/skills/review-code/SKILL.md:554` area
-- [ ] (suggestion) `--allow-all-tools` security caveat scope ambiguous on post-PR contributor diffs — `.claude/skills/review-code/SKILL.md:508`
+- [x] (suggestion) Light + --skip-static = zero-specialist predicate is stale post-5e — `.claude/skills/review-code/SKILL.md:629` and `:316-317`
+- [x] (suggestion) No timeout on synchronous Copilot invocation — `.claude/skills/review-code/SKILL.md:484`
+- [x] (suggestion) Post-invocation auth/empty-output detection in prose but not in snippet — `.claude/skills/review-code/SKILL.md:461-466`
+- [x] (suggestion) Pre-push progress.md entry header mismatch (`## Local Review` vs `(Pre-Push)`) — `.agent/work-plans/issue-461/progress.md:15`
+- [x] (suggestion) Pre-push coverage over-claim (tier semantics) — `.agent/knowledge/skill_workflows.md:24`, `.github/copilot-instructions.md:32`
+- [x] (suggestion) Naming inconsistency "Adversarial Specialist (Claude)" vs "Claude Adversarial Specialist" — `.agent/knowledge/inspiration_agent_workspace_digest.md:60`
+- [x] (suggestion) No `**Copilot Adversarial**:` parallel header line in Standard/Deep full report format — `.claude/skills/review-code/SKILL.md:554` area
+- [x] (suggestion) `--allow-all-tools` security caveat scope — resolved by adding `--allow-untrusted-copilot` gate (user-chosen policy: explicit confirmation gate) — `.claude/skills/review-code/SKILL.md` step 5e
 
 ### False positives dismissed
 - Copilot bot claimed duplicate adapter at `custom-instructions/repo/.github/copilot-instructions.md` — file does not exist (`find` empty).

--- a/.agent/work-plans/issue-461/progress.md
+++ b/.agent/work-plans/issue-461/progress.md
@@ -54,6 +54,6 @@ issue: 461
 **CI**: all-pass (8 checks)
 
 ### Actions
-- [ ] (suggestion) Drop the broken `see $FINDINGS_FILE` pointer from non-zero-exit skip reason — `.claude/skills/review-code/SKILL.md:516` (file deleted by EXIT trap)
-- [ ] (suggestion) Qualify framework-agnostic specialist claim to mention authentication — `.github/copilot-instructions.md:47`
+- [x] (suggestion) Drop the broken `see $FINDINGS_FILE` pointer from non-zero-exit skip reason — `.claude/skills/review-code/SKILL.md` (replaced with inline `head -c 200` capture of findings file contents into the reason string itself)
+- [x] (suggestion) Qualify framework-agnostic specialist claim to mention authentication — `.github/copilot-instructions.md:47`
 - [ ] (Optional, web-UI-only) Dismiss addressed + FP Copilot comments on GitHub

--- a/.agent/work-plans/issue-461/progress.md
+++ b/.agent/work-plans/issue-461/progress.md
@@ -1,0 +1,21 @@
+---
+issue: 461
+---
+
+# Issue #461 — Scope a Copilot-only cross-model adversarial review (revisit "Not adopted")
+
+## Local Review
+**Status**: complete
+**When**: 2026-05-18 14:41
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-461 at `4556bd4`
+**Mode**: pre-push
+**Depth**: Deep (reason: 443 changed lines ≥ 200 threshold)
+**Must-fix**: 0 | **Suggestions**: 3 (all addressed)
+
+### Findings
+- [x] (suggestion) `copilot --version` is a presence check, not an auth check — `.claude/skills/review-code/SKILL.md` step 5e probe
+- [x] (suggestion) `--allow-all-tools` threat-model documentation missing — `.claude/skills/review-code/SKILL.md` step 5e invocation
+- [x] (suggestion) Tempfile cleanup missing — `.claude/skills/review-code/SKILL.md` step 5e invocation

--- a/.agent/work-plans/issue-461/progress.md
+++ b/.agent/work-plans/issue-461/progress.md
@@ -44,3 +44,16 @@ issue: 461
 ### False positives dismissed
 - Copilot bot claimed duplicate adapter at `custom-instructions/repo/.github/copilot-instructions.md` — file does not exist (`find` empty).
 - `sed -i` BSD/macOS portability — workspace is Linux-only (Ubuntu/ROS 2 Jazzy).
+
+## External Review
+**Status**: complete
+**When**: 2026-05-18 21:10
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #464 — 4 review(s), 2 new valid (on current head 922d1ea), 14 prior comments triaged in Local Review above
+**CI**: all-pass (8 checks)
+
+### Actions
+- [ ] (suggestion) Drop the broken `see $FINDINGS_FILE` pointer from non-zero-exit skip reason — `.claude/skills/review-code/SKILL.md:516` (file deleted by EXIT trap)
+- [ ] (suggestion) Qualify framework-agnostic specialist claim to mention authentication — `.github/copilot-instructions.md:47`
+- [ ] (Optional, web-UI-only) Dismiss addressed + FP Copilot comments on GitHub

--- a/.agent/work-plans/issue-461/progress.md
+++ b/.agent/work-plans/issue-461/progress.md
@@ -19,3 +19,28 @@ issue: 461
 - [x] (suggestion) `copilot --version` is a presence check, not an auth check — `.claude/skills/review-code/SKILL.md` step 5e probe
 - [x] (suggestion) `--allow-all-tools` threat-model documentation missing — `.claude/skills/review-code/SKILL.md` step 5e invocation
 - [x] (suggestion) Tempfile cleanup missing — `.claude/skills/review-code/SKILL.md` step 5e invocation
+
+## Local Review
+**Status**: complete
+**When**: 2026-05-18 17:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved
+
+**PR**: #464 at `67a7f46`
+**Mode**: post-PR
+**Depth**: Standard (reason: governance-touching, 9 files, no ADR add)
+**Must-fix**: 0 | **Suggestions**: 8
+
+### Findings
+- [ ] (suggestion) Light + --skip-static = zero-specialist predicate is stale post-5e — `.claude/skills/review-code/SKILL.md:629` and `:316-317`
+- [ ] (suggestion) No timeout on synchronous Copilot invocation — `.claude/skills/review-code/SKILL.md:484`
+- [ ] (suggestion) Post-invocation auth/empty-output detection in prose but not in snippet — `.claude/skills/review-code/SKILL.md:461-466`
+- [ ] (suggestion) Pre-push progress.md entry header mismatch (`## Local Review` vs `(Pre-Push)`) — `.agent/work-plans/issue-461/progress.md:15`
+- [ ] (suggestion) Pre-push coverage over-claim (tier semantics) — `.agent/knowledge/skill_workflows.md:24`, `.github/copilot-instructions.md:32`
+- [ ] (suggestion) Naming inconsistency "Adversarial Specialist (Claude)" vs "Claude Adversarial Specialist" — `.agent/knowledge/inspiration_agent_workspace_digest.md:60`
+- [ ] (suggestion) No `**Copilot Adversarial**:` parallel header line in Standard/Deep full report format — `.claude/skills/review-code/SKILL.md:554` area
+- [ ] (suggestion) `--allow-all-tools` security caveat scope ambiguous on post-PR contributor diffs — `.claude/skills/review-code/SKILL.md:508`
+
+### False positives dismissed
+- Copilot bot claimed duplicate adapter at `custom-instructions/repo/.github/copilot-instructions.md` — file does not exist (`find` empty).
+- `sed -i` BSD/macOS portability — workspace is Linux-only (Ubuntu/ROS 2 Jazzy).

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -538,7 +538,9 @@ if [[ "$COPILOT_EXIT" == "124" ]]; then
     COPILOT_SKIP_REASON="copilot CLI timed out after 300s"
 elif [[ "$COPILOT_EXIT" != "0" ]]; then
     SKIP_COPILOT=1
-    COPILOT_SKIP_REASON="copilot CLI exited $COPILOT_EXIT (see $FINDINGS_FILE)"
+    # Capture findings-file contents in the reason itself — the EXIT
+    # trap will delete the tempfile before the user can inspect it.
+    COPILOT_SKIP_REASON="copilot CLI exited $COPILOT_EXIT: $(head -c 200 "$FINDINGS_FILE")"
 elif [[ ! -s "$FINDINGS_FILE" ]]; then
     SKIP_COPILOT=1
     COPILOT_SKIP_REASON="copilot produced no output (likely not authenticated)"

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -8,9 +8,9 @@ description: Lead reviewer that orchestrates specialist sub-reviews (static anal
 ## Usage
 
 ```
-/review-code [--base <branch>] [--skip-static] [--no-progress] [--issue <N>] [light|standard|deep]
+/review-code [--base <branch>] [--skip-static] [--no-progress] [--issue <N>] [--no-copilot] [light|standard|deep]
                                             # pre-push: diff vs default branch
-/review-code <pr-number-or-url> [--skip-static] [light|standard|deep]
+/review-code <pr-number-or-url> [--skip-static] [--no-copilot] [light|standard|deep]
                                             # post-PR: diff vs PR base
 ```
 
@@ -32,6 +32,10 @@ Flags:
   branches). When passed, the branch-name extraction at step 1 is
   skipped. Mutually compatible with `--no-progress` — `--no-progress`
   wins (no persistence regardless of issue number).
+- **`--no-copilot`** (both modes) suppresses the Copilot Adversarial
+  Specialist (5e) for this invocation. Useful when the Copilot CLI is
+  installed but you want to avoid the Premium-request cost on a
+  specific run.
 
 ## Overview
 
@@ -55,11 +59,14 @@ post comments or modify the PR unless the user asks.
   issue, plan file referenced in PR body.
 
 **Depth tiers** (see `.agent/knowledge/review_depth_classification.md`):
-- **Light** — Static Analysis only (small, low-risk changes)
+- **Light** — Static Analysis + Copilot Adversarial (small, low-risk
+  changes)
 - **Standard** — Static Analysis + Governance + Plan Drift + Claude
-  Adversarial (medium changes or governance-touching files)
-- **Deep** — Same as Standard with Adversarial primed for security /
-  concurrency / lifecycle (large changes, security, or cross-layer)
+  Adversarial + Copilot Adversarial (medium changes or
+  governance-touching files)
+- **Deep** — Same as Standard with both Adversarial specialists primed
+  for security / concurrency / lifecycle (large changes, security, or
+  cross-layer)
 
 **Specialists**:
 - **Static Analysis** — runs linters with ament-aligned configs on
@@ -68,9 +75,12 @@ post comments or modify the PR unless the user asks.
   consequences map
 - **Plan Drift** — compares implementation against the work plan (if one
   exists)
-- **Adversarial** — fresh-context Claude subagent that re-reads the diff
-  cold (Standard + Deep). Cross-model adversarial is **not** wired in
-  here; see `inspiration_agent_workspace_digest.md` "Not adopted".
+- **Claude Adversarial** — fresh-context Claude subagent that re-reads
+  the diff cold (Standard + Deep)
+- **Copilot Adversarial** — synchronous Copilot CLI dispatch that re-reads
+  the diff cold (Light + Standard + Deep). Skipped with a one-line
+  notice when `copilot` is unavailable; suppress entirely with
+  `--no-copilot`.
 
 ## Steps
 
@@ -80,16 +90,18 @@ Parse the arguments in this order: extract `--skip-static` (sets
 `SKIP_STATIC=true`), `--no-progress` (sets `NO_PROGRESS=true`, pre-push
 only — emit an error if passed in post-PR mode), `--issue <N>` (sets
 `USER_ISSUE=<N>`, pre-push only — emit an error if passed in post-PR
-mode, where `closingIssuesReferences` is authoritative), `--base
-<branch>` (sets `USER_BASE`), then the optional depth keyword (`light`
-/ `standard` / `deep` — positional). Classify what remains:
+mode, where `closingIssuesReferences` is authoritative), `--no-copilot`
+(sets `NO_COPILOT=1`, suppresses the Copilot Adversarial Specialist in
+step 5e), `--base <branch>` (sets `USER_BASE`), then the optional depth
+keyword (`light` / `standard` / `deep` — positional). Classify what
+remains:
 
 - Empty → **pre-push mode**
 - A number or `https://github.com/.../pull/<N>` → **post-PR mode**
 
-The depth keyword and `--skip-static` may appear in any order around
-the PR number / URL or `--base <branch>`. The same syntax applies in
-both modes. Examples:
+The depth keyword, `--skip-static`, and `--no-copilot` may appear in
+any order around the PR number / URL or `--base <branch>`. The same
+syntax applies in both modes. Examples:
 
 ```
 /review-code                                # pre-push, auto-classify
@@ -100,9 +112,11 @@ both modes. Examples:
 /review-code --skip-static light            # pre-push, light + skip static
 /review-code --no-progress                  # pre-push, don't write progress.md
 /review-code --issue 460                    # pre-push, override branch-name issue extraction
+/review-code --no-copilot                   # pre-push, skip Copilot Adversarial
 /review-code 42                             # post-PR, auto-classify
 /review-code 42 standard                    # post-PR, force Standard
 /review-code 42 --skip-static               # post-PR, skip static analysis
+/review-code 42 --no-copilot                # post-PR, skip Copilot Adversarial
 ```
 
 #### Pre-push mode
@@ -269,8 +283,10 @@ sequentially.
 
 #### Light tier
 
-Run only:
+Run:
 - **5a. Static Analysis Specialist**
+- **5e. Copilot Adversarial Specialist** (Standard prompt; skipped with
+  notice if `copilot` unavailable; suppressed entirely by `--no-copilot`)
 
 #### Standard tier
 
@@ -278,12 +294,15 @@ Run all of:
 - **5a. Static Analysis Specialist**
 - **5b. Governance Specialist**
 - **5c. Plan Drift Specialist** (if a plan exists)
-- **5d. Adversarial Specialist** (Standard prompt)
+- **5d. Claude Adversarial Specialist** (Standard prompt)
+- **5e. Copilot Adversarial Specialist** (Standard prompt; skipped with
+  notice if `copilot` unavailable; suppressed entirely by `--no-copilot`)
 
 #### Deep tier
 
-Same as Standard, but **5d. Adversarial Specialist** runs with the Deep
-prompt (broader file horizon plus an explicit security / concurrency /
+Same as Standard, but both adversarial specialists (**5d. Claude
+Adversarial** and **5e. Copilot Adversarial**) run with the Deep prompt
+(broader file horizon plus an explicit security / concurrency /
 lifecycle checklist).
 
 ---
@@ -361,7 +380,7 @@ If a work plan exists at `.agent/work-plans/issue-<N>/plan.md`:
 
 If no work plan exists, skip this specialist.
 
-#### 5d. Adversarial Specialist
+#### 5d. Claude Adversarial Specialist
 
 **Activates at**: Standard, Deep.
 
@@ -396,10 +415,84 @@ Report findings in the same format as other specialists (file, line,
 severity, description). The silence filter (step 6) deduplicates overlap
 with other specialists' findings.
 
-> **Cross-model adversarial is intentionally not wired here.** See
-> `inspiration_agent_workspace_digest.md` "Not adopted". When you want
-> a second model's read on a Deep PR, run that agent's review-code
-> manually.
+> **Cross-model adversarial** is wired in as the Copilot Adversarial
+> Specialist (step 5e below). The tmux-orchestrated Gemini/Codex
+> dispatch from upstream `cross_model_review.sh` remains unadopted —
+> see `inspiration_agent_workspace_digest.md` "Partially adopted".
+
+#### 5e. Copilot Adversarial Specialist
+
+**Activates at**: Light, Standard, Deep.
+
+A second adversarial pass that uses the GitHub Copilot CLI
+(`@github/copilot` ≥ v1.0.48) as a synchronous, cross-model reader of
+the same diff. Same fresh-context principle as 5d — Copilot sees only
+the diff prompt, no other specialists' findings. The cross-model
+signal value (a second vendor flagging an issue independently is a
+stronger signal than the same model agreeing with itself) is the
+reason this runs at every tier, not just Deep.
+
+**Availability probe**. Skip with a one-line notice (not a failure)
+when the CLI is missing or unauthenticated, so field-mode hosts
+(gabby, salmon — no GitHub credentials) don't block the rest of the
+review:
+
+```bash
+if [[ "$NO_COPILOT" == "1" ]]; then
+    # User opted out for this invocation; no "skipped" notice needed.
+    SKIP_COPILOT=1
+elif ! command -v copilot >/dev/null 2>&1; then
+    COPILOT_SKIP_REASON="copilot CLI not installed"
+    SKIP_COPILOT=1
+elif ! copilot --version >/dev/null 2>&1; then
+    COPILOT_SKIP_REASON="copilot CLI not authenticated (run \`copilot\` interactively to log in)"
+    SKIP_COPILOT=1
+fi
+```
+
+When `SKIP_COPILOT=1` and `NO_COPILOT` is unset, the report includes:
+`Copilot Adversarial skipped: <COPILOT_SKIP_REASON>`. When
+`NO_COPILOT=1`, the specialist is omitted from the report entirely.
+
+**Prompt body**. Light + Standard reuse the same prompt as the Standard
+Claude Adversarial prompt (the four focus areas under 5d: missed edge
+cases, assumption violations, subtle bugs, logic errors). Deep adds
+the same three Deep-tier focus areas as 5d (security, concurrency /
+lifecycle, cross-cutting effects). Reusing one prompt body per tier
+pair keeps the two adversarial specialists comparable — the cross-model
+signal is "two vendors reading the same brief", not "two prompts on
+the same diff".
+
+**Invocation**.
+
+```bash
+PROMPT_FILE=$(mktemp /tmp/copilot_adv_prompt.XXXXXX)
+FINDINGS_FILE=$(mktemp /tmp/copilot_adv_findings.XXXXXX)
+# Build $PROMPT_FILE from the diff + the tier-appropriate prompt body above.
+copilot -p "" --allow-all-tools < "$PROMPT_FILE" > "$FINDINGS_FILE" 2>&1
+# Strip the trailing `Changes / Requests / Tokens` metadata block. The
+# block starts with a "Changes" line and runs to EOF; cut from there.
+sed -i '/^Changes$/,$d' "$FINDINGS_FILE"
+```
+
+The empty-value form `-p ""` plus stdin is what activates Copilot's
+headless mode; `--allow-all-tools` is required so the CLI doesn't
+prompt for permission (which would hang on stdin). Smoke-tested
+locally on `@github/copilot` v1.0.48.
+
+**Context cost**. Copilot autoloads workspace context on launch — a
+trivial prompt floors at ~25.5k tokens and consumes one Premium
+request. v1 accepts that cost as the tradeoff for default-on
+all-tier activation. If the cost proves unacceptable in practice,
+tighten via `--add-dir <worktree>` (scope context to the worktree) or
+isolated `-C /tmp/scratch` invocation (diff + governance docs only).
+See the cost-evaluation follow-up issue
+([#467](https://github.com/rolker/ros2_agent_workspace/issues/467))
+for the data-collection plan.
+
+Report findings in the same format as other specialists. The silence
+filter (step 6) deduplicates overlap with 5d and with the other
+specialists.
 
 ### 6. Apply silence filter
 
@@ -492,6 +585,16 @@ Existing Review Comments sections. Use:
 | # | File | Line | Finding |
 |---|------|------|---------|
 | 1 | `path` | 42 | Description |
+
+### Copilot Adversarial
+
+| # | File | Line | Finding |
+|---|------|------|---------|
+| 1 | `path` | 17 | Description |
+
+<!-- Or, if the specialist was skipped or suppressed: -->
+<!-- Copilot Adversarial skipped: <reason>     (when copilot unavailable) -->
+<!-- (Section omitted entirely when invoked with --no-copilot) -->
 
 No governance concerns for a change of this scope.
 ```

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -433,9 +433,8 @@ stronger signal than the same model agreeing with itself) is the
 reason this runs at every tier, not just Deep.
 
 **Availability probe**. Skip with a one-line notice (not a failure)
-when the CLI is missing or unauthenticated, so field-mode hosts
-(gabby, salmon — no GitHub credentials) don't block the rest of the
-review:
+when the CLI is missing, so field-mode hosts (gabby, salmon — no
+GitHub credentials) don't block the rest of the review:
 
 ```bash
 if [[ "$NO_COPILOT" == "1" ]]; then
@@ -445,7 +444,16 @@ elif ! command -v copilot >/dev/null 2>&1; then
     COPILOT_SKIP_REASON="copilot CLI not installed"
     SKIP_COPILOT=1
 elif ! copilot --version >/dev/null 2>&1; then
-    COPILOT_SKIP_REASON="copilot CLI not authenticated (run \`copilot\` interactively to log in)"
+    # `copilot --version` is a presence check, not an auth check —
+    # `--version` typically prints without contacting the API. We keep
+    # it as a "binary at least runs" sanity guard. Auth failures
+    # surface from the actual invocation below: if the
+    # post-strip findings file is empty, contains only error text
+    # (e.g., `Please run \`copilot\` to authenticate`), or the
+    # command exits non-zero, switch the report line to
+    # `Copilot Adversarial skipped: copilot CLI not authenticated`
+    # rather than presenting empty findings.
+    COPILOT_SKIP_REASON="copilot --version failed (binary broken or missing dependencies)"
     SKIP_COPILOT=1
 fi
 ```
@@ -453,6 +461,9 @@ fi
 When `SKIP_COPILOT=1` and `NO_COPILOT` is unset, the report includes:
 `Copilot Adversarial skipped: <COPILOT_SKIP_REASON>`. When
 `NO_COPILOT=1`, the specialist is omitted from the report entirely.
+A post-call empty-findings or "Please run `copilot` to authenticate"
+output also routes to the skipped-notice path so unauthenticated
+hosts don't surface as silent zero-finding reviews.
 
 **Prompt body**. Light + Standard reuse the same prompt as the Standard
 Claude Adversarial prompt (the four focus areas under 5d: missed edge
@@ -468,17 +479,33 @@ the same diff".
 ```bash
 PROMPT_FILE=$(mktemp /tmp/copilot_adv_prompt.XXXXXX)
 FINDINGS_FILE=$(mktemp /tmp/copilot_adv_findings.XXXXXX)
+trap 'rm -f "$PROMPT_FILE" "$FINDINGS_FILE"' EXIT  # tempfile cleanup
 # Build $PROMPT_FILE from the diff + the tier-appropriate prompt body above.
 copilot -p "" --allow-all-tools < "$PROMPT_FILE" > "$FINDINGS_FILE" 2>&1
 # Strip the trailing `Changes / Requests / Tokens` metadata block. The
 # block starts with a "Changes" line and runs to EOF; cut from there.
+# If a future Copilot CLI version changes the footer format, this is
+# a no-op (no `^Changes$` line to match) and the metadata will leak
+# into the report — visible enough to prompt a regex update.
 sed -i '/^Changes$/,$d' "$FINDINGS_FILE"
+# Read $FINDINGS_FILE before the EXIT trap fires.
 ```
 
 The empty-value form `-p ""` plus stdin is what activates Copilot's
 headless mode; `--allow-all-tools` is required so the CLI doesn't
 prompt for permission (which would hang on stdin). Smoke-tested
 locally on `@github/copilot` v1.0.48.
+
+**Security note on `--allow-all-tools`**. The flag grants Copilot
+permission to execute any tool the CLI exposes (file reads, shell
+commands, etc.) on this host. The review-code use case — Copilot
+reading a diff that the invoking user just authored in their own
+worktree — accepts that threat model: the prompt is constructed
+locally, not received over a network, and the worktree is already
+under the user's control. Don't reuse this invocation pattern for
+prompts that include untrusted input (e.g., reviewing an unvetted PR
+from an external contributor with arbitrary diff content) until
+Copilot CLI grows scoped permissions.
 
 **Context cost**. Copilot autoloads workspace context on launch — a
 trivial prompt floors at ~25.5k tokens and consumes one Premium

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -10,7 +10,7 @@ description: Lead reviewer that orchestrates specialist sub-reviews (static anal
 ```
 /review-code [--base <branch>] [--skip-static] [--no-progress] [--issue <N>] [--no-copilot] [light|standard|deep]
                                             # pre-push: diff vs default branch
-/review-code <pr-number-or-url> [--skip-static] [--no-copilot] [light|standard|deep]
+/review-code <pr-number-or-url> [--skip-static] [--no-copilot] [--allow-untrusted-copilot] [light|standard|deep]
                                             # post-PR: diff vs PR base
 ```
 
@@ -36,6 +36,14 @@ Flags:
   Specialist (5e) for this invocation. Useful when the Copilot CLI is
   installed but you want to avoid the Premium-request cost on a
   specific run.
+- **`--allow-untrusted-copilot`** (post-PR only) overrides the
+  external-PR safety gate that suppresses Copilot Adversarial when the
+  PR head is from a fork or a non-collaborator author. Without this
+  flag, the specialist routes to the skipped-with-notice path on such
+  PRs because `--allow-all-tools` grants Copilot file/shell access to
+  the local worktree; running it against an untrusted contributor's
+  diff exposes that capability to attacker-controlled prompt content.
+  Pass only when you have read the diff and accept the risk.
 
 ## Overview
 
@@ -92,9 +100,11 @@ only — emit an error if passed in post-PR mode), `--issue <N>` (sets
 `USER_ISSUE=<N>`, pre-push only — emit an error if passed in post-PR
 mode, where `closingIssuesReferences` is authoritative), `--no-copilot`
 (sets `NO_COPILOT=1`, suppresses the Copilot Adversarial Specialist in
-step 5e), `--base <branch>` (sets `USER_BASE`), then the optional depth
-keyword (`light` / `standard` / `deep` — positional). Classify what
-remains:
+step 5e), `--allow-untrusted-copilot` (sets `ALLOW_UNTRUSTED_COPILOT=1`,
+post-PR only — emit an error if passed in pre-push mode, where the
+gate doesn't apply), `--base <branch>` (sets `USER_BASE`), then the
+optional depth keyword (`light` / `standard` / `deep` — positional).
+Classify what remains:
 
 - Empty → **pre-push mode**
 - A number or `https://github.com/.../pull/<N>` → **post-PR mode**
@@ -312,9 +322,12 @@ lifecycle checklist).
 **Skip if `SKIP_STATIC=true`** (`--skip-static` flag passed in step 1):
 emit no findings for this specialist and note "Static analysis skipped
 (--skip-static)" so the report header can surface it. At Light tier
-with `--skip-static`, zero specialists run and the silence filter
-produces the "No findings" output — that's the documented behavior,
-not a bug.
+with `--skip-static` **and** Copilot Adversarial also suppressed
+(`--no-copilot` or the CLI unavailable), zero specialists run and the
+silence filter produces the "No findings" output — that's the
+documented behavior, not a bug. If only `--skip-static` is set on
+Light, the Copilot Adversarial Specialist (5e) still runs and may
+produce findings.
 
 Otherwise, run linters on **changed files only**, using the config
 profile from step 4. See `.agent/knowledge/review_static_analysis.md`
@@ -446,24 +459,44 @@ elif ! command -v copilot >/dev/null 2>&1; then
 elif ! copilot --version >/dev/null 2>&1; then
     # `copilot --version` is a presence check, not an auth check —
     # `--version` typically prints without contacting the API. We keep
-    # it as a "binary at least runs" sanity guard. Auth failures
-    # surface from the actual invocation below: if the
-    # post-strip findings file is empty, contains only error text
-    # (e.g., `Please run \`copilot\` to authenticate`), or the
-    # command exits non-zero, switch the report line to
-    # `Copilot Adversarial skipped: copilot CLI not authenticated`
-    # rather than presenting empty findings.
+    # it as a "binary at least runs" sanity guard. Real auth failures
+    # are detected after the invocation below.
     COPILOT_SKIP_REASON="copilot --version failed (binary broken or missing dependencies)"
     SKIP_COPILOT=1
+fi
+```
+
+**Untrusted-PR safety gate** (post-PR mode only). Because
+`--allow-all-tools` grants Copilot file/shell access to the local
+worktree, do not invoke it against attacker-controlled prompt content.
+Before dispatch, check whether the PR head is from a fork or a
+non-collaborator author and gate accordingly:
+
+```bash
+if [[ "$MODE" == "post-PR" && "$SKIP_COPILOT" != "1" ]]; then
+    PR_AUTHOR_ASSOC=$(gh pr view "$PR" --json authorAssociation --jq '.authorAssociation')
+    PR_HEAD_REPO=$(gh pr view "$PR" --json headRepository,baseRepository \
+        --jq 'if .headRepository.nameWithOwner == .baseRepository.nameWithOwner then "owner" else "fork" end')
+    # Trusted: PR head is the base repo AND author is OWNER/MEMBER/COLLABORATOR.
+    # Anything else (fork, contributor, first-time contributor, none) is gated.
+    if [[ "$PR_HEAD_REPO" == "fork" ]] || \
+       [[ "$PR_AUTHOR_ASSOC" != "OWNER" && "$PR_AUTHOR_ASSOC" != "MEMBER" && "$PR_AUTHOR_ASSOC" != "COLLABORATOR" ]]; then
+        if [[ "$ALLOW_UNTRUSTED_COPILOT" == "1" ]]; then
+            : # User explicitly bypassed the gate. Proceed.
+        else
+            COPILOT_SKIP_REASON="external PR (head=$PR_HEAD_REPO, author=$PR_AUTHOR_ASSOC); pass --allow-untrusted-copilot after reviewing the diff to bypass"
+            SKIP_COPILOT=1
+        fi
+    fi
 fi
 ```
 
 When `SKIP_COPILOT=1` and `NO_COPILOT` is unset, the report includes:
 `Copilot Adversarial skipped: <COPILOT_SKIP_REASON>`. When
 `NO_COPILOT=1`, the specialist is omitted from the report entirely.
-A post-call empty-findings or "Please run `copilot` to authenticate"
-output also routes to the skipped-notice path so unauthenticated
-hosts don't surface as silent zero-finding reviews.
+Post-call empty findings or auth-error output also route to the
+skipped-notice path (see the post-invocation guard below) so
+unauthenticated hosts don't surface as silent zero-finding reviews.
 
 **Prompt body**. Light + Standard reuse the same prompt as the Standard
 Claude Adversarial prompt (the four focus areas under 5d: missed edge
@@ -474,20 +507,45 @@ pair keeps the two adversarial specialists comparable — the cross-model
 signal is "two vendors reading the same brief", not "two prompts on
 the same diff".
 
-**Invocation**.
+**Invocation** (only when `SKIP_COPILOT` is unset after both probes
+above).
 
 ```bash
 PROMPT_FILE=$(mktemp /tmp/copilot_adv_prompt.XXXXXX)
 FINDINGS_FILE=$(mktemp /tmp/copilot_adv_findings.XXXXXX)
 trap 'rm -f "$PROMPT_FILE" "$FINDINGS_FILE"' EXIT  # tempfile cleanup
 # Build $PROMPT_FILE from the diff + the tier-appropriate prompt body above.
-copilot -p "" --allow-all-tools < "$PROMPT_FILE" > "$FINDINGS_FILE" 2>&1
+
+# Bound the call so a hung Copilot CLI (network drop, model overload,
+# stuck stdin negotiation) doesn't block the entire review. 300 s is
+# generous for a single-diff prompt; tune if Deep-tier prompts on
+# large diffs need more.
+timeout 300 copilot -p "" --allow-all-tools < "$PROMPT_FILE" > "$FINDINGS_FILE" 2>&1
+COPILOT_EXIT=$?
+
 # Strip the trailing `Changes / Requests / Tokens` metadata block. The
 # block starts with a "Changes" line and runs to EOF; cut from there.
 # If a future Copilot CLI version changes the footer format, this is
 # a no-op (no `^Changes$` line to match) and the metadata will leak
 # into the report — visible enough to prompt a regex update.
 sed -i '/^Changes$/,$d' "$FINDINGS_FILE"
+
+# Post-invocation guard: route timeout / non-zero exit / empty output /
+# auth-error text to the skipped-notice path rather than surfacing the
+# stderr (captured via 2>&1) verbatim as findings.
+if [[ "$COPILOT_EXIT" == "124" ]]; then
+    SKIP_COPILOT=1
+    COPILOT_SKIP_REASON="copilot CLI timed out after 300s"
+elif [[ "$COPILOT_EXIT" != "0" ]]; then
+    SKIP_COPILOT=1
+    COPILOT_SKIP_REASON="copilot CLI exited $COPILOT_EXIT (see $FINDINGS_FILE)"
+elif [[ ! -s "$FINDINGS_FILE" ]]; then
+    SKIP_COPILOT=1
+    COPILOT_SKIP_REASON="copilot produced no output (likely not authenticated)"
+elif grep -qiE 'please run .copilot. to authenticate|not authenticated|sign in to GitHub' "$FINDINGS_FILE"; then
+    SKIP_COPILOT=1
+    COPILOT_SKIP_REASON="copilot CLI not authenticated"
+fi
 # Read $FINDINGS_FILE before the EXIT trap fires.
 ```
 
@@ -498,14 +556,26 @@ locally on `@github/copilot` v1.0.48.
 
 **Security note on `--allow-all-tools`**. The flag grants Copilot
 permission to execute any tool the CLI exposes (file reads, shell
-commands, etc.) on this host. The review-code use case — Copilot
-reading a diff that the invoking user just authored in their own
-worktree — accepts that threat model: the prompt is constructed
-locally, not received over a network, and the worktree is already
-under the user's control. Don't reuse this invocation pattern for
-prompts that include untrusted input (e.g., reviewing an unvetted PR
-from an external contributor with arbitrary diff content) until
-Copilot CLI grows scoped permissions.
+commands, etc.) on this host. The two main use cases have different
+threat models:
+
+- **Pre-push mode** — the diff is the user's own authored work in
+  their own worktree. The prompt is constructed locally, the worktree
+  is already under the user's control. Accepted threat model.
+- **Post-PR mode on owner / collaborator PRs** — same threat model as
+  pre-push: the diff was authored by someone whose code we already
+  treat as trusted.
+- **Post-PR mode on external contributor PRs** — diff content is
+  attacker-controlled. `--allow-all-tools` exposes file/shell access
+  to that content's prompt-injection surface. The "untrusted-PR
+  safety gate" above auto-suppresses 5e in this case; the
+  `--allow-untrusted-copilot` flag is the explicit bypass after the
+  reviewer has read the diff and accepted the risk. Don't add the flag
+  to a CI config or a wrapper script that auto-invokes review-code on
+  contributor PRs — that defeats the gate.
+
+Reuse of this invocation pattern outside `review-code` should retain
+the same trusted-input precondition or supply its own gate.
 
 **Context cost**. Copilot autoloads workspace context on launch — a
 trivial prompt floors at ~25.5k tokens and consumes one Premium
@@ -552,6 +622,7 @@ Collect all findings from all dispatched specialists and filter:
 **Files changed**: <count> (+<additions> -<deletions>)
 **Review depth**: <Light|Standard|Deep> (reason: <primary signal>)
 **Static analysis**: <run | skipped (--skip-static)>
+**Copilot Adversarial**: <run | skipped (<reason>) | suppressed (--no-copilot)>
 **Context**: <status of review-context.yaml — fresh / stale / not found / N/A>
 
 ### Must-Fix
@@ -606,6 +677,7 @@ Existing Review Comments sections. Use:
 **PR / Branch**: ...
 **Review depth**: Light (reason: <primary signal>)
 **Static analysis**: skipped (--skip-static)         <!-- include only when SKIP_STATIC=true -->
+**Copilot Adversarial**: <run | skipped (<reason>) | suppressed (--no-copilot)>
 
 ### Static Analysis
 
@@ -626,7 +698,7 @@ Existing Review Comments sections. Use:
 No governance concerns for a change of this scope.
 ```
 
-When `SKIP_STATIC=true` and no other specialists fire (Light + `--skip-static` = zero specialists), drop the `### Static Analysis` table entirely and use the No-findings format below — the `**Static analysis**: skipped` header line carries the only signal that needs to surface.
+When `SKIP_STATIC=true` and **both** `SKIP_COPILOT=1` (from `--no-copilot` or the availability/gate probes in 5e) — i.e., Light + `--skip-static` with Copilot also suppressed = zero specialists — drop the `### Static Analysis` and `### Copilot Adversarial` tables entirely and use the No-findings format below. The two `<header>: skipped` lines carry the only signals that need to surface.
 
 **No findings format** — if no findings exist across all sections:
 
@@ -636,6 +708,7 @@ When `SKIP_STATIC=true` and no other specialists fire (Light + `--skip-static` =
 **PR / Branch**: ...
 **Review depth**: <tier> (reason: <signal>)
 **Static analysis**: skipped (--skip-static)         <!-- include only when SKIP_STATIC=true -->
+**Copilot Adversarial**: <skipped (<reason>) | suppressed (--no-copilot)>  <!-- include only when SKIP_COPILOT=1 -->
 No issues found. LGTM.
 ```
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,12 +24,14 @@ not only in the workspace repo. When reviewing:
 The shared rule (see [`AGENTS.md` Post-Task Verification](../AGENTS.md#post-task-verification))
 expects authors to run `/review-code` against their diff before opening a PR.
 This applies to Copilot too when used in **agent / coding-assistant mode** —
-prefer a pre-push pass to catch static-analysis, governance,
-plan-drift, and Copilot Adversarial findings locally rather than in
-PR review rounds. (The Claude Adversarial Specialist is Claude-only —
-see caveat below — so a Copilot-only pre-push pass cannot catch
-Claude-side adversarial findings; the Copilot Adversarial Specialist
-runs natively.) See
+prefer a pre-push pass to catch findings locally rather than in PR
+review rounds. The specialists that actually run depend on the
+auto-classified tier: Light tier dispatches Static Analysis + Copilot
+Adversarial only, while Standard and Deep also dispatch Governance and
+Plan Drift. (The Claude Adversarial Specialist is Claude-only — see
+caveat below — so a Copilot-only pre-push pass cannot catch Claude-side
+adversarial findings; the Copilot Adversarial Specialist runs natively
+and remains in scope.) See
 [`.claude/skills/review-code/SKILL.md`](../.claude/skills/review-code/SKILL.md).
 
 **Limitation**: when Copilot runs as a **PR reviewer** (the GitHub

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,10 +24,12 @@ not only in the workspace repo. When reviewing:
 The shared rule (see [`AGENTS.md` Post-Task Verification](../AGENTS.md#post-task-verification))
 expects authors to run `/review-code` against their diff before opening a PR.
 This applies to Copilot too when used in **agent / coding-assistant mode** —
-prefer a pre-push pass to catch static-analysis, governance, and
-plan-drift findings locally rather than in PR review rounds. (The
-Adversarial Specialist is Claude-only — see caveat below — so Copilot's
-pre-push pass cannot catch adversarial findings.) See
+prefer a pre-push pass to catch static-analysis, governance,
+plan-drift, and Copilot Adversarial findings locally rather than in
+PR review rounds. (The Claude Adversarial Specialist is Claude-only —
+see caveat below — so a Copilot-only pre-push pass cannot catch
+Claude-side adversarial findings; the Copilot Adversarial Specialist
+runs natively.) See
 [`.claude/skills/review-code/SKILL.md`](../.claude/skills/review-code/SKILL.md).
 
 **Limitation**: when Copilot runs as a **PR reviewer** (the GitHub
@@ -35,10 +37,12 @@ pre-push pass cannot catch adversarial findings.) See
 pre-push check is the human-or-other-agent author's responsibility.
 The Copilot review surface remains complementary, not a substitute.
 
-**Adversarial Specialist is Claude-only** — it dispatches a fresh
-subagent via Claude Code's `Agent` tool, which Copilot doesn't expose.
-Other specialists (Static Analysis, Governance, Plan Drift) are
-framework-agnostic.
+**Claude Adversarial Specialist is Claude-only** — it dispatches a
+fresh subagent via Claude Code's `Agent` tool, which Copilot doesn't
+expose. The other specialists (Static Analysis, Governance, Plan
+Drift, **Copilot Adversarial**) are framework-agnostic and run
+regardless of host runtime, provided the relevant CLI tools are
+installed.
 
 ## Environment Setup
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,9 @@ fresh subagent via Claude Code's `Agent` tool, which Copilot doesn't
 expose. The other specialists (Static Analysis, Governance, Plan
 Drift, **Copilot Adversarial**) are framework-agnostic and run
 regardless of host runtime, provided the relevant CLI tools are
-installed.
+installed and authenticated where applicable (Copilot Adversarial
+additionally requires `copilot` CLI authentication — unauthenticated
+hosts route to the skipped-with-notice path automatically).
 
 ## Environment Setup
 


### PR DESCRIPTION
Closes #461

# Plan: Scope a Copilot-only cross-model adversarial review

## Issue

https://github.com/rolker/ros2_agent_workspace/issues/461

## Context

PR #453 ported the review-skill from `rolker/agent_workspace` but
deliberately did not adopt its `cross_model_review.sh` (tmux dispatch +
Gemini/Codex/Copilot). The 2026-05-15 scoping comment on #461 settled
the design for a slimmed-down, Copilot-only revisit. The four
acceptance-criteria questions were resolved 2026-05-18:

1. Activate on **all tiers** (Light + Standard + Deep), `--no-copilot`
   opt-out per invocation.
2. **Graceful skip with notice** when `copilot` binary missing or
   unauthenticated (covers field hosts gabby/salmon).
3. **Default Copilot context** for v1 (~25.5k token floor accepted);
   evaluate after a few real runs and tighten via `--add-dir` or
   isolated `-C` if Premium burn is unacceptable.
4. **File an issue on `rolker/agent_workspace`** about its likely-broken
   `copilot -p < prompt` invocation; decoupled from this PR.

## Approach

1. **Add Copilot Adversarial as a new specialist (5e) in `review-code` SKILL.md.**
   Synchronous call, no tmux. Invocation:
   `copilot -p "" --allow-all-tools < prompt > findings 2>&1`. Strip
   the trailing `Changes / Requests / Tokens` metadata block.
   Activates on Light + Standard + Deep. **Light tier reuses the
   Standard prompt body** (settled 2026-05-18 after review-plan
   flagged this as an unsurfaced design choice); Deep tier adds the
   existing Deep-prompt focus areas (security / concurrency /
   lifecycle / cross-cutting effects). Update the Light condensed
   report format (review-code SKILL.md lines 444–459) to include a
   Copilot Adversarial findings slot.
2. **Implement availability detection + post-invocation guard.**
   Before invoking, probe with `command -v copilot` and a sanity check
   `copilot --version` (presence-only — explicitly not an auth check;
   real auth detection happens after the call). After invoking, route
   timeout (exit 124), non-zero exit, empty output, or auth-error
   text in the output to the skipped-with-notice path so
   unauthenticated hosts never surface as silent zero-finding reviews.
   Wrap the invocation in `timeout 300` so a hung CLI cannot block
   the whole review. (Post-review hardening; see Implementation Notes.)
2a. **Implement untrusted-PR safety gate** (post-PR mode only). Before
    dispatching 5e, check whether the PR head is from a fork or the
    author lacks OWNER/MEMBER/COLLABORATOR association. If so, route to
    the skipped-with-notice path unless `--allow-untrusted-copilot` is
    set. Rationale: `--allow-all-tools` exposes file/shell access to
    Copilot, and an external contributor's diff is attacker-controlled
    prompt content. (Post-review hardening; see Implementation Notes.)
3. **Add `--no-copilot` flag** to the `review-code` Usage block and
   argument parser. When set, skip dispatch entirely without the
   "skipped" notice. Also add `--allow-untrusted-copilot` (post-PR only)
   as the explicit bypass for step 2a's gate.
4. **Update the Specialists overview** in step 5 to list 5a–5e and
   remove the "Cross-model adversarial is intentionally not wired here"
   note from 5d (replace with a pointer to 5e).
5. **Update `inspiration_agent_workspace_digest.md`.** Move the
   Cross-Model entry from "Not adopted" to a new "Partially adopted"
   section: Copilot-only synchronous dispatch ported; tmux machinery
   and Gemini/Codex remain non-adopted with the existing rationale.
   Also edit the "Ported → Adversarial Specialist" entry (line ~62)
   which currently states "Cross-model variant deliberately not
   ported" — that sentence directly contradicts the new partial
   adoption.

5a. **Update `.agent/knowledge/review_depth_classification.md`.** Three
    sites go stale on merge:
    - Light / Standard / Deep specialist lists (~lines 68–69, 81–86,
      98–102) — add Copilot Adversarial to all three.
    - "Note on cross-model adversarial" block (~lines 106–111) — its
      "not adopted here" framing inverts after this PR.
    - Light condensed report description (~lines 71–72) — needs a
      slot or pointer for Copilot findings to match the SKILL.md
      Light report shape.

5b. **Update `.agent/knowledge/skill_workflows.md` line 18.** The
    "Adversarial-Claude-only caveat" reference (applied to non-Claude
    framework adapters) becomes stale once Copilot Adversarial is
    in-tree on all tiers. Reword or remove.
6. **File the upstream invocation report** on
   `rolker/agent_workspace` as a discrete step. Title: "cross_model_review.sh:
   Copilot invocation likely missing `-p \"\"` and `--allow-all-tools`".
   Body: our verified local invocation + smoke-test repro. Not a
   blocker for this PR.
7. **Open a follow-up issue** for the v1 context-strategy evaluation
   ("Evaluate Copilot Adversarial context cost; tighten if needed").
   Link it from the digest entry and from `review-code` SKILL.md so the
   v1 choice doesn't silently calcify.

## Files to Change

| File | Change |
|------|--------|
| `.claude/skills/review-code/SKILL.md` | Add 5e Copilot Adversarial subsection (Standard prompt reused on Light + Deep adds existing Deep focus areas); add `--no-copilot` and `--allow-untrusted-copilot` to Usage + arg parser; update step-5 tier dispatch to fire 5e on all tiers; update Light condensed report format to include Copilot findings slot; rename 5d to "Claude Adversarial Specialist"; replace 5d cross-model-not-wired note with pointer to 5e. Post-review hardening: `timeout 300` wrapper, post-invocation guard (empty / auth-error / non-zero exit / timeout → skipped path), untrusted-PR safety gate, `**Copilot Adversarial**:` parallel header line in both standard and Light condensed report templates, qualified "Light + --skip-static = zero specialists" predicate to require Copilot also suppressed. |
| `.agent/knowledge/inspiration_agent_workspace_digest.md` | Move Cross-Model entry from "Not adopted" → new "Partially adopted" entry; preserve non-Copilot non-adoption rationale; fix the "Ported → Adversarial Specialist" stale "Cross-model variant deliberately not ported" sentence |
| `.agent/knowledge/review_depth_classification.md` | Add Copilot Adversarial to Light/Standard/Deep specialist lists; invert the "Note on cross-model adversarial" block; add Copilot slot to Light condensed report description |
| `.agent/knowledge/skill_workflows.md` | Reword the "Adversarial-Claude-only caveat" reference to "the Claude Adversarial Specialist still requires Claude Code's `Agent` tool, but the Copilot Adversarial Specialist runs from any runtime that has the `copilot` CLI"; qualify the pre-push coverage claim by tier (Light = SA+Copilot only; Standard/Deep add Governance + Plan Drift + Claude Adversarial). |
| `.github/copilot-instructions.md` | Rename "Adversarial Specialist is Claude-only" to "Claude Adversarial Specialist is Claude-only"; add Copilot Adversarial to framework-agnostic list; update the pre-push caveat (Copilot's pre-push pass cannot catch *Claude*-side adversarial findings — Copilot Adversarial runs natively); qualify the pre-push coverage claim by tier. |
| `.agent/instructions/gemini-cli.instructions.md` | Same rename + Copilot Adversarial addition pattern as the Copilot adapter |
| `.agent/AGENT_ONBOARDING.md` | Same rename + Copilot Adversarial addition pattern as the Copilot adapter |

No new script file. The inline shell in SKILL.md grew past the
original ~15-line threshold during post-review hardening (now ~60
lines across probe + gate + invocation + post-call guard), but the
content is kept inline rather than factored to
`.agent/scripts/run_copilot_adversarial.sh` because the security model
(`--allow-all-tools` + the untrusted-PR gate) needs to be visible to
the next agent reading 5e — not buried behind a script reference.
Revisit the factor-out decision if 5e accumulates non-security
elaboration in a future change.

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Human control and transparency | `--no-copilot` flag + "skipped" notice in report + tier table in SKILL.md make it visible when Copilot runs, when it doesn't, and how to suppress it. Default-on is "tight by default, relaxable as confidence grows." |
| Only what's needed | Copilot-only, synchronous, no tmux, no `--add-dir` plumbing. Inline shell in SKILL.md rather than a new script unless complexity demands it. **Tradeoff acknowledged**: all-tier activation produces a Light-tier resource inversion — a trivial PR's Light review now consumes ~25k Copilot tokens + 1 Premium request, more *external* cost than yesterday's Standard. The cost-evaluation follow-up issue (Step 7) is the data path to revisit, but the asymmetry is named here rather than papered over. |
| A change includes its consequences | Digest entry updated; follow-up evaluation issue filed so the v1 context choice has an owner; upstream invocation report filed; no schema changes to progress.md / review-context.yaml. |
| Capture decisions, not just implementations | Acceptance-criteria answers recorded on #461; rationale repeated in SKILL.md prose under 5e; "Partially adopted" entry captures the cross-model design split. |
| Improve incrementally | v1 ships default context + all-tier activation; tier-scoping and context-tightening deferred to the follow-up issue once we have cost data. |
| Workspace vs project separation | Workspace tooling; no project-repo coupling. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0002 worktree isolation | Yes | Plan + implementation land on `feature/issue-461` workspace worktree |
| 0003 workspace infra is project-agnostic | Yes | `review-code` and the new specialist are generic ROS 2 / workspace tooling; no project-specific assumptions |
| 0004 enforcement hierarchy | Yes | `--no-copilot` opt-out is a user-facing escape hatch; default-on enforces the cross-model second-read by default |
| 0011 field mode | Yes | Graceful skip when Copilot unavailable covers field-mode hosts (gabby/salmon) without a separate code path |

## Consequences

| If we change… | Also update… | Included in plan? |
|---|---|---|
| `review-code` specialist set (add 5e) | `inspiration_agent_workspace_digest.md` "Not adopted" → "Partially adopted" | Yes — Step 5 |
| `review-code` Usage (`--no-copilot`) | None — `review-code` is invoked as a skill; no other consumers of its CLI surface | Verify via workspace grep before commit |
| `review-code` specialist set | Framework adapters that reference "Adversarial Specialist is Claude-only" | Yes — Files-to-Change row added during implementation for `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md`. The original plan said "no specialist-list enumeration found"; that was wrong — three adapters carried the stale phrasing |
| Cross-model "not adopted" / "Claude-only" prose in knowledge docs | `review_depth_classification.md`, `skill_workflows.md`, `inspiration_agent_workspace_digest.md` (line ~62 in "Ported" section) | Yes — listed in Files to Change + Step 5a/5b |
| Default-on Premium-request consumption | Cost-evaluation follow-up issue | Yes — Step 7 |
| Upstream `cross_model_review.sh` invocation suspected broken | Issue filed on `rolker/agent_workspace` | Yes — Step 6 |

## Open Questions

None remaining. The four issue-comment acceptance answers settled the
top-level decisions; review-plan (PR #464, 2026-05-18) surfaced two
derived questions that the original four didn't directly address:

- **Light-tier prompt body** — resolved 2026-05-18: reuse the Standard
  prompt body (simplest one-prompt-per-tier-pair shape). Documented in
  Step 1.
- **Light-tier Premium-request asymmetry** — acknowledged as an
  intentional tradeoff in the "Only what's needed" self-check row;
  data-driven revisit deferred to the Step 7 follow-up issue.

## Estimated Scope

Single PR. Four-plus knowledge/skill file edits, three framework-adapter
edits, and two new issues filed (one upstream, one follow-up). Inline
shell grew past the original ~15-line threshold during post-review
hardening (timeout + post-invocation guard + untrusted-PR gate) but
is kept inline; see the note under "Files to Change" and Implementation
Notes for rationale.

## Implementation Notes

- **Framework adapters carried stale "Claude-only" phrasing.** Plan-time
  workspace grep was scoped narrowly; in-flight grep
  (`grep -rln -E "cross-model|cross_model|Claude.{0,5}only|..."`) found
  three additional consumers: `.github/copilot-instructions.md`,
  `.agent/instructions/gemini-cli.instructions.md`, and
  `.agent/AGENT_ONBOARDING.md`. All three said "Adversarial Specialist
  is Claude-only" — actively wrong after this PR. Folded into the same
  knowledge-doc commit since the prose change is identical
  (rename to "Claude Adversarial Specialist", add Copilot Adversarial
  as framework-agnostic).

- **Untrusted-PR safety gate added during post-PR review pass.**
  The original Step 2 only covered availability detection (binary
  missing / auth failure). Post-PR review of PR #464 surfaced that
  `--allow-all-tools` + post-PR mode on contributor diffs grants
  Copilot file/shell access to prompt content that originated outside
  the repo's trust boundary. User chose the "explicit confirmation
  gate" option: external PRs (fork head OR author association below
  COLLABORATOR) route to the skipped path unless
  `--allow-untrusted-copilot` is passed. Implemented as a new step 2a
  in 5e between the availability probe and the invocation. The flag
  is post-PR only (an error if passed in pre-push, where the gate
  doesn't apply).

- **Post-invocation guard formalized.** Step 2's original prose said
  "post-call empty findings or auth-text routes to skipped-notice
  path" but the snippet didn't actually enforce that. Post-PR review
  flagged this as a discrepancy between the documented contract and
  the shown code. The hardened snippet now includes explicit checks
  for timeout (exit 124), non-zero exit, empty findings file, and
  auth-error grep patterns — each routes to the skipped path with a
  specific reason. Plus a `timeout 300` wrapper so a hung CLI cannot
  block the whole review (field-mode-relevant when connectivity is
  flaky).

- **Light-tier zero-specialist predicate corrected.** With 5e firing
  at Light, the prior "Light + --skip-static = zero specialists"
  predicate became conditional on Copilot also being suppressed. Both
  the Step 5a comment and the Step 7 report-format guidance updated
  to reflect the new precondition.
