### PR TITLE
docs(adr): draft ADR-0014 deployment mode (behavioral mode + lifecycle tooling)

### DIFF
--- a/.agent/work-plans/issue-499/progress.md
+++ b/.agent/work-plans/issue-499/progress.md
@@ -1,0 +1,22 @@
+---
+issue: 499
+---
+
+# Issue #499 — Draft ADR-0014: deployment mode (behavioral autonomy mode + lifecycle tooling)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-05-28 09:25 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #500 at `05a4a42`
+**Sources**: 1 (Copilot R2 @ `05a4a42`) — no prior `progress.md`, no human reviews, no conversation comments
+**Cross-source confirmations**: 0
+**CI**: all-pass (Lint, Validate Documentation, commit identity)
+
+### Findings
+- [ ] (must-fix, Copilot R2) PR-body description still references marker-based activation (*"the activation marker + lifecycle skills may land before it's marked Accepted"* and *"activation via an operator-set marker (works dev + field)"*); contradicts the amended ADR (no marker, per-session via `/start-deployment`) — PR body
+- [ ] (suggestion, Copilot R2) `Proposed (Draft)` status line is novel vocabulary; other Proposed ADRs (0005, 0008, 0009) and the template (`adr_template.md:67-69`) use plain `Proposed`. Drop `(Draft)`; trailing sentence already explains in-flight context — `docs/decisions/0014-deployment-mode.md:5`
+
+### False positives
+None.

--- a/.agent/work-plans/issue-499/progress.md
+++ b/.agent/work-plans/issue-499/progress.md
@@ -15,8 +15,24 @@ issue: 499
 **CI**: all-pass (Lint, Validate Documentation, commit identity)
 
 ### Findings
-- [ ] (must-fix, Copilot R2) PR-body description still references marker-based activation (*"the activation marker + lifecycle skills may land before it's marked Accepted"* and *"activation via an operator-set marker (works dev + field)"*); contradicts the amended ADR (no marker, per-session via `/start-deployment`) — PR body
-- [ ] (suggestion, Copilot R2) `Proposed (Draft)` status line is novel vocabulary; other Proposed ADRs (0005, 0008, 0009) and the template (`adr_template.md:67-69`) use plain `Proposed`. Drop `(Draft)`; trailing sentence already explains in-flight context — `docs/decisions/0014-deployment-mode.md:5`
+- [x] (must-fix, Copilot R2) PR-body description still references marker-based activation (*"the activation marker + lifecycle skills may land before it's marked Accepted"* and *"activation via an operator-set marker (works dev + field)"*); contradicts the amended ADR (no marker, per-session via `/start-deployment`) — PR body **(resolved in `90c9287` push — PR body rewritten)**
+- [x] (suggestion, Copilot R2) `Proposed (Draft)` status line is novel vocabulary; other Proposed ADRs (0005, 0008, 0009) and the template (`adr_template.md:67-69`) use plain `Proposed`. Drop `(Draft)`; trailing sentence already explains in-flight context — `docs/decisions/0014-deployment-mode.md:5` **(resolved in `90c9287` — Status is now plain `Proposed`)**
+
+### False positives
+None.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-05-28 09:58 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #500 at `90c9287`
+**Sources**: 2 (Copilot R3 @ `90c9287`, prior Integrated Review @ `05a4a42`)
+**Cross-source confirmations**: 0
+**CI**: all-pass (Lint, Validate Documentation, commit identity)
+
+### Findings
+- [ ] None — Copilot R3 at HEAD returned no comments. Both prior R2 findings resolved by `90c9287`.
 
 ### False positives
 None.

