### PR TITLE
Ignore Claude Code harness lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ COLCON_IGNORE
 # Generated Claude Code skills (regenerate with: make generate-skills)
 .claude/skills/make_*/
 
+# Claude Code harness runtime state (per-session lock files)
+.claude/*.lock
+
 # Agent Scratchpad (Temporary files and artifacts)
 .agent/scratchpad/*
 !.agent/scratchpad/README.md


### PR DESCRIPTION
Closes #463

One-line addition to `.gitignore` covering `.claude/*.lock` — catches Claude Code's harness scheduled-tasks lock file (and any future per-session lock files) so `make sync` stops skipping the workspace repo.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
