### PR TITLE
fix: prepend worktree LD_LIBRARY_PATH so C++ libs aren't shadowed (closes #484)

### DIFF
--- a/.agent/scripts/tests/test_worktree_create.sh
+++ b/.agent/scripts/tests/test_worktree_create.sh
@@ -849,6 +849,8 @@ test_layer_setup_bash_has_path_priority_block() {
         || { echo "    missing core_ws/build reference"; fail=1; }
     grep -Fq "_wt_path_prepend AMENT_PREFIX_PATH" "$wt_setup" \
         || { echo "    AMENT_PREFIX_PATH not routed through idempotency helper"; fail=1; }
+    grep -Fq "_wt_path_prepend LD_LIBRARY_PATH" "$wt_setup" \
+        || { echo "    LD_LIBRARY_PATH not routed through idempotency helper"; fail=1; }
     grep -Fq "_wt_path_prepend PYTHONPATH" "$wt_setup" \
         || { echo "    PYTHONPATH not routed through idempotency helper"; fail=1; }
 
@@ -934,21 +936,35 @@ test_layer_setup_bash_idempotent_resourcing() {
         set -u
         WORKTREE_DIR='$wt_dir'
         AMENT_PREFIX_PATH=''
+        LD_LIBRARY_PATH=''
         PYTHONPATH=''
         source '$block_file'
         source '$block_file'
         echo \"AMENT_PREFIX_PATH=\$AMENT_PREFIX_PATH\"
+        echo \"LD_LIBRARY_PATH=\$LD_LIBRARY_PATH\"
         echo \"PYTHONPATH=\$PYTHONPATH\"
     " 2>&1)
 
     local fail=0
-    local ament_count py_sp_count py_build_count
-    ament_count=$(echo "$out" | grep '^AMENT_PREFIX_PATH=' | grep -o "install/$pkg" | wc -l)
-    py_sp_count=$(echo "$out"  | grep '^PYTHONPATH='       | grep -o "site-packages" | wc -l)
-    py_build_count=$(echo "$out" | grep '^PYTHONPATH='     | grep -o "build/$pkg" | wc -l)
+    local ament_count ld_lib_count ld_build_count py_sp_count py_build_count
+    ament_count=$(echo "$out"     | grep '^AMENT_PREFIX_PATH=' | grep -o "install/$pkg" | wc -l)
+    ld_lib_count=$(echo "$out"    | grep '^LD_LIBRARY_PATH='   | grep -o "install/$pkg/lib" | wc -l)
+    ld_build_count=$(echo "$out"  | grep '^LD_LIBRARY_PATH='   | grep -o "build/$pkg" | wc -l)
+    py_sp_count=$(echo "$out"     | grep '^PYTHONPATH='        | grep -o "site-packages" | wc -l)
+    py_build_count=$(echo "$out"  | grep '^PYTHONPATH='        | grep -o "build/$pkg" | wc -l)
 
     if [ "$ament_count" -ne 1 ]; then
         echo "    AMENT_PREFIX_PATH grew on re-source (count=$ament_count, expected 1)"
+        echo "    out: $out"
+        fail=1
+    fi
+    if [ "$ld_lib_count" -ne 1 ]; then
+        echo "    LD_LIBRARY_PATH install/lib grew on re-source (count=$ld_lib_count, expected 1)"
+        echo "    out: $out"
+        fail=1
+    fi
+    if [ "$ld_build_count" -ne 1 ]; then
+        echo "    LD_LIBRARY_PATH build dir grew on re-source (count=$ld_build_count, expected 1)"
         echo "    out: $out"
         fail=1
     fi

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -201,6 +201,15 @@ for _wt_pkg_build in "\$WORKTREE_DIR/${target_layer}_ws/build"/*/; do
     if [ -d "\$_wt_pkg_prefix" ]; then
         _wt_path_prepend AMENT_PREFIX_PATH "\$_wt_pkg_prefix"
     fi
+    # LD_LIBRARY_PATH: same shadowing problem for C++ shared libs (#484).
+    # Prepend <install>/lib first, then <build>/<pkg>, so <build>/<pkg> ends
+    # up FIRST on the path — correct for POST_BUILD generators that dlopen
+    # sibling .so before install runs, and harmless under --symlink-install
+    # (the workspace default) where install/lib symlinks back to <build>/<pkg>.
+    if [ -d "\$_wt_pkg_prefix/lib" ]; then
+        _wt_path_prepend LD_LIBRARY_PATH "\$_wt_pkg_prefix/lib"
+    fi
+    _wt_path_prepend LD_LIBRARY_PATH "\${_wt_pkg_build%/}"
     # PYTHONPATH: prepend site-packages and build dir for Python packages
     for _wt_sp in "\$_wt_pkg_prefix"/lib/python3.*/site-packages; do
         [ -d "\$_wt_sp" ] || continue

--- a/.agent/work-plans/issue-484/plan.md
+++ b/.agent/work-plans/issue-484/plan.md
@@ -15,15 +15,19 @@ Scope confirmed via [the review-issue comment](https://github.com/rolker/ros2_ag
 ## Approach
 
 1. **Extend the override block in `worktree_create.sh::generate_worktree_scripts()`** — inside the existing per-package `for _wt_pkg_build in …` loop, after the `AMENT_PREFIX_PATH` branch, add two `_wt_path_prepend LD_LIBRARY_PATH` calls:
-   - `<install>/<pkg>/lib` — covers post-install runtime resolution
-   - `<build>/<pkg>` (the loop variable's directory itself) — covers POST_BUILD generator binaries that dlopen sibling `.so` before install happens
+   - `<install>/<pkg>/lib` (prepended first) — covers post-install runtime resolution
+   - `<build>/<pkg>` (the loop variable's directory; prepended second so it ends up *first* on `LD_LIBRARY_PATH`) — covers POST_BUILD generator binaries that dlopen sibling `.so` before install happens
    Both go through the existing `_wt_path_prepend` helper so they inherit its idempotency guarantee.
+
+   **Ordering rationale (worth a one-line code comment in the heredoc):** `<build>/<pkg>` first is correct for POST_BUILD (the install step hasn't run yet, so `<install>/<pkg>/lib` may be empty or stale). Under `--symlink-install` (the workspace default) `<install>/<pkg>/lib` symlinks back to `<build>/<pkg>` anyway, so order doesn't matter at runtime. Without `--symlink-install`, the `<build>/<pkg>` priority means dev iterations always pick up the freshest build artifact — also the right choice during active development.
 
 2. **Extend test 21 (`test_layer_setup_bash_has_path_priority_block`)** in `test_worktree_create.sh` — add one `grep -Fq "_wt_path_prepend LD_LIBRARY_PATH"` assertion so the symmetry with `AMENT_PREFIX_PATH` / `PYTHONPATH` is enforced going forward.
 
-3. **Extend test 23 (`test_layer_setup_bash_idempotent_resourcing`)** — fabricate a `<build>/<pkg>` and `<install>/<pkg>/lib` pair, source the extracted block twice, and assert `LD_LIBRARY_PATH` contains each entry exactly once. Mirrors the existing `ament_count` / `py_sp_count` / `py_build_count` checks.
+3. **Extend test 23 (`test_layer_setup_bash_idempotent_resourcing`)** — test 23 already fabricates `<install>/<pkg>/lib/python3.99/site-packages`, so `<install>/<pkg>/lib` exists transitively and `<build>/<pkg>` is already created. No new directory fabrication needed — just add `LD_LIBRARY_PATH=''` to the sub-bash env (alongside the existing `AMENT_PREFIX_PATH=''` and `PYTHONPATH=''`), echo `LD_LIBRARY_PATH=$LD_LIBRARY_PATH` in the captured output, and add two assertions matching the existing pattern: `ld_lib_count` (occurrences of `install/$pkg/lib`) and `ld_build_count` (occurrences of `build/$pkg`), each expected to be 1.
 
-4. **Validate against the original repro** — recreate the unh_marine_navigation issue-26 worktree fresh, run `./core_ws/build.sh marine_nav_behavior_tree` without manual `LD_LIBRARY_PATH` munging, confirm POST_BUILD generator succeeds. This is the acceptance gate from the issue.
+4. **Validate against the original repro** — run `./core_ws/build.sh marine_nav_behavior_tree` in a fresh layer worktree on `unh_marine_navigation`, without manual `LD_LIBRARY_PATH` munging, and confirm the POST_BUILD generator succeeds. This is the acceptance gate from the issue.
+
+   **Timing constraint**: the existing `issue-unh_marine_navigation-26` worktree is **active** while PR #27 is in review (round-4 fixes pushed but not merged). Don't `worktree_remove` it to run this validation — that would lose mid-review state. Two options: (a) **defer** the validation to after PR #27 merges, then recreate that worktree from the merged `jazzy` and verify; (b) **use a separate test fixture** — create a throwaway layer worktree on a different C++ package whose main install has the shadow problem, or against a fresh `unh_marine_navigation` issue branch after merge. (a) is preferable — strongest signal, lowest setup cost — and PR #27 is the immediate next thing landing.
 
 5. **Sanity check `WORKTREE_GUIDE.md` and `AGENTS.md`** — both already omit any mention of the path-priority block (verified). No doc updates needed; consistent with how #428 landed.
 
@@ -62,10 +66,11 @@ Scope confirmed via [the review-issue comment](https://github.com/rolker/ros2_ag
 | `worktree_create.sh` | `AGENTS.md` worktree section | Not needed — same reason. |
 | `worktree_create.sh::generate_worktree_scripts()` | `test_worktree_create.sh` tests 21 + 23 | Yes — step 2 + step 3 |
 | Generated `setup.bash` format | Existing worktrees don't auto-update | Document in PR description; manual workaround (prepend `LD_LIBRARY_PATH` before `colcon build`) still works for the interim |
+| `worktree_create.sh` | `Makefile` if it has a target (per consequences map) | Verified: `grep -F worktree_create Makefile` returns nothing — `worktree_create.sh` is not a Make target. No update needed. |
 
 ## Open Questions
 
-- None. The scope, mechanism, and tests are all bounded by #428's precedent.
+- **Validation timing vs PR #27**: the cleanest acceptance test is recreating the `issue-unh_marine_navigation-26` worktree post-implementation and running `./core_ws/build.sh marine_nav_behavior_tree` clean. That worktree is currently active with PR #27's round-4 fixes; recreating it now would lose mid-review state. Resolution defaults to step 4(a) (sequence after PR #27 merges) unless a substitute fixture is preferred for faster turnaround.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-484/plan.md
+++ b/.agent/work-plans/issue-484/plan.md
@@ -1,0 +1,72 @@
+# Plan: fix: layer worktree LD_LIBRARY_PATH shadowed by main tree install
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/484
+
+## Context
+
+[#428](https://github.com/rolker/ros2_agent_workspace/pull/428) added a `_wt_path_prepend` block to the generated `setup.bash` that force-prepends the worktree's target-layer paths for `AMENT_PREFIX_PATH` and `PYTHONPATH`. That closed the Python-side variant of the shadow bug.
+
+The C++-side variant survived: `LD_LIBRARY_PATH` isn't in the override block, so the dynamic linker still finds main's stale `<pkg>.so` before the worktree's freshly-built one. This breaks POST_BUILD generator binaries (the dlopen-on-build case that hit [`rolker/unh_marine_navigation#27`](https://github.com/rolker/unh_marine_navigation/pull/27) earlier today) and would also affect `pluginlib` resolution at runtime for any downstream consumer of a worktree-modified `.so`.
+
+Scope confirmed via [the review-issue comment](https://github.com/rolker/ros2_agent_workspace/issues/484#issuecomment-4536226615): only `LD_LIBRARY_PATH` needs to be added. `AMENT_PREFIX_PATH` is already covered by #428 (verified by reading the existing block in a real worktree's `setup.bash`). `CMAKE_PREFIX_PATH` has no concrete repro — defer.
+
+## Approach
+
+1. **Extend the override block in `worktree_create.sh::generate_worktree_scripts()`** — inside the existing per-package `for _wt_pkg_build in …` loop, after the `AMENT_PREFIX_PATH` branch, add two `_wt_path_prepend LD_LIBRARY_PATH` calls:
+   - `<install>/<pkg>/lib` — covers post-install runtime resolution
+   - `<build>/<pkg>` (the loop variable's directory itself) — covers POST_BUILD generator binaries that dlopen sibling `.so` before install happens
+   Both go through the existing `_wt_path_prepend` helper so they inherit its idempotency guarantee.
+
+2. **Extend test 21 (`test_layer_setup_bash_has_path_priority_block`)** in `test_worktree_create.sh` — add one `grep -Fq "_wt_path_prepend LD_LIBRARY_PATH"` assertion so the symmetry with `AMENT_PREFIX_PATH` / `PYTHONPATH` is enforced going forward.
+
+3. **Extend test 23 (`test_layer_setup_bash_idempotent_resourcing`)** — fabricate a `<build>/<pkg>` and `<install>/<pkg>/lib` pair, source the extracted block twice, and assert `LD_LIBRARY_PATH` contains each entry exactly once. Mirrors the existing `ament_count` / `py_sp_count` / `py_build_count` checks.
+
+4. **Validate against the original repro** — recreate the unh_marine_navigation issue-26 worktree fresh, run `./core_ws/build.sh marine_nav_behavior_tree` without manual `LD_LIBRARY_PATH` munging, confirm POST_BUILD generator succeeds. This is the acceptance gate from the issue.
+
+5. **Sanity check `WORKTREE_GUIDE.md` and `AGENTS.md`** — both already omit any mention of the path-priority block (verified). No doc updates needed; consistent with how #428 landed.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/worktree_create.sh` | In the `# 5. Prioritize worktree target layer…` heredoc, add `LD_LIBRARY_PATH` prepends inside the per-package loop (~5 lines: empty check for `<install>/lib`, two `_wt_path_prepend` calls, brief comment) |
+| `.agent/scripts/tests/test_worktree_create.sh` | Extend test 21 with one `grep -Fq "_wt_path_prepend LD_LIBRARY_PATH"` assertion. Extend test 23: pre-create `<install>/<pkg>/lib`, set `LD_LIBRARY_PATH=''` in the sub-bash, capture/check `ld_count` for both `lib` and `build/<pkg>` entries |
+| `.agent/work-plans/issue-484/plan.md` | This plan |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Enforcement over documentation | Fix is automatic in generated `setup.bash` — no manual workaround. Mirrors #428's mechanism exactly. |
+| A change includes its consequences | Test parity covered (assertion + idempotency). No doc updates needed (#428 didn't update WORKTREE_GUIDE.md or AGENTS.md either; the override block is internal mechanism, not user-facing API). Existing worktrees won't auto-update — will note in PR description that users with active C++ worktrees should recreate (`worktree_remove` + `worktree_create`). |
+| Only what's needed | Two lines of generator code + assertion parity. Resisted the issue's "while we're in there, check AMENT_PREFIX_PATH and CMAKE_PREFIX_PATH" — `AMENT_PREFIX_PATH` is already handled by #428; `CMAKE_PREFIX_PATH` has no concrete repro. |
+| Improve incrementally | Small additive change on top of existing block; no refactor. |
+| Test what breaks | Two test extensions: (a) assertion that the env var is wired through the helper, (b) functional idempotency. Real-world acceptance test is the unh_marine_navigation#27 reproducer. |
+| Workspace improvements cascade to projects | All future layer worktrees benefit automatically on next `worktree_create`. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0002 (worktree isolation) | Yes | This fix is exactly what isolation means in practice — the worktree's freshly built `.so` should win over the main tree's stale install. Strengthens the principle. |
+| ADR-0004 (enforcement hierarchy) | Yes | Fix is at the generated-`setup.bash` layer (same as #428); the regression tests in `test_worktree_create.sh` are the load-bearing defense. No CI gate beyond the existing test runner needed. |
+| ADR-0008 (ROS 2 conventions) | No | Works *with* colcon's `LD_LIBRARY_PATH` ordering, not against it. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `worktree_create.sh` | `.agent/WORKTREE_GUIDE.md` per the consequences map | Not needed — the path-priority block isn't documented there (verified); #428 didn't add it either. Including for consistency would be over-scoping. |
+| `worktree_create.sh` | `AGENTS.md` worktree section | Not needed — same reason. |
+| `worktree_create.sh::generate_worktree_scripts()` | `test_worktree_create.sh` tests 21 + 23 | Yes — step 2 + step 3 |
+| Generated `setup.bash` format | Existing worktrees don't auto-update | Document in PR description; manual workaround (prepend `LD_LIBRARY_PATH` before `colcon build`) still works for the interim |
+
+## Open Questions
+
+- None. The scope, mechanism, and tests are all bounded by #428's precedent.
+
+## Estimated Scope
+
+Single PR. ~10–15 lines of generator code + ~10 lines of test extensions. No design decisions remain; this is a mechanical mirror of #428 for the C++ env var.

--- a/.agent/work-plans/issue-484/progress.md
+++ b/.agent/work-plans/issue-484/progress.md
@@ -15,3 +15,19 @@ issue: 484
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-05-25 15:20 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context)) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-484/plan.md` at `ddbef78`
+**PR**: https://github.com/rolker/ros2_agent_workspace/pull/487
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (must-fix) Acceptance-gate timing collides with active unh_marine_navigation#26 worktree — defer validation to post-PR-#27 merge, or rephrase gate to "any C++ worktree with new symbols" — `plan.md:26`
+- [ ] (suggestion) Makefile sanity-check row missing from consequences table — confirm `grep -F worktree_create Makefile` shows no target — `plan.md:57-64`
+- [ ] (suggestion) Prepend ordering rationale (`<build>/<pkg>` first vs `<install>/<pkg>/lib`) should be noted in plan step 1 so the explanatory comment lands at implementation time — `plan.md:17-20`
+- [ ] (suggestion) "Open Questions: None" contradicts must-fix finding above — update to capture the acceptance-gate timing question — `plan.md:66-68`
+- [ ] (suggestion) Test 23 extension underspecified — note that python3.99/site-packages fabrication already exists; new step is just counting `lib` and `build/<pkg>` occurrences in `$LD_LIBRARY_PATH` — `plan.md:24, 35`

--- a/.agent/work-plans/issue-484/progress.md
+++ b/.agent/work-plans/issue-484/progress.md
@@ -31,3 +31,17 @@ issue: 484
 - [ ] (suggestion) Prepend ordering rationale (`<build>/<pkg>` first vs `<install>/<pkg>/lib`) should be noted in plan step 1 so the explanatory comment lands at implementation time — `plan.md:17-20`
 - [ ] (suggestion) "Open Questions: None" contradicts must-fix finding above — update to capture the acceptance-gate timing question — `plan.md:66-68`
 - [ ] (suggestion) Test 23 extension underspecified — note that python3.99/site-packages fabrication already exists; new step is just counting `lib` and `build/<pkg>` occurrences in `$LD_LIBRARY_PATH` — `plan.md:24, 35`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-25 16:30 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved
+
+**Branch**: `feature/issue-484` at `10f7be2`
+**Mode**: pre-push
+**Depth**: Light (reason: <50 code lines, ≤3 code files, no override-trigger files)
+**Must-fix**: 0 | **Suggestions**: 0
+
+### Findings
+- [ ] No issues found. LGTM. (Copilot Adversarial surfaced 2 candidate findings — both verified as false positives: asymmetric guarding matches the sibling AMENT/PYTHONPATH pattern; `$pkg` is defined at test_worktree_create.sh:924 within the same function scope.)

--- a/.agent/work-plans/issue-484/progress.md
+++ b/.agent/work-plans/issue-484/progress.md
@@ -1,0 +1,17 @@
+---
+issue: 484
+---
+
+# Issue #484 — fix: layer worktree LD_LIBRARY_PATH shadowed by main tree install (C++ analog of #427)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-05-25 14:50 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Plan**: `.agent/work-plans/issue-484/plan.md` at `ddbef78`
+**PR**: https://github.com/rolker/ros2_agent_workspace/pull/487 (`[PLAN]` prefix)
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-484/progress.md
+++ b/.agent/work-plans/issue-484/progress.md
@@ -45,3 +45,16 @@ issue: 484
 
 ### Findings
 - [ ] No issues found. LGTM. (Copilot Adversarial surfaced 2 candidate findings — both verified as false positives: asymmetric guarding matches the sibling AMENT/PYTHONPATH pattern; `$pkg` is defined at test_worktree_create.sh:924 within the same function scope.)
+
+## External Review
+**Status**: complete
+**When**: 2026-05-25 16:55 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #487 at `648da0c`
+**Reviews**: 8 inline comments across 3 Copilot rounds; 1 valid, 2 addressed, 5 false positives
+**CI**: all-pass (copilot-pull-request-reviewer, Validate Documentation, Validate commit identity, Lint)
+
+### Actions
+- [ ] Mark the addressed findings in this file's `## Plan Review` entry (lines 28-33) as `[x]` to resolve the verdict-vs-findings ambiguity Copilot flagged: verdict says "approve-with-suggestions" but the must-fix item is now resolved by plan inline edit `5e1b628`. Updates the checkbox status without rewriting the historical verdict (Copilot R2 #4).
+- [ ] (FP note) Copilot flagged "double-leading pipe `||`" in plan.md tables 5 times across R1+R2. Verified false positive — `grep '\|\|' plan.md` returns zero matches; every row uses single `|`. Render misread on Copilot's side, no edit needed.


### PR DESCRIPTION
Closes #484

# Plan: fix: layer worktree LD_LIBRARY_PATH shadowed by main tree install

## Issue

https://github.com/rolker/ros2_agent_workspace/issues/484

## Context

[#428](https://github.com/rolker/ros2_agent_workspace/pull/428) added a `_wt_path_prepend` block to the generated `setup.bash` that force-prepends the worktree's target-layer paths for `AMENT_PREFIX_PATH` and `PYTHONPATH`. That closed the Python-side variant of the shadow bug.

The C++-side variant survived: `LD_LIBRARY_PATH` isn't in the override block, so the dynamic linker still finds main's stale `<pkg>.so` before the worktree's freshly-built one. This breaks POST_BUILD generator binaries (the dlopen-on-build case that hit [`rolker/unh_marine_navigation#27`](https://github.com/rolker/unh_marine_navigation/pull/27) earlier today) and would also affect `pluginlib` resolution at runtime for any downstream consumer of a worktree-modified `.so`.

Scope confirmed via [the review-issue comment](https://github.com/rolker/ros2_agent_workspace/issues/484#issuecomment-4536226615): only `LD_LIBRARY_PATH` needs to be added. `AMENT_PREFIX_PATH` is already covered by #428 (verified by reading the existing block in a real worktree's `setup.bash`). `CMAKE_PREFIX_PATH` has no concrete repro — defer.

## Approach

1. **Extend the override block in `worktree_create.sh::generate_worktree_scripts()`** — inside the existing per-package `for _wt_pkg_build in …` loop, after the `AMENT_PREFIX_PATH` branch, add two `_wt_path_prepend LD_LIBRARY_PATH` calls:
   - `<install>/<pkg>/lib` (prepended first) — covers post-install runtime resolution
   - `<build>/<pkg>` (the loop variable's directory; prepended second so it ends up *first* on `LD_LIBRARY_PATH`) — covers POST_BUILD generator binaries that dlopen sibling `.so` before install happens
   Both go through the existing `_wt_path_prepend` helper so they inherit its idempotency guarantee.

   **Ordering rationale (worth a one-line code comment in the heredoc):** `<build>/<pkg>` first is correct for POST_BUILD (the install step hasn't run yet, so `<install>/<pkg>/lib` may be empty or stale). Under `--symlink-install` (the workspace default) `<install>/<pkg>/lib` symlinks back to `<build>/<pkg>` anyway, so order doesn't matter at runtime. Without `--symlink-install`, the `<build>/<pkg>` priority means dev iterations always pick up the freshest build artifact — also the right choice during active development.

2. **Extend test 21 (`test_layer_setup_bash_has_path_priority_block`)** in `test_worktree_create.sh` — add one `grep -Fq "_wt_path_prepend LD_LIBRARY_PATH"` assertion so the symmetry with `AMENT_PREFIX_PATH` / `PYTHONPATH` is enforced going forward.

3. **Extend test 23 (`test_layer_setup_bash_idempotent_resourcing`)** — test 23 already fabricates `<install>/<pkg>/lib/python3.99/site-packages`, so `<install>/<pkg>/lib` exists transitively and `<build>/<pkg>` is already created. No new directory fabrication needed — just add `LD_LIBRARY_PATH=''` to the sub-bash env (alongside the existing `AMENT_PREFIX_PATH=''` and `PYTHONPATH=''`), echo `LD_LIBRARY_PATH=$LD_LIBRARY_PATH` in the captured output, and add two assertions matching the existing pattern: `ld_lib_count` (occurrences of `install/$pkg/lib`) and `ld_build_count` (occurrences of `build/$pkg`), each expected to be 1.

4. **Validate against the original repro** — run `./core_ws/build.sh marine_nav_behavior_tree` in a fresh layer worktree on `unh_marine_navigation`, without manual `LD_LIBRARY_PATH` munging, and confirm the POST_BUILD generator succeeds. This is the acceptance gate from the issue.

   **Timing constraint**: the existing `issue-unh_marine_navigation-26` worktree is **active** while PR #27 is in review (round-4 fixes pushed but not merged). Don't `worktree_remove` it to run this validation — that would lose mid-review state. Two options: (a) **defer** the validation to after PR #27 merges, then recreate that worktree from the merged `jazzy` and verify; (b) **use a separate test fixture** — create a throwaway layer worktree on a different C++ package whose main install has the shadow problem, or against a fresh `unh_marine_navigation` issue branch after merge. (a) is preferable — strongest signal, lowest setup cost — and PR #27 is the immediate next thing landing.

5. **Sanity check `WORKTREE_GUIDE.md` and `AGENTS.md`** — both already omit any mention of the path-priority block (verified). No doc updates needed; consistent with how #428 landed.

## Files to Change

| File | Change |
|------|--------|
| `.agent/scripts/worktree_create.sh` | In the `# 5. Prioritize worktree target layer…` heredoc, add `LD_LIBRARY_PATH` prepends inside the per-package loop (~5 lines: empty check for `<install>/lib`, two `_wt_path_prepend` calls, brief comment) |
| `.agent/scripts/tests/test_worktree_create.sh` | Extend test 21 with one `grep -Fq "_wt_path_prepend LD_LIBRARY_PATH"` assertion. Extend test 23: pre-create `<install>/<pkg>/lib`, set `LD_LIBRARY_PATH=''` in the sub-bash, capture/check `ld_count` for both `lib` and `build/<pkg>` entries |
| `.agent/work-plans/issue-484/plan.md` | This plan |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Enforcement over documentation | Fix is automatic in generated `setup.bash` — no manual workaround. Mirrors #428's mechanism exactly. |
| A change includes its consequences | Test parity covered (assertion + idempotency). No doc updates needed (#428 didn't update WORKTREE_GUIDE.md or AGENTS.md either; the override block is internal mechanism, not user-facing API). Existing worktrees won't auto-update — will note in PR description that users with active C++ worktrees should recreate (`worktree_remove` + `worktree_create`). |
| Only what's needed | Two lines of generator code + assertion parity. Resisted the issue's "while we're in there, check AMENT_PREFIX_PATH and CMAKE_PREFIX_PATH" — `AMENT_PREFIX_PATH` is already handled by #428; `CMAKE_PREFIX_PATH` has no concrete repro. |
| Improve incrementally | Small additive change on top of existing block; no refactor. |
| Test what breaks | Two test extensions: (a) assertion that the env var is wired through the helper, (b) functional idempotency. Real-world acceptance test is the unh_marine_navigation#27 reproducer. |
| Workspace improvements cascade to projects | All future layer worktrees benefit automatically on next `worktree_create`. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| ADR-0002 (worktree isolation) | Yes | This fix is exactly what isolation means in practice — the worktree's freshly built `.so` should win over the main tree's stale install. Strengthens the principle. |
| ADR-0004 (enforcement hierarchy) | Yes | Fix is at the generated-`setup.bash` layer (same as #428); the regression tests in `test_worktree_create.sh` are the load-bearing defense. No CI gate beyond the existing test runner needed. |
| ADR-0008 (ROS 2 conventions) | No | Works *with* colcon's `LD_LIBRARY_PATH` ordering, not against it. |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| `worktree_create.sh` | `.agent/WORKTREE_GUIDE.md` per the consequences map | Not needed — the path-priority block isn't documented there (verified); #428 didn't add it either. Including for consistency would be over-scoping. |
| `worktree_create.sh` | `AGENTS.md` worktree section | Not needed — same reason. |
| `worktree_create.sh::generate_worktree_scripts()` | `test_worktree_create.sh` tests 21 + 23 | Yes — step 2 + step 3 |
| Generated `setup.bash` format | Existing worktrees don't auto-update | Document in PR description; manual workaround (prepend `LD_LIBRARY_PATH` before `colcon build`) still works for the interim |
| `worktree_create.sh` | `Makefile` if it has a target (per consequences map) | Verified: `grep -F worktree_create Makefile` returns nothing — `worktree_create.sh` is not a Make target. No update needed. |

## Open Questions

- **Validation timing vs PR #27**: the cleanest acceptance test is recreating the `issue-unh_marine_navigation-26` worktree post-implementation and running `./core_ws/build.sh marine_nav_behavior_tree` clean. That worktree is currently active with PR #27's round-4 fixes; recreating it now would lose mid-review state. Resolution defaults to step 4(a) (sequence after PR #27 merges) unless a substitute fixture is preferred for faster turnaround.

## Estimated Scope

Single PR. ~10–15 lines of generator code + ~10 lines of test extensions. No design decisions remain; this is a mechanical mirror of #428 for the C++ env var.
