### PR TITLE
[PLAN] Sub-agent commits drop agent git identity; commits get authored under human user

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -26,6 +26,23 @@ source .agent/scripts/set_git_identity_env.sh "<Agent Name>" "<email>" "<your mo
 
 See [`AI_IDENTITY_STRATEGY.md`](AI_IDENTITY_STRATEGY.md) for the full identity decision tree.
 
+**Commit pattern** (host-based agents): the env vars exported by
+`set_git_identity_env.sh` may not survive across separate bash
+invocations (most agent runtimes spawn fresh subshells per call). Use
+per-commit `-c` overrides as the canonical pattern:
+
+```bash
+git -c user.name="$AGENT_NAME" \
+    -c user.email="$AGENT_EMAIL" \
+    commit -m "…"
+```
+
+The `-c` flags propagate to git's subprocesses (including the
+pre-commit hook) via `GIT_CONFIG_PARAMETERS`, so the identity is
+robust regardless of subshell semantics. Enforced on agent-convention
+branches by `.agent/hooks/check-commit-identity.py` and the CI check.
+See AGENTS.md "Agent Commit Identity" for full rationale.
+
 ## Core Rules
 
 See [`AGENTS.md`](../AGENTS.md) for the shared workspace rules all agents must follow.

--- a/.agent/AI_IDENTITY_STRATEGY.md
+++ b/.agent/AI_IDENTITY_STRATEGY.md
@@ -79,6 +79,23 @@ source .agent/scripts/set_git_identity_env.sh "Copilot CLI Agent" "roland+copilo
 
 **How it works**: Sets `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL` environment variables which take precedence over `.git/config`. Also exports `AGENT_NAME`, `AGENT_EMAIL`, `AGENT_MODEL`, `AGENT_FRAMEWORK` for use in GitHub API signatures.
 
+**Subshell caveat**: agent tool runtimes typically run each bash
+invocation in a fresh subshell, so the env-var exports from this script
+don't reach a separate `git commit` subshell run later. The robust
+agent-commit pattern combines the env-var exports (for signatures)
+with **per-commit `-c` overrides** (for the commit itself):
+
+```bash
+git -c user.name="$AGENT_NAME" \
+    -c user.email="$AGENT_EMAIL" \
+    commit -m "…"
+```
+
+The `-c` flags propagate to git's subprocesses via `GIT_CONFIG_PARAMETERS`
+so pre-commit hooks see the agent identity even when the bash subshell
+running the commit didn't inherit the sourced exports. See AGENTS.md
+"Agent Commit Identity" for the full pattern + rationale.
+
 #### When to Use Persistent Identity (Containerized Agents)
 
 **Use for**: Antigravity, containerized agents, or dedicated agent-only checkouts.

--- a/.agent/hooks/check-commit-identity.py
+++ b/.agent/hooks/check-commit-identity.py
@@ -1,31 +1,45 @@
 #!/usr/bin/env python3
-"""
-Pre-commit hook to block commits with unconfigured or unrecognized git identity.
+"""Pre-commit hook to block commits with wrong git identity.
 