--- a/docs/decisions/0014-deployment-mode.md
+++ b/docs/decisions/0014-deployment-mode.md
@@ -1,0 +1,142 @@
+# ADR-0014: Deployment Mode — An Urgency-Aware Behavioral Mode for Live Field Operations
+
+## Status
+
+Proposed (Draft) — recorded ahead of full implementation so the design has a
+stable reference; some components (activation marker, lifecycle skills) may land
+before this ADR is marked Accepted.
+
+## Context
+
+Field deployments of autonomous robot boats put the agent in a **live-assistant**
+role: troubleshooting, hot-fixes, and situational response while the operator runs
+the boat. On-water operating/testing time is the scarce resource, and the pre-class
+deployment calendar (June 2026 freeze) makes cycle latency the bottleneck.
+
+Two recurring problems motivated this (see [#495](https://github.com/rolker/ros2_agent_workspace/issues/495),
+[#477](https://github.com/rolker/ros2_agent_workspace/issues/477), and the
+`unh_echoboats_project11` deployment logs):
+
+1. **Agents rabbit-hole under time pressure** — deep-diving an investigation or
+   over-polishing setup when the operator needed a fast response, consuming
+   irreplaceable operating time.
+2. **The deployment lifecycle** (start → session → recovery → wrap-up → next) has
+   accumulated as a project-local convention with no workspace tooling.
+
+The workspace already has a precedent for a context-scoped exception to default
+agent behavior: **field mode** ([ADR-0011](0011-field-mode-for-non-github-origins.md)),
+detected by origin URL, relaxing commit/PR ceremony. Deployment mode is a sibling
+on a different axis — not *where commits go*, but *how the agent behaves under live
+time pressure*.
+
+The behavioral half is grounded in established operational practice (incident
+command / SRE, the aviation sterile-cockpit rule, supervisory control / adjustable
+autonomy) — see the workspace research digest entry "Operational-Assistant Behavior
+Under Live Time Pressure."
+
+## Decision
+
+Define **deployment mode**: a behavioral operating mode, active during a live field
+deployment, with two co-equal halves — (1) an **urgency contract** (behavioral
+adjustments) and (2) the **lifecycle tooling** that runs inside it.
+
+### Activation
+
+An **operator-set marker**: a slash command / skill writes a state marker at
+deployment start and clears it at wrap-up. It works identically on dev and field
+hosts (no GitHub dependency — field hosts have no GitHub access). The operator may
+also dial the autonomy level (adjustable autonomy); deployment mode is a setting,
+not a fixed behavior.
+
+### The urgency contract (phase-aware behavioral adjustments)
+
+- **Sterile cockpit** — during live on-water ops, do *only* operation-essential
+  work; no doc polish, refactors, or speculative deep-dives.
+- **Mitigate before diagnose** — stabilize / hot-fix now; defer root-cause analysis
+  to wrap-up.
+- **Confidence-threshold handoff** — below confidence, or outside a known failure
+  class, stop and surface a prepared summary to the operator instead of spiraling;
+  run cheap deterministic checks before expensive investigation.
+- **Phase-aware** — the contract is strongest in live ops and **relaxes in wrap-up**,
+  where deep analysis belongs. Lifecycle: [0] start → [1] session → [2] recovery →
+  [3] wrap-up → [4] next (≈ the SRE Prepare → Detect → Respond → Recover → Learn loop).
+
+### Invariants (what deployment mode does NOT relax)
+
+- **Safety-critical correctness** (boat control, collision avoidance) is never
+  traded for speed.
+- Pre-commit hooks, AI signature, atomic commits, no secrets, no destructive ops
+  without approval — same as field mode.
+- **Defer is not skip** — deferred RCA / tests / docs are *tracked* (follow-up
+  issues, roadmap, wrap-up checklist), not dropped. The Quality Standard's "never
+  table when the permanent solve is near" still holds; deployment mode only defers
+  *within a live session*, and wrap-up is where completeness is restored.
+- **Human control** — the operator is continuously in the loop, so deployment mode
+  *increases* responsiveness precisely because real-time oversight is higher. This
+  is the "tight by default, relaxable as confidence grows" principle, not a
+  weakening of it.
+
+### Content split (per [ADR-0003](0003-workspace-infrastructure-is-project-agnostic.md))
+
+| Tier | Content | Home |
+|---|---|---|
+| Generic | mode concept, urgency contract, lifecycle skeleton, log naming, recovery machinery, activation skill | workspace `.agent/` + skills + this ADR |
+| Project-general (marine) | tides-in-metres, OTH, gitcloud reconciliation, marine nav rates, dev-vs-`hostname` label rule | `unh_marine_autonomy/.agents/workspace-context/` |
+| Platform-specific | host inventory (gabby/salmon/mercat/dora), bag paths, sensor specifics | `unh_echoboats_project11` (README becomes a thin pointer) |
+
+### Deployment identity (multi-platform / multi-day)
+
+A deployment is **one issue**, not bound to a single day or platform. Hosts across
+platforms each keep a per-host log; the filename's date is the deployment **start**
+date; "Hosts active" spans platforms (e.g. dev, salmon, gabby [BizzyBoat], dora
+[IzzyBoat]).
+
+### Modes family (framing, not a framework)
+
+Deployment mode is one of an emerging family of agent operating modes:
+
+| Mode | Trigger | Adjusts |
+|---|---|---|
+| Development (default) | the normal case | full worktree/PR ceremony |
+| Field ([ADR-0011](0011-field-mode-for-non-github-origins.md)) | origin not on GitHub | where commits go |
+| Deployment (this ADR) | operator-set marker | behavior under live time pressure |
+| Device/tmux troubleshooting (informal, [#420](https://github.com/rolker/ros2_agent_workspace/issues/420)) | interactive hardware session | collaboration rules |
+
+They share a structure — **trigger / behavioral adjustments / invariants**. This ADR
+*names* the pattern but does not create a general framework; a unifying "agent
+operating modes" ADR may follow once ≥3 modes are formalized.
+
+## Consequences
+
+**Positive:**
+
+- Directly attacks the rabbit-hole / lost-operating-time failure mode.
+- Reuses the field-mode precedent; composes with existing skills rather than
+  replacing them.
+- Gives the lifecycle tooling a stable behavioral contract to build against.
+- The three-tier split makes the capability adoptable by other marine platforms.
+
+**Negative / risks:**
+
+- A *behavioral* mode is harder to enforce mechanically than field mode (which is
+  origin-detected). It relies on the agent reading the marker and honoring the
+  contract — mitigated by making the marker explicit and surfaced in context, with
+  a possible future hook.
+- "Defer to wrap-up" carries risk if wrap-up is skipped — mitigated by the recovery
+  checklist ([#496](https://github.com/rolker/ros2_agent_workspace/issues/496)) and
+  wrap-up orchestration.
+- Drawing and maintaining the three-tier boundary takes ongoing discipline.
+- The activation marker is one more thing to set/clear — owned by the start/wrap-up
+  skills so the operator isn't doing it by hand.
+
+## References
+
+- [ADR-0011](0011-field-mode-for-non-github-origins.md) — Field Mode (sibling; this
+  ADR follows its trigger/adjustments/invariants shape)
+- [ADR-0003](0003-workspace-infrastructure-is-project-agnostic.md) — Workspace
+  Infrastructure Is Project-Agnostic (the three-tier split)
+- [#495](https://github.com/rolker/ros2_agent_workspace/issues/495) — Deployment-mode
+  umbrella · [#477](https://github.com/rolker/ros2_agent_workspace/issues/477) —
+  logging convention · [#496](https://github.com/rolker/ros2_agent_workspace/issues/496) —
+  recovery checklist
+- Workspace research digest — "Operational-Assistant Behavior Under Live Time Pressure"

--- a/docs/decisions/0014-deployment-mode.md
+++ b/docs/decisions/0014-deployment-mode.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Proposed (Draft) — recorded ahead of full implementation so the design has a
-stable reference; lifecycle skills (`/start-deployment` first, [#501](https://github.com/rolker/ros2_agent_workspace/issues/501))
+Proposed — recorded ahead of full implementation so the design has a stable
+reference; lifecycle skills (`/start-deployment` first, [#501](https://github.com/rolker/ros2_agent_workspace/issues/501))
 may land before this ADR is marked Accepted.
 
 ## Context

--- a/docs/decisions/0014-deployment-mode.md
+++ b/docs/decisions/0014-deployment-mode.md
@@ -3,8 +3,8 @@
 ## Status
 
 Proposed (Draft) — recorded ahead of full implementation so the design has a
-stable reference; some components (activation marker, lifecycle skills) may land
-before this ADR is marked Accepted.
+stable reference; lifecycle skills (`/start-deployment` first, [#501](https://github.com/rolker/ros2_agent_workspace/issues/501))
+may land before this ADR is marked Accepted.
 
 ## Context
 
@@ -42,11 +42,17 @@ adjustments) and (2) the **lifecycle tooling** that runs inside it.
 
 ### Activation
 
-An **operator-set marker**: a slash command / skill writes a state marker at
-deployment start and clears it at wrap-up. It works identically on dev and field
-hosts (no GitHub dependency — field hosts have no GitHub access). The operator may
-also dial the autonomy level (adjustable autonomy); deployment mode is a setting,
-not a fixed behavior.
+**Per-agent-session**: invoking the activation skill (`/start-deployment`,
+[#501](https://github.com/rolker/ros2_agent_workspace/issues/501)) puts the
+current agent session in deployment mode. Other agent sessions on the same host
+doing unrelated work are unaffected. No filesystem marker and no host-wide
+hook — on-disk evidence of an ongoing deployment is what already exists
+naturally: an open `deployment`-labeled issue, plus a worktree (dev side) or a
+host log file (field side). This works identically on dev and field hosts (no
+GitHub dependency — field hosts have no GitHub access, so the field
+`issue_sync` mechanism — e.g. git-bug + a shared field remote — surfaces the
+issue there). The operator may also dial the autonomy level (adjustable
+autonomy); deployment mode is a setting, not a fixed behavior.
 
 ### The urgency contract (phase-aware behavioral adjustments)
 
@@ -99,7 +105,7 @@ Deployment mode is one of an emerging family of agent operating modes:
 |---|---|---|
 | Development (default) | the normal case | full worktree/PR ceremony |
 | Field ([ADR-0011](0011-field-mode-for-non-github-origins.md)) | origin not on GitHub | where commits go |
-| Deployment (this ADR) | operator-set marker | behavior under live time pressure |
+| Deployment (this ADR) | per-session, operator-invoked via `/start-deployment` | behavior under live time pressure |
 | Device/tmux troubleshooting (informal, [#420](https://github.com/rolker/ros2_agent_workspace/issues/420)) | interactive hardware session | collaboration rules |
 
 They share a structure — **trigger / behavioral adjustments / invariants**. This ADR
@@ -119,15 +125,20 @@ operating modes" ADR may follow once ≥3 modes are formalized.
 **Negative / risks:**
 
 - A *behavioral* mode is harder to enforce mechanically than field mode (which is
-  origin-detected). It relies on the agent reading the marker and honoring the
-  contract — mitigated by making the marker explicit and surfaced in context, with
-  a possible future hook.
+  origin-detected). It relies on the operator invoking the activation skill and
+  the agent honoring the embedded urgency contract — mitigated by embedding the
+  contract verbatim in the skill (so invocation puts the rules in context) and
+  by leaving the door open for a future framework-level hook if the
+  skill-invocation channel proves insufficient.
 - "Defer to wrap-up" carries risk if wrap-up is skipped — mitigated by the recovery
   checklist ([#496](https://github.com/rolker/ros2_agent_workspace/issues/496)) and
   wrap-up orchestration.
 - Drawing and maintaining the three-tier boundary takes ongoing discipline.
-- The activation marker is one more thing to set/clear — owned by the start/wrap-up
-  skills so the operator isn't doing it by hand.
+- Per-session activation means a second agent session on the same host won't
+  inherit deployment mode automatically — the operator has to invoke
+  `/start-deployment` in each session that should run under the contract. This
+  is by design (other sessions doing unrelated work shouldn't be constrained),
+  but it does require operator awareness.
 
 ## References
 


### PR DESCRIPTION
## Summary

Draft **ADR-0014** capturing the deployment-mode design decisions from the design discussion (umbrella [#495](https://github.com/rolker/ros2_agent_workspace/issues/495)). Status is **Proposed** — recorded ahead of full implementation so the design has a stable reference; lifecycle skills (`/start-deployment` first, [#501](https://github.com/rolker/ros2_agent_workspace/issues/501)) may land before it's marked Accepted.

Defines **deployment mode** as two co-equal halves:

1. a phase-aware **behavioral autonomy mode** — the urgency contract (sterile cockpit, mitigate-before-diagnose, confidence-threshold handoff, human-on-the-loop, adjustable autonomy), a sibling to field mode ([ADR-0011](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0011-field-mode-for-non-github-origins.md))
2. the **lifecycle tooling** that runs inside it

Plus: **per-agent-session activation** via invoking the `/start-deployment` skill (no filesystem marker, no host-wide hook — on-disk evidence of an ongoing deployment is the existing `deployment`-labeled issue plus the worktree or per-host log; works identically dev + field because field-side issue surfacing goes through the project's `issue_sync` mechanism), the **three-tier content split** ([ADR-0003](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0003-workspace-infrastructure-is-project-agnostic.md): workspace / `unh_marine_autonomy` / `unh_echoboats_project11`), **one-issue multi-platform/multi-day** deployment identity, and a **modes-family framing** (dev / field / deployment / tmux) that names the pattern without building a general framework yet.

Grounded in the research digest entry merged in [#498](https://github.com/rolker/ros2_agent_workspace/pull/498).

Opened as **draft** for design review — the ADR stays at Proposed and moves to Accepted once the design settles / first components land.

Closes #499. Part of #495.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