-Agents frequently commit with wrong identity when they forget to run
-set_git_identity_env.sh. This hook catches that before it becomes a problem.
+Branch-and-env aware:
+- On an agent-convention branch AND `$AGENT_NAME` set in the environment,
+  enforce strict mode: require an agent-pattern email
+  (`roland+*@ccom.unh.edu`) and reject the human patterns.
+- Otherwise stay permissive (the pre-#468 behavior): accept any pattern
+  in PERMISSIVE_ACCEPTED_PATTERNS so the human can edit interactively
+  and field-mode hotfixes still work.
+
+Patterns and the agent-branch regex live in `identity_patterns.py`.
+
+Caveat (per #468 / plan): strict mode is gated on `$AGENT_NAME`, so an
+agent committing in a subshell that lost the env var falls into
+permissive mode — exactly the failure this hook tries to defeat. The CI
+check (Mechanism C, `check_pr_authors.py`) is the load-bearing defense
+against that case; this hook helps when the agent *does* have
+`$AGENT_NAME` set.
 """
 
-import fnmatch
 import os
 import subprocess
 import sys
+from pathlib import Path
 
-# Accepted email patterns
-# - roland+*@ccom.unh.edu: any agent identity (copilot, gemini, claude, etc.)
-# - roland@ccom.unh.edu: human (work)
-# - roland@rolker.net: human (personal)
-ACCEPTED_PATTERNS = [
-    "roland+*@ccom.unh.edu",
-    "roland@ccom.unh.edu",
-    "roland@rolker.net",
-]
+# Make identity_patterns importable when invoked as a pre-commit script.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from identity_patterns import (  # noqa: E402
+    ACCEPTED_AGENT_PATTERNS,
+    PERMISSIVE_ACCEPTED_PATTERNS,
+    is_agent_branch,
+    matches_any,
+)
 
 
 def get_commit_email():
-    """Get the email that will be used for the next commit.
+    """Return the email that will be used for the next commit.
 
-    GIT_AUTHOR_EMAIL env var takes precedence over git config user.email.
+    GIT_AUTHOR_EMAIL takes precedence over git config user.email
+    (matching git's own resolution order).
     """
     email = os.environ.get("GIT_AUTHOR_EMAIL", "").strip()
     if email:
@@ -43,34 +57,53 @@ def get_commit_email():
         return ""
 
 
-def is_accepted(email):
-    """Check if email matches any accepted pattern."""
-    if not email:
+def get_current_branch():
+    """Return the current branch name, or "" on detached HEAD / error."""
+    try:
+        result = subprocess.run(
+            ["git", "symbolic-ref", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def strict_mode_active():
+    """Return True if the strict gate fires: agent branch AND $AGENT_NAME set."""
+    if not os.environ.get("AGENT_NAME", "").strip():
         return False
-    for pattern in ACCEPTED_PATTERNS:
-        if fnmatch.fnmatch(email, pattern):
-            return True
-    return False
+    return is_agent_branch(get_current_branch())
 
 
 def main():
-    """Verify commit identity is configured correctly."""
     email = get_commit_email()
+    strict = strict_mode_active()
+    accepted = ACCEPTED_AGENT_PATTERNS if strict else PERMISSIVE_ACCEPTED_PATTERNS
 
-    if is_accepted(email):
+    if matches_any(email, accepted):
         return 0
 
     print()
-    print("ERROR: Commit identity is not configured or not recognized!")
-    print()
-    if email:
-        print(f"  Current email: {email}")
+    if strict:
+        print("ERROR: Agent branch + $AGENT_NAME set — strict commit-identity mode.")
+        print("       Commit must be authored under an agent email pattern.")
     else:
-        print("  Current email: (not set)")
+        print("ERROR: Commit identity is not configured or not recognized!")
     print()
-    print(f"  Accepted patterns: {', '.join(ACCEPTED_PATTERNS)}")
+    print(f"  Current email: {email or '(not set)'}")
+    print(f"  AGENT_NAME:    {os.environ.get('AGENT_NAME') or '(not set)'}")
+    print(f"  Branch:        {get_current_branch() or '(detached / unknown)'}")
+    print(f"  Mode:          {'strict (agent-only)' if strict else 'permissive'}")
     print()
-    print("  To fix, run one of:")
+    print(f"  Accepted patterns: {', '.join(accepted)}")
+    print()
+    print("  To fix:")
+    if strict:
+        print('    git -c user.name="$AGENT_NAME" -c user.email="$AGENT_EMAIL" commit -m "…"')
+        print("  Or:")
     print("    source .agent/scripts/set_git_identity_env.sh --detect")
     print("    source .agent/scripts/set_git_identity_env.sh --agent <framework>")
     print()

--- a/.agent/hooks/check_pr_authors.py
+++ b/.agent/hooks/check_pr_authors.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""CI check: reject PRs where an agent-convention branch has commits
+authored under a human email (Mechanism C from issue #468).
+
+The pre-commit hook `check-commit-identity.py` enforces the same rule
+locally, but it depends on `$AGENT_NAME` being set in the commit
+shell — which the very bug #468 describes (env vars not surviving
+subshells) can defeat. This script is the load-bearing defense: it
+runs in CI, has no env-var dependency, and operates only on the commit
+authorship that GitHub records.
+
+Usage:
+    check_pr_authors.py <pr-number>
+
+Exits 0 if:
+- The PR head branch is not an agent-convention branch (nothing to
+  check), or
+- All commits have authors matching `ACCEPTED_AGENT_PATTERNS` (or
+  github-bot author types that are explicitly allowlisted).
+
+Exits 1 (and prints offending commits) otherwise.
+
+Requires the `gh` CLI authenticated against the repository.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from identity_patterns import (  # noqa: E402
+    HUMAN_PATTERNS,
+    is_agent_branch,
+    matches_any,
+)
+
+
+def gh_json(args: list) -> object:
+    """Run `gh` and parse the JSON output. Exits 2 on gh failure."""
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError:
+        print("ERROR: `gh` CLI not found on PATH.", file=sys.stderr)
+        sys.exit(2)
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: gh failed: {' '.join(['gh', *args])}", file=sys.stderr)
+        print(exc.stderr, file=sys.stderr)
+        sys.exit(2)
+    return json.loads(result.stdout)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <pr-number>", file=sys.stderr)
+        return 2
+
+    pr_number = sys.argv[1]
+
+    # Pull PR metadata + commit list in one gh call (fewer round trips).
+    pr_info = gh_json(
+        [
+            "pr",
+            "view",
+            pr_number,
+            "--json",
+            "headRefName,isCrossRepository,commits",
+        ]
+    )
+    head_branch = pr_info.get("headRefName", "")
+    is_fork = bool(pr_info.get("isCrossRepository"))
+    commits = pr_info.get("commits", [])
+
+    if not is_agent_branch(head_branch):
+        print(
+            f"PR #{pr_number} head branch '{head_branch}' is not an "
+            "agent-convention branch — nothing to check."
+        )
+        return 0
+
+    if is_fork:
+        print(
+            f"INFO: PR #{pr_number} is a cross-repository PR (fork head). "
+            "Validating commit authorship anyway."
+        )
+    if not commits:
+        print(f"WARNING: PR #{pr_number} has no commits to validate.")
+        return 0
+
+    offending = []
+    for c in commits:
+        sha = c.get("oid", "")[:7]
+        # gh returns a list of authors per commit (GitHub coauthor model).
+        # Reject if any author's email is in HUMAN_PATTERNS.
+        for author in c.get("authors") or []:
+            email = (author.get("email") or "").strip()
+            name = (author.get("name") or "").strip()
+            if matches_any(email, HUMAN_PATTERNS):
+                offending.append((sha, name, email, c.get("messageHeadline", "")))
+
+    if not offending:
+        print(
+            f"✅ PR #{pr_number}: {len(commits)} commit(s) on agent branch "
+            f"'{head_branch}'; no human-authored commits."
+        )
+        return 0
+
+    print(
+        f"❌ PR #{pr_number}: {len(offending)} of {len(commits)} commit(s) "
+        f"on agent branch '{head_branch}' are authored under a human email.",
+        file=sys.stderr,
+    )
+    print(file=sys.stderr)
+    print("Offending commits:", file=sys.stderr)
+    for sha, name, email, headline in offending:
+        print(f"  {sha} <{email}> {name} — {headline}", file=sys.stderr)
+    print(file=sys.stderr)
+    print(
+        "Agent-convention branches (feature/issue-N, feature/ISSUE-N-desc,",
+        file=sys.stderr,
+    )
+    print("skill/<name>-<timestamp>) must carry agent-authored commits only.", file=sys.stderr)
+    print('See AGENTS.md "Agent Commit Identity" for the canonical pattern.', file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agent/hooks/check_pr_authors.py
+++ b/.agent/hooks/check_pr_authors.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """CI check: reject PRs where an agent-convention branch has commits
-authored under a human email (Mechanism C from issue #468).
+whose primary author email matches a human pattern (Mechanism C from
+issue #468).
 
 The pre-commit hook `check-commit-identity.py` enforces the same rule
 locally, but it depends on `$AGENT_NAME` being set in the commit
@@ -9,14 +10,22 @@ subshells) can defeat. This script is the load-bearing defense: it
 runs in CI, has no env-var dependency, and operates only on the commit
 authorship that GitHub records.
 
+**Primary-author semantics.** The check inspects only the primary
+author (the `author` of record on the commit). Co-Authored-By trailers
+— which GitHub surfaces alongside the primary author in
+`gh pr view --json commits` — are **not** evaluated. This is
+deliberate: legitimate agent commits often credit Roland as
+Co-Authored-By for pair-work, and #468's actual failure mode is
+primary-author drift (the worked example on PR #464 had four commits
+whose primary author was the human user, not their coauthor).
+
 Usage:
     check_pr_authors.py <pr-number>
 
 Exits 0 if:
 - The PR head branch is not an agent-convention branch (nothing to
   check), or
-- All commits have authors matching `ACCEPTED_AGENT_PATTERNS` (or
-  github-bot author types that are explicitly allowlisted).
+- Every commit's primary author email is NOT in `HUMAN_PATTERNS`.
 
 Exits 1 (and prints offending commits) otherwise.
 
@@ -62,6 +71,13 @@ def main():
         return 2
 
     pr_number = sys.argv[1]
+    if not pr_number.isdigit():
+        print(
+            f"ERROR: <pr-number> must be a positive integer; got: {pr_number!r}",
+            file=sys.stderr,
+        )
+        print(f"usage: {sys.argv[0]} <pr-number>", file=sys.stderr)
+        return 2
 
     # Pull PR metadata + commit list in one gh call (fewer round trips).
     pr_info = gh_json(
@@ -96,13 +112,19 @@ def main():
     offending = []
     for c in commits:
         sha = c.get("oid", "")[:7]
-        # gh returns a list of authors per commit (GitHub coauthor model).
-        # Reject if any author's email is in HUMAN_PATTERNS.
-        for author in c.get("authors") or []:
-            email = (author.get("email") or "").strip()
-            name = (author.get("name") or "").strip()
-            if matches_any(email, HUMAN_PATTERNS):
-                offending.append((sha, name, email, c.get("messageHeadline", "")))
+        # gh's `commits` field returns an `authors` list where authors[0]
+        # is the primary commit author and authors[1:] are Co-Authored-By
+        # trailers. #468 is about *primary* author drift — we deliberately
+        # do not evaluate coauthors so legitimate pair-work attribution
+        # (e.g., agent commit crediting Roland as coauthor) isn't blocked.
+        authors = c.get("authors") or []
+        if not authors:
+            continue
+        primary = authors[0]
+        email = (primary.get("email") or "").strip()
+        name = (primary.get("name") or "").strip()
+        if matches_any(email, HUMAN_PATTERNS):
+            offending.append((sha, name, email, c.get("messageHeadline", "")))
 
     if not offending:
         print(
@@ -113,7 +135,7 @@ def main():
 
     print(
         f"❌ PR #{pr_number}: {len(offending)} of {len(commits)} commit(s) "
-        f"on agent branch '{head_branch}' are authored under a human email.",
+        f"on agent branch '{head_branch}' have a human-pattern primary author.",
         file=sys.stderr,
     )
     print(file=sys.stderr)

--- a/.agent/hooks/identity_patterns.py
+++ b/.agent/hooks/identity_patterns.py
@@ -1,0 +1,69 @@
+"""Shared identity patterns for agent-vs-human commit-author checks.
+
+Single source of truth for:
+- Accepted agent email patterns (any +suffix on roland@ccom.unh.edu)
+- Human email patterns (Roland's bare addresses)
+- Agent-branch regexes (feature/issue-N and skill/<name>-<timestamp>)
+
+Consumers:
+- .agent/hooks/check-commit-identity.py — pre-commit hook (Mechanism A)
+- .agent/hooks/check_pr_authors.py     — CI script (Mechanism C)
+- .agent/hooks/verify-issue-branch.py  — pre-commit hook (existing, uses
+  the same feature/issue regex to extract issue numbers)
+
+Keeping these patterns and regexes here prevents drift between layers.
+"""
+
+import fnmatch
+import re
+
+# Emails accepted as agent identities — any +suffix before @ccom.unh.edu.
+# Examples: roland+claude-code@ccom.unh.edu, roland+copilot-cli@ccom.unh.edu.
+ACCEPTED_AGENT_PATTERNS = [
+    "roland+*@ccom.unh.edu",
+]
+
+# Roland's human email addresses. Accepted in human-mode contexts
+# (AGENT_NAME unset, non-agent branch, detached HEAD, field-mode hotfix)
+# and rejected in strict-mode contexts (agent branch + AGENT_NAME set).
+HUMAN_PATTERNS = [
+    "roland@ccom.unh.edu",
+    "roland@rolker.net",
+]
+
+# Permissive accepted set — what check-commit-identity.py accepts when
+# the strict-mode gate doesn't fire. Matches the pre-#468 behavior.
+PERMISSIVE_ACCEPTED_PATTERNS = ACCEPTED_AGENT_PATTERNS + HUMAN_PATTERNS
+
+# Agent branch convention regex (mirrors verify-issue-branch.py's
+# historical regex). Case-insensitive on the literal "ISSUE" portion
+# to accept both `feature/issue-N` and `feature/ISSUE-N-desc`.
+FEATURE_ISSUE_BRANCH_RE = re.compile(r"^feature/[iI][sS][sS][uU][eE]-(\d+)")
+
+# Skill-worktree branch convention from AGENTS.md:
+# skill/{name}-{YYYYMMDD-HHMMSS-NNNNNNNNN}
+SKILL_BRANCH_RE = re.compile(r"^skill/[^/]+-\d{8}-\d{6}-\d{9}$")
+
+
+def matches_any(email: str, patterns: list) -> bool:
+    """Return True if email matches any fnmatch pattern in patterns."""
+    if not email:
+        return False
+    return any(fnmatch.fnmatch(email, p) for p in patterns)
+
+
+def is_agent_branch(branch_name: str) -> bool:
+    """Return True if branch matches the agent-branch convention.
+
+    Recognizes:
+    - feature/issue-N or feature/ISSUE-N-description (issue branches)
+    - skill/<name>-YYYYMMDD-HHMMSS-NNNNNNNNN (skill-worktree branches)
+
+    An empty / missing branch name (detached HEAD) returns False so the
+    caller falls through to permissive mode rather than failing closed.
+    """
+    if not branch_name:
+        return False
+    return bool(FEATURE_ISSUE_BRANCH_RE.match(branch_name)) or bool(
+        SKILL_BRANCH_RE.match(branch_name)
+    )

--- a/.agent/hooks/verify-issue-branch.py
+++ b/.agent/hooks/verify-issue-branch.py
@@ -7,9 +7,15 @@ Informational only — always returns 0.
 """
 
 import os
-import re
 import subprocess
 import sys
+from pathlib import Path
+
+# Reuse the shared agent-branch regex so this hook and check-commit-identity.py
+# never disagree on what counts as a feature/issue-N branch.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from identity_patterns import FEATURE_ISSUE_BRANCH_RE  # noqa: E402
 
 
 def get_branch_name():
@@ -24,7 +30,7 @@ def get_branch_name():
 
 def extract_issue_number(branch_name):
     """Extract issue number from branch name like feature/issue-42 or feature/ISSUE-42-desc."""
-    match = re.match(r"^feature/[iI][sS][sS][uU][eE]-(\d+)", branch_name)
+    match = FEATURE_ISSUE_BRANCH_RE.match(branch_name)
     if match:
         return match.group(1)
     return None

--- a/.agent/instructions/gemini-cli.instructions.md
+++ b/.agent/instructions/gemini-cli.instructions.md
@@ -15,6 +15,22 @@ Replace `<your model>` with your actual runtime model (e.g. `Gemini 2.5 Pro`, `G
 Verify with `echo "$AGENT_MODEL"` — it should echo exactly what you passed. Do not edit
 `framework_config.sh` to match your model; the entries there are fallback-only.
 
+**Commit pattern**: sourcing `set_git_identity_env.sh` exports the env
+vars for this shell, but Gemini CLI typically runs each bash command
+in a fresh subshell — the exports don't reach a separate `git commit`
+invocation later. Use per-commit `-c` overrides instead:
+
+```bash
+git -c user.name="$AGENT_NAME" \
+    -c user.email="$AGENT_EMAIL" \
+    commit -m "…"
+```
+
+This is enforced on `feature/issue-<N>` / `feature/ISSUE-<N>-<desc>` /
+`skill/*` branches by `.agent/hooks/check-commit-identity.py` (pre-commit)
+and `.agent/hooks/check_pr_authors.py` (CI). See AGENTS.md "Agent
+Commit Identity" for the full rationale.
+
 ## Gemini-Specific Notes
 
 - **Google Cloud**: If Gemini CLI has access to Google Cloud services, check your environment for available integrations.

--- a/.agent/scripts/test_check_commit_identity.sh
+++ b/.agent/scripts/test_check_commit_identity.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Regression test for .agent/hooks/check-commit-identity.py.
+#
+# Verifies the branch-and-env-aware gate from #468:
+# - Strict mode fires only when AGENT_NAME is set AND the branch matches
+#   the agent-branch convention (feature/issue-N, feature/ISSUE-N-desc,
+#   skill/<name>-<timestamp>).
+# - Permissive mode applies otherwise (AGENT_NAME unset, non-agent branch,
+#   detached HEAD).
+#
+# Standalone-runnable; no Makefile target required. Run from anywhere:
+#     bash .agent/scripts/test_check_commit_identity.sh
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    echo "Error: This script should be executed, not sourced."
+    return 1
+fi
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$WORKSPACE_ROOT/hooks/check-commit-identity.py"
+
+if [[ ! -f "$HOOK" ]]; then
+    echo "❌ Hook not found at $HOOK"
+    exit 2
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cd "$TMPDIR" || exit 2
+git init --quiet --initial-branch=main
+git config user.name "Test Setup"
+git config user.email "test-setup@example.com"
+git commit --allow-empty --quiet -m "init"
+
+PASS=0
+FAIL=0
+FAIL_DETAILS=()
+
+# run_case <desc> <branch> <AGENT_NAME> <GIT_AUTHOR_EMAIL> <expected_exit>
+#
+# branch:           literal branch name to checkout (or "__DETACHED__" to
+#                   detach HEAD instead of creating/switching a branch)
+# AGENT_NAME:       passed via env; empty string means unset
+# GIT_AUTHOR_EMAIL: passed via env; takes precedence over git config
+# expected_exit:    0 for accept, 1 for reject
+run_case() {
+    local desc="$1"
+    local branch="$2"
+    local agent_name="$3"
+    local email="$4"
+    local expected_exit="$5"
+
+    if [[ "$branch" == "__DETACHED__" ]]; then
+        git checkout --detach --quiet HEAD
+    else
+        # -B creates or resets the branch and switches to it (works for any name)
+        git checkout -B "$branch" --quiet 2>/dev/null
+    fi
+
+    local actual_exit=0
+    local output
+    output=$(
+        AGENT_NAME="$agent_name" GIT_AUTHOR_EMAIL="$email" \
+        python3 "$HOOK" 2>&1
+    ) || actual_exit=$?
+
+    if [[ "$actual_exit" == "$expected_exit" ]]; then
+        echo "✅ $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "❌ $desc"
+        echo "   branch=$branch AGENT_NAME='$agent_name' email='$email'"
+        echo "   expected exit=$expected_exit, got=$actual_exit"
+        FAIL=$((FAIL + 1))
+        FAIL_DETAILS+=("$desc")
+        # Indented hook output for diagnostic context
+        while IFS= read -r line; do echo "     $line"; done <<<"$output"
+    fi
+}
+
+echo "=== check-commit-identity.py regression test ==="
+echo "Hook: $HOOK"
+echo ""
+
+# --- Strict-mode cases (agent branch + AGENT_NAME set) ---
+run_case "strict: feature/issue-N + AGENT_NAME + human email → reject" \
+    "feature/issue-100" "Claude Code Agent" "roland@ccom.unh.edu" 1
+
+run_case "strict: feature/issue-N + AGENT_NAME + agent email → accept" \
+    "feature/issue-100" "Claude Code Agent" "roland+claude-code@ccom.unh.edu" 0
+
+run_case "strict: feature/ISSUE-N-desc (uppercase) + AGENT_NAME + human email → reject" \
+    "feature/ISSUE-100-some-description" "Claude Code Agent" "roland@ccom.unh.edu" 1
+
+run_case "strict: skill/<name>-<timestamp> + AGENT_NAME + human email → reject" \
+    "skill/research-20260518-120000-123456789" "Claude Code Agent" "roland@ccom.unh.edu" 1
+
+run_case "strict: feature/issue-N + AGENT_NAME + rolker.net (other human) → reject" \
+    "feature/issue-100" "Claude Code Agent" "roland@rolker.net" 1
+
+# --- Permissive-mode cases (AGENT_NAME unset OR non-agent branch) ---
+run_case "permissive: agent branch + AGENT_NAME unset + human email → accept" \
+    "feature/issue-100" "" "roland@ccom.unh.edu" 0
+
+run_case "permissive: agent branch + AGENT_NAME unset + agent email → accept" \
+    "feature/issue-100" "" "roland+claude-code@ccom.unh.edu" 0
+
+run_case "permissive: non-agent branch (main) + AGENT_NAME + human email → accept" \
+    "main" "Claude Code Agent" "roland@ccom.unh.edu" 0
+
+run_case "permissive: non-agent branch (fix/foo) + AGENT_NAME + human email → accept" \
+    "fix/something" "Claude Code Agent" "roland@ccom.unh.edu" 0
+
+run_case "permissive: detached HEAD + AGENT_NAME + human email → accept" \
+    "__DETACHED__" "Claude Code Agent" "roland@ccom.unh.edu" 0
+
+# --- Reject-in-both-modes cases (email matches no accepted pattern) ---
+run_case "permissive: unknown email → reject (current behavior preserved)" \
+    "main" "" "stranger@example.com" 1
+
+run_case "strict: unknown email → reject" \
+    "feature/issue-100" "Claude Code Agent" "stranger@example.com" 1
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+    echo ""
+    echo "Failures:"
+    for d in "${FAIL_DETAILS[@]}"; do echo "  - $d"; done
+    exit 1
+fi
+
+exit 0

--- a/.agent/scripts/test_check_commit_identity.sh
+++ b/.agent/scripts/test_check_commit_identity.sh
@@ -125,6 +125,60 @@ run_case "permissive: unknown email → reject (current behavior preserved)" \
 run_case "strict: unknown email → reject" \
     "feature/issue-100" "Claude Code Agent" "stranger@example.com" 1
 
+# --- Canonical Mechanism B pattern: git -c user.email=... propagation ---
+# This tests that the hook correctly sees the agent email when the user
+# invokes `git -c user.email=$AGENT_EMAIL commit` against a repo whose
+# .git/config carries the human identity. Git propagates -c overrides
+# to subprocesses (including the pre-commit hook) via the
+# GIT_CONFIG_PARAMETERS env var. This is the pattern documented in
+# AGENTS.md "Agent Commit Identity"; pin it here so any regression in
+# the hook's email resolution (e.g., bypassing the override) trips the
+# test.
+echo ""
+echo "--- Mechanism B canonical -c propagation ---"
+
+# Pre-set the on-disk config to a human email (simulating the failure
+# mode where a sub-agent inherits .git/config from the user's setup).
+git config user.email "roland@ccom.unh.edu"
+git checkout -B "feature/issue-100" --quiet
+
+# Simulate `git -c user.email=$AGENT_EMAIL commit`: git would set
+# GIT_CONFIG_PARAMETERS for the hook subprocess so it sees the override.
+actual_exit=0
+output=$(
+    AGENT_NAME="Claude Code Agent" \
+    GIT_CONFIG_PARAMETERS="'user.email=roland+claude-code@ccom.unh.edu'" \
+    python3 "$HOOK" 2>&1
+) || actual_exit=$?
+
+if [[ "$actual_exit" == "0" ]]; then
+    echo "✅ strict: agent branch + AGENT_NAME + on-disk human email + -c agent override → accept (GIT_CONFIG_PARAMETERS propagation works)"
+    PASS=$((PASS + 1))
+else
+    echo "❌ strict: -c agent override should have been seen by hook, got exit=$actual_exit"
+    FAIL=$((FAIL + 1))
+    FAIL_DETAILS+=("git -c propagation")
+    while IFS= read -r line; do echo "     $line"; done <<<"$output"
+fi
+
+# Sanity check the inverse: without the -c override but with the same
+# on-disk human config, strict mode rejects.
+actual_exit=0
+output=$(
+    AGENT_NAME="Claude Code Agent" \
+    python3 "$HOOK" 2>&1
+) || actual_exit=$?
+
+if [[ "$actual_exit" == "1" ]]; then
+    echo "✅ strict: agent branch + AGENT_NAME + on-disk human email (no -c) → reject (no propagation, hook sees human)"
+    PASS=$((PASS + 1))
+else
+    echo "❌ strict: should have rejected on-disk human email without override, got exit=$actual_exit"
+    FAIL=$((FAIL + 1))
+    FAIL_DETAILS+=("no propagation rejection")
+    while IFS= read -r line; do echo "     $line"; done <<<"$output"
+fi
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 

--- a/.agent/work-plans/issue-468/plan.md
+++ b/.agent/work-plans/issue-468/plan.md
@@ -28,13 +28,37 @@ A + B + C below). Belt-and-suspenders from the start.
 
 1. **Mechanism A — tighten `.agent/hooks/check-commit-identity.py`
    to be branch-and-env aware.** When `$AGENT_NAME` is set AND the
-   current branch matches the agent-branch convention
-   (`feature/issue-*` or `skill/<name>-<timestamp>`), require an
-   agent-pattern email (`roland+*@ccom.unh.edu`) and reject the human
-   patterns. Otherwise preserve current permissive behavior so the
-   human can edit interactively and field-mode hotfixes still work.
-   Branch detection uses `git symbolic-ref --short HEAD` (fail-safe to
-   permissive on detached HEAD).
+   current branch matches the agent-branch convention (defined in
+   shared module; see step 1a), require an agent-pattern email
+   (`roland+*@ccom.unh.edu`) and reject the human patterns. Otherwise
+   preserve current permissive behavior so the human can edit
+   interactively and field-mode hotfixes still work. Branch detection
+   uses `git symbolic-ref --short HEAD` (fail-safe to permissive on
+   detached HEAD).
+
+   **Honest acknowledgement**: Mechanism A is bypassed by the same
+   root cause #468 describes — an unset `$AGENT_NAME` in a subshell
+   silently triggers permissive mode. The hook helps when agents
+   *do* set the env var; it can't defend against agents that don't.
+   Mechanism C is therefore **load-bearing**, not optional
+   belt-and-suspenders — it's the only layer immune to the
+   subshell-env-var failure mode.
+
+1a. **Extract shared identity patterns and agent-branch regex to a new
+    module** `.agent/hooks/identity_patterns.py`. Both Mechanism A's
+    hook and Mechanism C's CI script (and the existing
+    `verify-issue-branch.py`) consume it. Contents:
+    - `ACCEPTED_AGENT_PATTERNS = ["roland+*@ccom.unh.edu"]`
+    - `HUMAN_PATTERNS = ["roland@ccom.unh.edu", "roland@rolker.net"]`
+    - `PERMISSIVE_ACCEPTED_PATTERNS = ACCEPTED_AGENT_PATTERNS + HUMAN_PATTERNS`
+    - Agent-branch regex reused from `verify-issue-branch.py:27`:
+      `^feature/[iI][sS][sS][uU][eE]-(\d+)`, plus
+      `^skill/[^/]+-\d{8}-\d{6}-\d{9}$` for the skill-worktree
+      convention from AGENTS.md.
+    - `is_agent_branch(name: str) -> bool` helper.
+    Single source of truth eliminates DRY drift between A and C.
+    `verify-issue-branch.py` refactored to import from this module
+    on the same PR to ensure the regex stays consistent.
 
 2. **Mechanism A regression test —**
    `.agent/scripts/test_check_commit_identity.sh` mirroring the
@@ -60,22 +84,26 @@ A + B + C below). Belt-and-suspenders from the start.
    - Cross-reference to `set_git_identity_env.sh` which still exports
      `$AGENT_NAME` / `$AGENT_EMAIL` for the `-c` flags to reference.
 
-4. **Mechanism B cascade —** add `$AGENT_EMAIL` export to
-   `set_git_identity_env.sh` if not already present (so step 3's
-   recommended invocation works without the agent having to know
-   their own email). Verify the three framework adapters
-   (`.github/copilot-instructions.md`,
+4. **Mechanism B cascade —** verify `$AGENT_EMAIL` is exported by
+   `set_git_identity_env.sh` (it is, at line 184 — no edit needed).
+   Cascade the new "Agent Commit Identity" section to the three
+   framework adapters (`.github/copilot-instructions.md`,
    `.agent/instructions/gemini-cli.instructions.md`,
-   `.agent/AGENT_ONBOARDING.md`) mirror the new section per ADR-0006
-   and the consequences map.
+   `.agent/AGENT_ONBOARDING.md`) per ADR-0006 and the consequences map.
+   Also update `.agent/AI_IDENTITY_STRATEGY.md` (the canonical
+   multi-framework identity doc — references the env-var pattern and
+   should mention the `git -c` pattern alongside).
 
-5. **Mechanism C — CI step.** Add a job to
-   `.github/workflows/validate.yml` that fetches the PR commits via
-   `gh api` and fails if any author email matches the human patterns
-   (`roland@ccom.unh.edu`, `roland@rolker.net`) on a branch matching
-   the agent convention. Runs on `pull_request` only (the existing
-   workflow already filters there). Independent of `$AGENT_NAME`
-   env-var context, which CI doesn't have.
+5. **Mechanism C — CI step.** Add a new CI-callable Python script
+   `.agent/hooks/check_pr_authors.py` that takes a PR number, fetches
+   commits via `gh api`, and exits non-zero if any commit on an
+   agent-convention branch (per `identity_patterns.is_agent_branch`)
+   has an author email matching `HUMAN_PATTERNS`. The script imports
+   from `identity_patterns.py` so A and C share the source of truth.
+   Then add a new `validate-commit-identity` job to
+   `.github/workflows/validate.yml` that invokes the script on
+   `pull_request` events. Independent of `$AGENT_NAME` env-var context
+   (CI runners don't have it) — operates on git author email alone.
 
 6. **Self-test on the fix-pass commit.** Before merging this PR, run
    the regression test script + verify CI's new step catches a
@@ -86,14 +114,19 @@ A + B + C below). Belt-and-suspenders from the start.
 
 | File | Change |
 |------|--------|
-| `.agent/hooks/check-commit-identity.py` | Add branch-detection (`git symbolic-ref --short HEAD`) + `$AGENT_NAME` check. When both gates fire, swap `ACCEPTED_PATTERNS` to agent-only (`roland+*@ccom.unh.edu`). |
-| `.agent/scripts/test_check_commit_identity.sh` | NEW. Five-case regression test (agent-branch×agent-env matrix + detached HEAD). |
-| `.agent/scripts/set_git_identity_env.sh` | Verify/add `AGENT_EMAIL` export so `git -c user.email="$AGENT_EMAIL"` works downstream. |
-| `AGENTS.md` | New "Agent Commit Identity" subsection after "AI Signature" documenting the `git -c` pattern + rationale. |
+| `.agent/hooks/identity_patterns.py` | **NEW** shared module: `ACCEPTED_AGENT_PATTERNS`, `HUMAN_PATTERNS`, `PERMISSIVE_ACCEPTED_PATTERNS`, agent-branch regex (`feature/[iI][sS][sS][uU][eE]-N` + `skill/<name>-<timestamp>`), `is_agent_branch(name)` helper. Single source of truth for A and C. |
+| `.agent/hooks/check-commit-identity.py` | Import from `identity_patterns`. Add branch-detection (`git symbolic-ref --short HEAD`) + `$AGENT_NAME` check. When both gates fire, restrict to `ACCEPTED_AGENT_PATTERNS`; otherwise use `PERMISSIVE_ACCEPTED_PATTERNS` (current behavior). |
+| `.agent/hooks/verify-issue-branch.py` | Refactor to import the feature/issue regex from `identity_patterns` (same source of truth). Behavior preserved. |
+| `.agent/hooks/check_pr_authors.py` | **NEW** CI-callable script. Takes a PR number, fetches commits via `gh api`, fails if any commit on an agent-convention branch has an author email matching `HUMAN_PATTERNS`. Uses `identity_patterns`. |
+| `.agent/scripts/test_check_commit_identity.sh` | **NEW**. Five-case regression test (agent-branch × agent-env matrix + detached HEAD). |
+| `.agent/scripts/set_git_identity_env.sh` | No change — `$AGENT_EMAIL` already exported at line 184. (Verified before plan-edit, not a TODO.) |
+| `AGENTS.md` | New "Agent Commit Identity" subsection after "AI Signature" documenting the `git -c` pattern + Bash-tool-state rationale. Add `check_pr_authors.py`, `identity_patterns.py`, and `test_check_commit_identity.sh` to the Script Reference table. |
+| `.agent/AI_IDENTITY_STRATEGY.md` | Add a section noting the `git -c` per-commit pattern alongside the existing env-var setup. Cross-reference AGENTS.md. |
 | `.github/copilot-instructions.md` | Mirror new section. Per ADR-0006. |
 | `.agent/instructions/gemini-cli.instructions.md` | Mirror new section. Per ADR-0006. |
 | `.agent/AGENT_ONBOARDING.md` | Mirror new section. Per ADR-0006. |
-| `.github/workflows/validate.yml` | New `validate-commit-identity` job: on `pull_request`, iterate PR commits, fail if author email matches human pattern on agent-convention branch. |
+| `.github/workflows/validate.yml` | New `validate-commit-identity` job: on `pull_request`, invokes `check_pr_authors.py` against the PR. |
+| `Makefile` | Verify `make test` / `make lint` runs the new shell test (or add explicit target). Confirm during implementation. |
 
 ## Principles Self-Check
 
@@ -122,20 +155,61 @@ A + B + C below). Belt-and-suspenders from the start.
 
 | If we change... | Also update... | Included in plan? |
 |---|---|---|
-| `check-commit-identity.py` | `.agent/hooks/README.md` (if it documents the hook's accepted patterns) | Verify during implementation; doc fix folds into the hook commit if needed |
-| `AGENTS.md` (new section) | `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md` | Yes — listed in Files to Change |
-| `set_git_identity_env.sh` (add AGENT_EMAIL export) | None known; the new var is additive | Verify with `rg -F '$AGENT_EMAIL'` before commit |
-| `.github/workflows/validate.yml` (new job) | Branch protection rules (which checks block merge) — if the new check should be required to merge, update branch protection separately | Flag as follow-up if user wants the new check required for merge |
+| `check-commit-identity.py` | `.agent/hooks/README.md` (if it documents accepted patterns) | Verify during implementation; doc fix folds into the hook commit if needed |
+| `AGENTS.md` (new section) | `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md`, `.agent/AI_IDENTITY_STRATEGY.md` | Yes — all four listed in Files to Change |
+| `AGENTS.md` Script Reference table | New scripts added there (`check_pr_authors.py`, `identity_patterns.py`, `test_check_commit_identity.sh`) | Yes — included in the AGENTS.md row above |
+| New shell test (`test_check_commit_identity.sh`) | `Makefile` — verify it's picked up by `make test` / `make lint` | Yes — Makefile in Files to Change with verify-during-implementation note |
+| `.github/workflows/validate.yml` (new job) | Branch protection rules — if the new check should be required to merge, update branch protection separately (per AGENTS.md "Ask First") | Flagged as Open Question 1, not in this PR |
 | Sub-agent dispatch prompt prose in skill bodies (`plan-task` SKILL.md, `review-code` SKILL.md) | Adopt the `git -c` pattern when documenting commit examples for sub-agents | Yes — verify via workspace grep during implementation |
 
 ## Open Questions
 
 1. **Branch protection** — should the new CI check be a *required* status check for merging into `main`, or just informational? If required, that's a separate config change in the repo's GitHub settings (per AGENTS.md "Ask First" — modifying branch protection requires human approval). Flag for the user at PR open time, not now.
-2. **Hook escape hatch** — should there be an explicit `GIT_IDENTITY_OVERRIDE=1` env var that lets a maintainer commit as themselves on an agent branch (e.g., to fix something the agent broke in-place)? Open question, default: no — the user can always cd out of the agent branch or rebase, and the override creates a foot-gun. Decide based on whether the user wants it.
+
+**Resolved during plan-revision (2026-05-18, after review-plan pass)**:
+
+- **Hook escape hatch (Q2)**: **No.** A `GIT_IDENTITY_OVERRIDE=1` env-var bypass creates a foot-gun without solving a real workflow problem — a maintainer who needs to commit as themselves on an agent branch can either rebase off the branch, cherry-pick to a non-agent branch, or `unset AGENT_NAME` in the current shell (which already triggers permissive mode). Decision: no escape hatch.
 
 ## Estimated Scope
 
-Single PR, ~8 file edits + 1 new test script. Atomic commits suggested
-grouping: (1) hook tighten + test, (2) AGENTS.md + 3 adapter cascade
-+ AGENT_EMAIL export, (3) CI job. Three commits, each independently
-revertable.
+Single PR, ~12 file edits + 3 new files (`identity_patterns.py`,
+`check_pr_authors.py`, `test_check_commit_identity.sh`). Atomic
+commits suggested grouping:
+
+1. Shared module + hook tighten + regression test (new
+   `identity_patterns.py`, modified `check-commit-identity.py`,
+   refactored `verify-issue-branch.py`, new
+   `test_check_commit_identity.sh`, Makefile if needed)
+2. AGENTS.md "Agent Commit Identity" section + 4-doc cascade
+   (3 framework adapters + `AI_IDENTITY_STRATEGY.md`) +
+   AGENTS.md Script Reference table updates
+3. CI: new `check_pr_authors.py` + new `validate-commit-identity`
+   job in `validate.yml`
+
+Three commits, each independently revertable.
+
+## Implementation Notes
+
+- **Shared `identity_patterns.py` module (Step 1a)** — added after the
+  review-plan pass surfaced a DRY concern: the human-email pattern
+  list would otherwise be hard-coded in both `check-commit-identity.py`
+  (Mechanism A) and `check_pr_authors.py` (Mechanism C), and future
+  updates would silently desync. The shared module also absorbs the
+  agent-branch regex (`^feature/[iI][sS][sS][uU][eE]-(\d+)` from
+  `verify-issue-branch.py` plus the skill-worktree pattern from
+  AGENTS.md). User explicitly chose "extract to shared config" over
+  the alternatives (hard-code-with-comments / defer-to-follow-up).
+
+- **Honest acknowledgement of Mechanism A's bypass surface (Step 1)** —
+  the carve-out for permissive mode (`AGENT_NAME` unset → permissive)
+  is bypassed by the exact root cause #468 describes. This is not a
+  flaw in the plan — it's a fundamental limit of pre-commit hooks that
+  read env vars in the commit-time shell. Mechanism C (CI) is the only
+  layer immune to this bypass. The rationale shift: C is not optional
+  belt-and-suspenders; it's load-bearing for the principal failure
+  mode this issue addresses. Plan now states this explicitly.
+
+- **Resolved Open Question 2 (escape hatch)** during plan revision
+  rather than deferring to implementation. The plan's own rationale
+  already implied "no" — explicit resolution avoids scope churn during
+  implementation.

--- a/.agent/work-plans/issue-468/plan.md
+++ b/.agent/work-plans/issue-468/plan.md
@@ -1,0 +1,141 @@
+# Plan: Sub-agent commits drop agent git identity
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/468
+
+## Context
+
+Sub-agent commits in this workspace can land with the human user's git
+identity (`Roland Arsenault <roland@ccom.unh.edu>`) instead of the agent
+identity (`Claude Code Agent <roland+claude-code@ccom.unh.edu>`).
+Worked example: 4 of 6 commits on PR #464's branch before rebase.
+
+Root cause: Bash tool calls don't persist shell state between
+invocations. Sourcing `set_git_identity_env.sh` in one call exports
+env vars that the next subshell doesn't see, so `git commit` falls back
+to `.git/config`'s `user.email` (the human pattern).
+
+The existing `.agent/hooks/check-commit-identity.py` pre-commit hook
+*does* run on every commit, but its `ACCEPTED_PATTERNS` includes the
+human emails alongside agent emails — so it passes the wrong-author
+commits silently. Surfaced by the review-issue comment on #468.
+
+User chose to bundle three mitigations into one PR (acceptance criteria
+A + B + C below). Belt-and-suspenders from the start.
+
+## Approach
+
+1. **Mechanism A — tighten `.agent/hooks/check-commit-identity.py`
+   to be branch-and-env aware.** When `$AGENT_NAME` is set AND the
+   current branch matches the agent-branch convention
+   (`feature/issue-*` or `skill/<name>-<timestamp>`), require an
+   agent-pattern email (`roland+*@ccom.unh.edu`) and reject the human
+   patterns. Otherwise preserve current permissive behavior so the
+   human can edit interactively and field-mode hotfixes still work.
+   Branch detection uses `git symbolic-ref --short HEAD` (fail-safe to
+   permissive on detached HEAD).
+
+2. **Mechanism A regression test —**
+   `.agent/scripts/test_check_commit_identity.sh` mirroring the
+   pattern of the existing `test_identity_introspection.sh`. Covers:
+   - Agent branch + `AGENT_NAME` set + human email → hook fails (exit 1)
+   - Agent branch + `AGENT_NAME` set + agent email → hook passes (exit 0)
+   - Agent branch + `AGENT_NAME` unset → permissive (passes either email)
+   - Non-agent branch + `AGENT_NAME` set → permissive (passes either email)
+   - Detached HEAD → permissive (no false-positive lockout)
+   Hooked into `Makefile` `test` target if there's one for shell tests;
+   otherwise standalone-runnable.
+
+3. **Mechanism B — update `AGENTS.md` to recommend the per-commit
+   `git -c` pattern.** New short section after "AI Signature" titled
+   "Agent Commit Identity", documenting:
+   - The canonical pattern:
+     `git -c user.name="$AGENT_NAME" -c user.email="$AGENT_EMAIL" commit -m "…"`
+   - Rationale: Bash tool calls don't persist shell state across
+     invocations; the env-var script remains correct for human use
+     and as a fallback, but per-commit `-c` is the robust pattern for
+     agents that may commit across multiple Bash calls (which is
+     all agents that touch this workspace).
+   - Cross-reference to `set_git_identity_env.sh` which still exports
+     `$AGENT_NAME` / `$AGENT_EMAIL` for the `-c` flags to reference.
+
+4. **Mechanism B cascade —** add `$AGENT_EMAIL` export to
+   `set_git_identity_env.sh` if not already present (so step 3's
+   recommended invocation works without the agent having to know
+   their own email). Verify the three framework adapters
+   (`.github/copilot-instructions.md`,
+   `.agent/instructions/gemini-cli.instructions.md`,
+   `.agent/AGENT_ONBOARDING.md`) mirror the new section per ADR-0006
+   and the consequences map.
+
+5. **Mechanism C — CI step.** Add a job to
+   `.github/workflows/validate.yml` that fetches the PR commits via
+   `gh api` and fails if any author email matches the human patterns
+   (`roland@ccom.unh.edu`, `roland@rolker.net`) on a branch matching
+   the agent convention. Runs on `pull_request` only (the existing
+   workflow already filters there). Independent of `$AGENT_NAME`
+   env-var context, which CI doesn't have.
+
+6. **Self-test on the fix-pass commit.** Before merging this PR, run
+   the regression test script + verify CI's new step catches a
+   deliberately-mis-authored commit if pushed. Document in
+   `progress.md` as Local Review entry.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/hooks/check-commit-identity.py` | Add branch-detection (`git symbolic-ref --short HEAD`) + `$AGENT_NAME` check. When both gates fire, swap `ACCEPTED_PATTERNS` to agent-only (`roland+*@ccom.unh.edu`). |
+| `.agent/scripts/test_check_commit_identity.sh` | NEW. Five-case regression test (agent-branch×agent-env matrix + detached HEAD). |
+| `.agent/scripts/set_git_identity_env.sh` | Verify/add `AGENT_EMAIL` export so `git -c user.email="$AGENT_EMAIL"` works downstream. |
+| `AGENTS.md` | New "Agent Commit Identity" subsection after "AI Signature" documenting the `git -c` pattern + rationale. |
+| `.github/copilot-instructions.md` | Mirror new section. Per ADR-0006. |
+| `.agent/instructions/gemini-cli.instructions.md` | Mirror new section. Per ADR-0006. |
+| `.agent/AGENT_ONBOARDING.md` | Mirror new section. Per ADR-0006. |
+| `.github/workflows/validate.yml` | New `validate-commit-identity` job: on `pull_request`, iterate PR commits, fail if author email matches human pattern on agent-convention branch. |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Hook fails loudly with actionable message ("commit author X on agent branch — set `$AGENT_NAME` correctly or use `git -c user.email=...`"). CI failure is visible on PR. |
+| **Enforcement over documentation** | Core principle this issue addresses. AGENTS.md AI-signature rule is currently doc-only; Mechanisms A + C enforce it at two layers per ADR-0004. |
+| Only what's needed | Tighten existing hook rather than build new one. Single CI job, not a separate workflow file. No new env-var script. |
+| A change includes its consequences | AGENTS.md edit cascades to 3 framework adapters (per consequences map). Regression test added in same PR. Sub-agent dispatch prompts in skill bodies (plan-task SKILL.md, review-code SKILL.md) noted as informational — agents read these but they're prose, not configuration; no separate file to update. |
+| Test what breaks | Five-case regression test covers the dual-gate semantics. The hook can no longer fail-open silently the way it did on PR #464. |
+| Workspace vs project separation | Workspace-level enforcement; project repos can opt-in by adding the same hook. |
+| Primary framework first, portability where free | Hook is framework-agnostic Python. CI is generic GitHub Actions. AGENTS.md cascade preserves framework-agnostic guidance. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0004 — Enforcement hierarchy | Yes | Three layers: instructions (B) + pre-commit hook (A) + CI (C). Matches the ADR's "no single layer is sufficient." |
+| 0005 — Layered enforcement | Yes | CI/branch protection is authoritative (Mechanism C); pre-commit provides local feedback (Mechanism A); instructions express intent (Mechanism B). |
+| 0006 — Shared AGENTS.md | Yes | AGENTS.md is the source of truth; three framework adapters mirror per the consequences map. |
+| 0011 — Field mode | Yes | The dual gate (`$AGENT_NAME` set AND agent-branch name) preserves field-mode hotfix workflow on the default branch — those commits won't trigger the strict path. |
+| 0002 — Worktree isolation | Yes | Plan + implementation land on `feature/issue-468` workspace worktree. |
+| 0003 — Workspace infra is project-agnostic | Yes | Hook, test, workflow, and instructions are generic. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `check-commit-identity.py` | `.agent/hooks/README.md` (if it documents the hook's accepted patterns) | Verify during implementation; doc fix folds into the hook commit if needed |
+| `AGENTS.md` (new section) | `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md` | Yes — listed in Files to Change |
+| `set_git_identity_env.sh` (add AGENT_EMAIL export) | None known; the new var is additive | Verify with `rg -F '$AGENT_EMAIL'` before commit |
+| `.github/workflows/validate.yml` (new job) | Branch protection rules (which checks block merge) — if the new check should be required to merge, update branch protection separately | Flag as follow-up if user wants the new check required for merge |
+| Sub-agent dispatch prompt prose in skill bodies (`plan-task` SKILL.md, `review-code` SKILL.md) | Adopt the `git -c` pattern when documenting commit examples for sub-agents | Yes — verify via workspace grep during implementation |
+
+## Open Questions
+
+1. **Branch protection** — should the new CI check be a *required* status check for merging into `main`, or just informational? If required, that's a separate config change in the repo's GitHub settings (per AGENTS.md "Ask First" — modifying branch protection requires human approval). Flag for the user at PR open time, not now.
+2. **Hook escape hatch** — should there be an explicit `GIT_IDENTITY_OVERRIDE=1` env var that lets a maintainer commit as themselves on an agent branch (e.g., to fix something the agent broke in-place)? Open question, default: no — the user can always cd out of the agent branch or rebase, and the override creates a foot-gun. Decide based on whether the user wants it.
+
+## Estimated Scope
+
+Single PR, ~8 file edits + 1 new test script. Atomic commits suggested
+grouping: (1) hook tighten + test, (2) AGENTS.md + 3 adapter cascade
++ AGENT_EMAIL export, (3) CI job. Three commits, each independently
+revertable.

--- a/.agent/work-plans/issue-468/plan.md
+++ b/.agent/work-plans/issue-468/plan.md
@@ -186,7 +186,7 @@ commits suggested grouping:
 3. CI: new `check_pr_authors.py` + new `validate-commit-identity`
    job in `validate.yml`
 
-Three commits, each independently revertable.
+Three commits, each independently revertible.
 
 ## Implementation Notes
 

--- a/.agent/work-plans/issue-468/progress.md
+++ b/.agent/work-plans/issue-468/progress.md
@@ -22,3 +22,27 @@ issue: 468
 
 ### Dogfooding verification
 All 5 commits on this branch authored as `Claude Code Agent <roland+claude-code@ccom.unh.edu>` (the agent pattern). The CI check this PR introduces accepts its own branch; if a commit were accidentally human-authored, this PR would self-reject — the exact dogfooding outcome the plan promised.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-05-18 23:10
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context)) — emulating the future triage-reviews-as-integrator from [#470](https://github.com/rolker/ros2_agent_workspace/issues/470)
+
+**PR**: #471 at `f5817e3` (before fix-pass)
+**Sources**: 4 (Copilot R1 on `4e54c01`, Copilot R2 on `04589d6`, Local Review on `04589d6`, CI rollup)
+**Cross-source confirmations**: 1
+**CI**: all-pass (10 checks, including Mechanism C dogfooded against this PR)
+
+### Findings (sources column)
+- [x] (cross-confirmed) Coauthor handling — reject only on `authors[0]` primary author; resolves both **Copilot R2** + **Local Review** independently catching the same future-state bug + Copilot R2's offending-counter over-count complaint — `.agent/hooks/check_pr_authors.py`
+- [x] (suggestion, Copilot R2) Docstring claimed bot allowlist that didn't exist — rewritten with primary-author semantics — `.agent/hooks/check_pr_authors.py:1-31`
+- [x] (suggestion, Local Review) Test gap for `git -c user.email=…` + `GIT_CONFIG_PARAMETERS` propagation — added 2 new cases; regression test now 14-case — `.agent/scripts/test_check_commit_identity.sh`
+- [x] (suggestion, Local Review) `pr_number` input validation — `.isdigit()` check with actionable error message — `.agent/hooks/check_pr_authors.py`
+- [x] (suggestion, Copilot R1) "revertable" → "revertible" spelling — `.agent/work-plans/issue-468/plan.md`
+
+### False positives (sources column, dismissed in this report)
+- (Copilot R1 on stale plan-only commit) `feature/ISSUE-<N>-<description>` form not handled. **Stale** — current plan and implementation use case-insensitive regex `[iI][sS][sS][uU][eE]` from `identity_patterns.py`; regression test covers `feature/ISSUE-100-some-description`. Comment was on pre-revision plan wording.
+- (Copilot R2) Drop `[PLAN]` prefix from PR title. **False positive by convention** — `plan-task` SKILL.md establishes the prefix as a stable marker through the PR lifecycle (PR #464 kept it through merge). Established workspace convention.
+
+### Worked-example notes for #470
+- triage-reviews-as-integrator emulated manually for this PR: read Copilot reviews from GitHub + Local Review from progress.md, surfaced 1 cross-source confirmation (coauthor handling) as the strongest signal. Two false-positive bot findings correctly dismissed with justifications. The shared `.agent/scripts/progress_read.sh` helper from #470 would have made the integration scripted instead of manual.

--- a/.agent/work-plans/issue-468/progress.md
+++ b/.agent/work-plans/issue-468/progress.md
@@ -1,0 +1,24 @@
+---
+issue: 468
+---
+
+# Issue #468 — Sub-agent commits drop agent git identity; commits get authored under human user
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-18 22:15
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-468 at `04589d6`
+**Mode**: pre-push
+**Depth**: Standard (reason: 12 files, governance + hook + CI surface, identity-enforcement security-relevance)
+**Must-fix**: 0 | **Suggestions**: 3
+
+### Findings
+- [ ] (suggestion) Coauthor semantics stricter than #468's primary-author failure mode — inspect `authors[0]` only or document intent — `.agent/hooks/check_pr_authors.py:97-105`
+- [ ] (suggestion) Test gap: canonical `git -c user.email=…` + `GIT_CONFIG_PARAMETERS` propagation flow not pinned by regression test — `.agent/scripts/test_check_commit_identity.sh`
+- [ ] (suggestion) `pr_number` arg unvalidated; add `.isdigit()` check + clearer usage error — `.agent/hooks/check_pr_authors.py:64`
+
+### Dogfooding verification
+All 5 commits on this branch authored as `Claude Code Agent <roland+claude-code@ccom.unh.edu>` (the agent pattern). The CI check this PR introduces accepts its own branch; if a commit were accidentally human-authored, this PR would self-reject — the exact dogfooding outcome the plan promised.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,6 +52,22 @@ Replace `<your model>` with your actual runtime model (e.g. `Claude Sonnet 4.5`,
 Verify with `echo "$AGENT_MODEL"` — it should echo exactly what you passed. Do not edit
 `framework_config.sh` to match your model; the entries there are fallback-only.
 
+**Commit pattern**: sourcing `set_git_identity_env.sh` exports the env
+vars for this shell, but Copilot CLI typically runs each bash command
+in a fresh subshell — the exports don't reach a separate `git commit`
+invocation later. Use per-commit `-c` overrides instead:
+
+```bash
+git -c user.name="$AGENT_NAME" \
+    -c user.email="$AGENT_EMAIL" \
+    commit -m "…"
+```
+
+This is enforced on `feature/issue-<N>` / `feature/ISSUE-<N>-<desc>` /
+`skill/*` branches by `.agent/hooks/check-commit-identity.py` (pre-commit)
+and `.agent/hooks/check_pr_authors.py` (CI). See AGENTS.md "Agent
+Commit Identity" for the full rationale.
+
 ## Copilot-Specific Notes
 
 - **Native GitHub access**: Use `gh` CLI for fast PR/issue operations.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,3 +48,22 @@ jobs:
           use-quiet-mode: 'yes'
           config-file: '.github/markdown-link-check.json'
         continue-on-error: true
+
+  validate-commit-identity:
+    name: Validate commit identity (Mechanism C)
+    runs-on: ubuntu-latest
+    # Only run on PRs — there's no PR number to check against on bare pushes.
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Validate PR commit authors against agent-branch convention
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 .agent/hooks/check_pr_authors.py "${{ github.event.pull_request.number }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,41 @@ AI signature, pre-commit hooks) still apply.
 Use your actual runtime identity — never copy example model names from docs.
 Check `$AGENT_NAME` / `$AGENT_MODEL` environment variables.
 
+## Agent Commit Identity
+
+For commits on agent-convention branches (`feature/issue-<N>`,
+`feature/ISSUE-<N>-<desc>`, `skill/<name>-<timestamp>`), the canonical
+pattern is per-invocation `-c` overrides:
+
+```bash
+git -c user.name="$AGENT_NAME" \
+    -c user.email="$AGENT_EMAIL" \
+    commit -m "…"
+```
+
+**Why per-commit `-c`, not the env-var script alone**: agent tool runtimes
+(Claude Code, Copilot CLI, etc.) typically run each bash invocation in a
+fresh subshell. `set_git_identity_env.sh`'s exports
+(`GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`) are bound to the shell that sourced
+the script — they don't propagate to a separate `git commit` subshell run
+later. The `-c` flags travel with the command and propagate to git's
+subprocesses (including pre-commit hooks) via `GIT_CONFIG_PARAMETERS`,
+so the identity is robust regardless of which subshell does the commit.
+
+`set_git_identity_env.sh` is still useful — it exports `$AGENT_NAME`,
+`$AGENT_EMAIL`, `$AGENT_MODEL`, `$AGENT_FRAMEWORK` for `gh` signatures
+and as values for the `-c` flags above. Source it once at session start
+and the env vars feed every commit.
+
+**Enforcement**: `.agent/hooks/check-commit-identity.py` (pre-commit)
+rejects human-pattern emails on agent-convention branches when
+`$AGENT_NAME` is set. A CI check
+(`.agent/hooks/check_pr_authors.py`, run from `validate.yml`) catches
+the same condition on PRs and is the load-bearing defense when the
+hook's env-var gate is bypassed (e.g., `$AGENT_NAME` lost across
+subshells). The shared patterns and branch regex live in
+`.agent/hooks/identity_patterns.py`.
+
 ## GitHub CLI Patterns
 
 ### Use `--body-file`, Not `--body`
@@ -400,6 +435,9 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/validate_workspace.py` | Validate repos match .repos config |
 | `.agent/scripts/detect_agent_identity.sh` | Auto-detect agent framework + model |
 | `.agent/scripts/fetch_pr_reviews.sh` | Fetch all PR reviews and CI status |
+| `.agent/scripts/test_check_commit_identity.sh` | Regression test for `check-commit-identity.py` branch+env gate |
+| `.agent/hooks/identity_patterns.py` | Shared agent/human email patterns + agent-branch regex (imported by commit-identity hooks + CI script) |
+| `.agent/hooks/check_pr_authors.py` | CI-callable PR-commit author validator (Mechanism C from issue #468) |
 
 ## Layered Architecture
 


### PR DESCRIPTION
Closes #468

# Plan: Sub-agent commits drop agent git identity

## Issue

https://github.com/rolker/ros2_agent_workspace/issues/468

## Context

Sub-agent commits in this workspace can land with the human user's git
identity (`Roland Arsenault <roland@ccom.unh.edu>`) instead of the agent
identity (`Claude Code Agent <roland+claude-code@ccom.unh.edu>`).
Worked example: 4 of 6 commits on PR #464's branch before rebase.

Root cause: Bash tool calls don't persist shell state between
invocations. Sourcing `set_git_identity_env.sh` in one call exports
env vars that the next subshell doesn't see, so `git commit` falls back
to `.git/config`'s `user.email` (the human pattern).

The existing `.agent/hooks/check-commit-identity.py` pre-commit hook
*does* run on every commit, but its `ACCEPTED_PATTERNS` includes the
human emails alongside agent emails — so it passes the wrong-author
commits silently. Surfaced by the review-issue comment on #468.

User chose to bundle three mitigations into one PR (acceptance criteria
A + B + C below). Belt-and-suspenders from the start.

## Approach

1. **Mechanism A — tighten `.agent/hooks/check-commit-identity.py`
   to be branch-and-env aware.** When `$AGENT_NAME` is set AND the
   current branch matches the agent-branch convention (defined in
   shared module; see step 1a), require an agent-pattern email
   (`roland+*@ccom.unh.edu`) and reject the human patterns. Otherwise
   preserve current permissive behavior so the human can edit
   interactively and field-mode hotfixes still work. Branch detection
   uses `git symbolic-ref --short HEAD` (fail-safe to permissive on
   detached HEAD).

   **Honest acknowledgement**: Mechanism A is bypassed by the same
   root cause #468 describes — an unset `$AGENT_NAME` in a subshell
   silently triggers permissive mode. The hook helps when agents
   *do* set the env var; it can't defend against agents that don't.
   Mechanism C is therefore **load-bearing**, not optional
   belt-and-suspenders — it's the only layer immune to the
   subshell-env-var failure mode.

1a. **Extract shared identity patterns and agent-branch regex to a new
    module** `.agent/hooks/identity_patterns.py`. Both Mechanism A's
    hook and Mechanism C's CI script (and the existing
    `verify-issue-branch.py`) consume it. Contents:
    - `ACCEPTED_AGENT_PATTERNS = ["roland+*@ccom.unh.edu"]`
    - `HUMAN_PATTERNS = ["roland@ccom.unh.edu", "roland@rolker.net"]`
    - `PERMISSIVE_ACCEPTED_PATTERNS = ACCEPTED_AGENT_PATTERNS + HUMAN_PATTERNS`
    - Agent-branch regex reused from `verify-issue-branch.py:27`:
      `^feature/[iI][sS][sS][uU][eE]-(\d+)`, plus
      `^skill/[^/]+-\d{8}-\d{6}-\d{9}$` for the skill-worktree
      convention from AGENTS.md.
    - `is_agent_branch(name: str) -> bool` helper.
    Single source of truth eliminates DRY drift between A and C.
    `verify-issue-branch.py` refactored to import from this module
    on the same PR to ensure the regex stays consistent.

2. **Mechanism A regression test —**
   `.agent/scripts/test_check_commit_identity.sh` mirroring the
   pattern of the existing `test_identity_introspection.sh`. Covers:
   - Agent branch + `AGENT_NAME` set + human email → hook fails (exit 1)
   - Agent branch + `AGENT_NAME` set + agent email → hook passes (exit 0)
   - Agent branch + `AGENT_NAME` unset → permissive (passes either email)
   - Non-agent branch + `AGENT_NAME` set → permissive (passes either email)
   - Detached HEAD → permissive (no false-positive lockout)
   Hooked into `Makefile` `test` target if there's one for shell tests;
   otherwise standalone-runnable.

3. **Mechanism B — update `AGENTS.md` to recommend the per-commit
   `git -c` pattern.** New short section after "AI Signature" titled
   "Agent Commit Identity", documenting:
   - The canonical pattern:
     `git -c user.name="$AGENT_NAME" -c user.email="$AGENT_EMAIL" commit -m "…"`
   - Rationale: Bash tool calls don't persist shell state across
     invocations; the env-var script remains correct for human use
     and as a fallback, but per-commit `-c` is the robust pattern for
     agents that may commit across multiple Bash calls (which is
     all agents that touch this workspace).
   - Cross-reference to `set_git_identity_env.sh` which still exports
     `$AGENT_NAME` / `$AGENT_EMAIL` for the `-c` flags to reference.

4. **Mechanism B cascade —** verify `$AGENT_EMAIL` is exported by
   `set_git_identity_env.sh` (it is, at line 184 — no edit needed).
   Cascade the new "Agent Commit Identity" section to the three
   framework adapters (`.github/copilot-instructions.md`,
   `.agent/instructions/gemini-cli.instructions.md`,
   `.agent/AGENT_ONBOARDING.md`) per ADR-0006 and the consequences map.
   Also update `.agent/AI_IDENTITY_STRATEGY.md` (the canonical
   multi-framework identity doc — references the env-var pattern and
   should mention the `git -c` pattern alongside).

5. **Mechanism C — CI step.** Add a new CI-callable Python script
   `.agent/hooks/check_pr_authors.py` that takes a PR number, fetches
   commits via `gh api`, and exits non-zero if any commit on an
   agent-convention branch (per `identity_patterns.is_agent_branch`)
   has an author email matching `HUMAN_PATTERNS`. The script imports
   from `identity_patterns.py` so A and C share the source of truth.
   Then add a new `validate-commit-identity` job to
   `.github/workflows/validate.yml` that invokes the script on
   `pull_request` events. Independent of `$AGENT_NAME` env-var context
   (CI runners don't have it) — operates on git author email alone.

6. **Self-test on the fix-pass commit.** Before merging this PR, run
   the regression test script + verify CI's new step catches a
   deliberately-mis-authored commit if pushed. Document in
   `progress.md` as Local Review entry.

## Files to Change

| File | Change |
|------|--------|
| `.agent/hooks/identity_patterns.py` | **NEW** shared module: `ACCEPTED_AGENT_PATTERNS`, `HUMAN_PATTERNS`, `PERMISSIVE_ACCEPTED_PATTERNS`, agent-branch regex (`feature/[iI][sS][sS][uU][eE]-N` + `skill/<name>-<timestamp>`), `is_agent_branch(name)` helper. Single source of truth for A and C. |
| `.agent/hooks/check-commit-identity.py` | Import from `identity_patterns`. Add branch-detection (`git symbolic-ref --short HEAD`) + `$AGENT_NAME` check. When both gates fire, restrict to `ACCEPTED_AGENT_PATTERNS`; otherwise use `PERMISSIVE_ACCEPTED_PATTERNS` (current behavior). |
| `.agent/hooks/verify-issue-branch.py` | Refactor to import the feature/issue regex from `identity_patterns` (same source of truth). Behavior preserved. |
| `.agent/hooks/check_pr_authors.py` | **NEW** CI-callable script. Takes a PR number, fetches commits via `gh api`, fails if any commit on an agent-convention branch has an author email matching `HUMAN_PATTERNS`. Uses `identity_patterns`. |
| `.agent/scripts/test_check_commit_identity.sh` | **NEW**. Five-case regression test (agent-branch × agent-env matrix + detached HEAD). |
| `.agent/scripts/set_git_identity_env.sh` | No change — `$AGENT_EMAIL` already exported at line 184. (Verified before plan-edit, not a TODO.) |
| `AGENTS.md` | New "Agent Commit Identity" subsection after "AI Signature" documenting the `git -c` pattern + Bash-tool-state rationale. Add `check_pr_authors.py`, `identity_patterns.py`, and `test_check_commit_identity.sh` to the Script Reference table. |
| `.agent/AI_IDENTITY_STRATEGY.md` | Add a section noting the `git -c` per-commit pattern alongside the existing env-var setup. Cross-reference AGENTS.md. |
| `.github/copilot-instructions.md` | Mirror new section. Per ADR-0006. |
| `.agent/instructions/gemini-cli.instructions.md` | Mirror new section. Per ADR-0006. |
| `.agent/AGENT_ONBOARDING.md` | Mirror new section. Per ADR-0006. |
| `.github/workflows/validate.yml` | New `validate-commit-identity` job: on `pull_request`, invokes `check_pr_authors.py` against the PR. |
| `Makefile` | Verify `make test` / `make lint` runs the new shell test (or add explicit target). Confirm during implementation. |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Human control and transparency | Hook fails loudly with actionable message ("commit author X on agent branch — set `$AGENT_NAME` correctly or use `git -c user.email=...`"). CI failure is visible on PR. |
| **Enforcement over documentation** | Core principle this issue addresses. AGENTS.md AI-signature rule is currently doc-only; Mechanisms A + C enforce it at two layers per ADR-0004. |
| Only what's needed | Tighten existing hook rather than build new one. Single CI job, not a separate workflow file. No new env-var script. |
| A change includes its consequences | AGENTS.md edit cascades to 3 framework adapters (per consequences map). Regression test added in same PR. Sub-agent dispatch prompts in skill bodies (plan-task SKILL.md, review-code SKILL.md) noted as informational — agents read these but they're prose, not configuration; no separate file to update. |
| Test what breaks | Five-case regression test covers the dual-gate semantics. The hook can no longer fail-open silently the way it did on PR #464. |
| Workspace vs project separation | Workspace-level enforcement; project repos can opt-in by adding the same hook. |
| Primary framework first, portability where free | Hook is framework-agnostic Python. CI is generic GitHub Actions. AGENTS.md cascade preserves framework-agnostic guidance. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0004 — Enforcement hierarchy | Yes | Three layers: instructions (B) + pre-commit hook (A) + CI (C). Matches the ADR's "no single layer is sufficient." |
| 0005 — Layered enforcement | Yes | CI/branch protection is authoritative (Mechanism C); pre-commit provides local feedback (Mechanism A); instructions express intent (Mechanism B). |
| 0006 — Shared AGENTS.md | Yes | AGENTS.md is the source of truth; three framework adapters mirror per the consequences map. |
| 0011 — Field mode | Yes | The dual gate (`$AGENT_NAME` set AND agent-branch name) preserves field-mode hotfix workflow on the default branch — those commits won't trigger the strict path. |
| 0002 — Worktree isolation | Yes | Plan + implementation land on `feature/issue-468` workspace worktree. |
| 0003 — Workspace infra is project-agnostic | Yes | Hook, test, workflow, and instructions are generic. |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| `check-commit-identity.py` | `.agent/hooks/README.md` (if it documents accepted patterns) | Verify during implementation; doc fix folds into the hook commit if needed |
| `AGENTS.md` (new section) | `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md`, `.agent/AI_IDENTITY_STRATEGY.md` | Yes — all four listed in Files to Change |
| `AGENTS.md` Script Reference table | New scripts added there (`check_pr_authors.py`, `identity_patterns.py`, `test_check_commit_identity.sh`) | Yes — included in the AGENTS.md row above |
| New shell test (`test_check_commit_identity.sh`) | `Makefile` — verify it's picked up by `make test` / `make lint` | Yes — Makefile in Files to Change with verify-during-implementation note |
| `.github/workflows/validate.yml` (new job) | Branch protection rules — if the new check should be required to merge, update branch protection separately (per AGENTS.md "Ask First") | Flagged as Open Question 1, not in this PR |
| Sub-agent dispatch prompt prose in skill bodies (`plan-task` SKILL.md, `review-code` SKILL.md) | Adopt the `git -c` pattern when documenting commit examples for sub-agents | Yes — verify via workspace grep during implementation |

## Open Questions

1. **Branch protection** — should the new CI check be a *required* status check for merging into `main`, or just informational? If required, that's a separate config change in the repo's GitHub settings (per AGENTS.md "Ask First" — modifying branch protection requires human approval). Flag for the user at PR open time, not now.

**Resolved during plan-revision (2026-05-18, after review-plan pass)**:

- **Hook escape hatch (Q2)**: **No.** A `GIT_IDENTITY_OVERRIDE=1` env-var bypass creates a foot-gun without solving a real workflow problem — a maintainer who needs to commit as themselves on an agent branch can either rebase off the branch, cherry-pick to a non-agent branch, or `unset AGENT_NAME` in the current shell (which already triggers permissive mode). Decision: no escape hatch.

## Estimated Scope

Single PR, ~12 file edits + 3 new files (`identity_patterns.py`,
`check_pr_authors.py`, `test_check_commit_identity.sh`). Atomic
commits suggested grouping:

1. Shared module + hook tighten + regression test (new
   `identity_patterns.py`, modified `check-commit-identity.py`,
   refactored `verify-issue-branch.py`, new
   `test_check_commit_identity.sh`, Makefile if needed)
2. AGENTS.md "Agent Commit Identity" section + 4-doc cascade
   (3 framework adapters + `AI_IDENTITY_STRATEGY.md`) +
   AGENTS.md Script Reference table updates
3. CI: new `check_pr_authors.py` + new `validate-commit-identity`
   job in `validate.yml`

Three commits, each independently revertable.

## Implementation Notes

- **Shared `identity_patterns.py` module (Step 1a)** — added after the
  review-plan pass surfaced a DRY concern: the human-email pattern
  list would otherwise be hard-coded in both `check-commit-identity.py`
  (Mechanism A) and `check_pr_authors.py` (Mechanism C), and future
  updates would silently desync. The shared module also absorbs the
  agent-branch regex (`^feature/[iI][sS][sS][uU][eE]-(\d+)` from
  `verify-issue-branch.py` plus the skill-worktree pattern from
  AGENTS.md). User explicitly chose "extract to shared config" over
  the alternatives (hard-code-with-comments / defer-to-follow-up).

- **Honest acknowledgement of Mechanism A's bypass surface (Step 1)** —
  the carve-out for permissive mode (`AGENT_NAME` unset → permissive)
  is bypassed by the exact root cause #468 describes. This is not a
  flaw in the plan — it's a fundamental limit of pre-commit hooks that
  read env vars in the commit-time shell. Mechanism C (CI) is the only
  layer immune to this bypass. The rationale shift: C is not optional
  belt-and-suspenders; it's load-bearing for the principal failure
  mode this issue addresses. Plan now states this explicitly.

- **Resolved Open Question 2 (escape hatch)** during plan revision
  rather than deferring to implementation. The plan's own rationale
  already implied "no" — explicit resolution avoids scope churn during
  implementation.
