### PR TITLE
[PLAN] v1 /start-deployment skill + activation marker (deployment-mode gap 1)

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -91,7 +91,8 @@ Available workflow skills: `review-issue`, `plan-task`, `review-plan`,
 `review-code`, `brainstorm`, `research`, `audit-workspace`, `audit-project`,
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
 `triage-reviews`, `skill-importer`, `document-package`, `issue-triage`,
-`test-engineering`, `inspiration-tracker`, `import-field-changes`.
+`test-engineering`, `inspiration-tracker`, `import-field-changes`,
+`start-deployment`.
 
 ## References
 

--- a/.agent/instructions/gemini-cli.instructions.md
+++ b/.agent/instructions/gemini-cli.instructions.md
@@ -64,7 +64,8 @@ Available workflow skills: `review-issue`, `plan-task`, `review-plan`,
 `review-code`, `brainstorm`, `research`, `audit-workspace`, `audit-project`,
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
 `triage-reviews`, `skill-importer`, `document-package`, `issue-triage`,
-`test-engineering`, `inspiration-tracker`, `import-field-changes`.
+`test-engineering`, `inspiration-tracker`, `import-field-changes`,
+`start-deployment`.
 
 ## References
 

--- a/.agent/knowledge/deployment_mode.md
+++ b/.agent/knowledge/deployment_mode.md
@@ -261,8 +261,7 @@ issue_sync:
 
 # Default data sources for pre-flight (all optional; dev-only).
 tides:
-  station: <NOAA station ID>
-  units: metres                   # always metres for tides
+  station: <NOAA station ID>      # heights always reported in metres
 currents:
   station: <NOAA station ID>      # e.g. "ACT0731" for Clark Island
 weather:

--- a/.agent/knowledge/deployment_mode.md
+++ b/.agent/knowledge/deployment_mode.md
@@ -249,9 +249,13 @@ hosts:
   field: <list of field hostnames>  # informational; field_mode.sh is authoritative
 
 # Pluggable issue-sync mechanism (no git-bug-shaped default — see ADR-0003).
-# If issue_sync is absent, the skill skips the sync step and notes
-# "no issue_sync configured" so the operator can ensure all hosts see
-# the deployment issue by other means.
+# - Dev side: issue_sync is fully optional (gh handles discovery, listing,
+#   editing). If absent, the skill skips dev_push and continues.
+# - Field side: field_pull, field_list_open, and field_show are
+#   HARD-REQUIRED — without them the skill has no way to discover or
+#   read deployment issues on field hosts (no gh fallback). If any of
+#   the three is missing on field side, the skill stops with an explicit
+#   error directing the operator to configure them.
 issue_sync:
   field_pull: <command>           # field: refresh issues from share
   field_list_open: <command>      # field: list open deployment issues

--- a/.agent/knowledge/deployment_mode.md
+++ b/.agent/knowledge/deployment_mode.md
@@ -1,0 +1,311 @@
+# Deployment Mode — Operational Reference
+
+Canonical reference for *deployment mode*: how to activate it, what the urgency
+contract means in practice, the lifecycle phases, log-naming conventions, what
+to write down and what to skip, and the per-project config schema that drives
+the [`start-deployment`](../../.claude/skills/start-deployment/SKILL.md) skill.
+
+See [ADR-0014](../../docs/decisions/0014-deployment-mode.md) for the decision
+record. SKILL.md embeds the urgency contract verbatim; if this doc and SKILL.md
+ever drift on the contract wording, **SKILL.md wins** (it's what's in context
+when the skill runs).
+
+## What it is
+
+Deployment mode is a *behavioral* operating mode the agent enters for a live
+field deployment of an autonomous robot boat. The decision record is in
+[ADR-0014](../../docs/decisions/0014-deployment-mode.md); this doc is the
+operational how-to.
+
+Two halves, both load-bearing:
+
+1. **An urgency contract** — sterile-cockpit-style behavioral adjustments that
+   keep the agent fast and operator-responsive during live ops.
+2. **Lifecycle tooling** — the skills and templates that run inside the mode
+   (`/start-deployment` is the first; `/wrap-up-deployment` and
+   `/next-deployment` are tracked as follow-ups under the umbrella
+   [#495](https://github.com/rolker/ros2_agent_workspace/issues/495)).
+
+It's a sibling to **field mode** ([ADR-0011](../../docs/decisions/0011-field-mode-for-non-github-origins.md)):
+field mode is detected by origin URL and scopes *where commits go*; deployment
+mode is operator-set per agent session and scopes *how the agent behaves under
+live time pressure*. The two axes are orthogonal; they overlap on field hosts
+during a deployment.
+
+## Activation
+
+**Per-agent-session.** Invoking the `/start-deployment` skill puts the current
+agent session in deployment mode. Other agent sessions on the same host doing
+unrelated work are **not** affected — the operator has to invoke
+`/start-deployment` in each session that should run under the contract.
+
+There is **no filesystem marker** and **no host-wide hook**. On-disk evidence
+of an ongoing deployment is what already exists naturally: an open
+`deployment`-labeled issue, plus a worktree (dev side) or a host log file
+(field side). The skill's three-state detection (see below) uses those
+artifacts to decide whether to create a new deployment, first-activate an
+existing one, or resume an ongoing one.
+
+## The urgency contract
+
+Eleven rules. They are embedded verbatim in
+[`SKILL.md`](../../.claude/skills/start-deployment/SKILL.md) so that invoking
+the skill puts the contract in context. The fuller treatment below explains
+*why* and *when* each one bites.
+
+1. **You are an assistant, not an investigator.** During live ops the operator
+   is running the boat; the agent's job is to make the operator faster, not to
+   pursue an investigation independently.
+2. **Mitigate before diagnose.** Stabilize the symptom now — turn down a rate,
+   swap a topic, restart a node — and defer root-cause analysis to wrap-up. A
+   live deployment is not a debugging session.
+3. **Time-box / confidence handoff.** If a path is taking more than ~1–2
+   minutes or your confidence is low, **stop**, summarize what you've checked
+   and what you'd try next, and hand back to the operator. Don't spiral.
+4. **Append, don't commit.** Batch commits at natural breakpoints (between
+   runs, at recovery). Each commit is a permission prompt and a context
+   switch; live ops absorb neither well.
+5. **Overlog rather than underlog.** Appending to a log file is near-zero cost.
+   Commits are what cause the prompts. Capture observations liberally; sort
+   them out at wrap-up.
+6. **Avoid permission prompts.** Use `git -C <path>`, absolute paths, `gh -R`,
+   and the file tools over heredocs / find / cat. The allowlist defeats
+   itself when commands are wrapped in `cd && …`. Generate timestamps with
+   `date '+%Y-%m-%d %H:%M %:z'`, not `date | sed`.
+7. **Sterile cockpit.** During live on-water ops, do *only* operation-essential
+   work — no doc polish, refactors, or "while we're here" cleanups. Write
+   them down for wrap-up.
+8. **Tides / weather / currents are dev-only.** Field hosts skip pre-flight
+   data entirely. The dev session ingests them (after asking the operator) and
+   logs them in the dev-side log's per-day `## Pre-flight` section.
+9. **Suggestions are conversation, not log entries.** "What if we tried X?"
+   stays in chat unless the operator decides to act on it. The log records
+   what *happened*, not what was proposed.
+10. **Operator notes are quotes plus factual context only.** No invented
+    mechanisms. If the operator says "felt sluggish," log the quote and the
+    nearest objective measurement; don't extrapolate to "thrust loss."
+11. **No self-imposed hard gates.** Don't write "⛔ Mandatory" / "sim-verify
+    required before…" into issues or PRs during live ops. Risk-acceptance
+    gates are the operator's call.
+
+The contract is **phase-aware** — sterile-cockpit bites hardest during live
+ops (phase [1] below) and **relaxes in wrap-up (phase [3])**, where deep
+analysis is the *expected* work.
+
+### Invariants (what the contract does NOT relax)
+
+- **Safety-critical correctness** (boat control, collision avoidance) is
+  never traded for speed.
+- Pre-commit hooks, AI signature, atomic commits, no secrets, no destructive
+  ops without explicit operator approval — same as field mode.
+- **Defer is not skip.** Deferred RCA / tests / docs are *tracked* — as
+  follow-up issues, roadmap items, or wrap-up checkboxes — not dropped. The
+  Quality Standard's "never table when the permanent solve is near" still
+  holds; deployment mode only defers *within a live session*, and wrap-up is
+  where completeness is restored.
+- **Human control.** The operator is continuously in the loop, which is
+  precisely why deployment mode can be more responsive — real-time oversight
+  is higher, not lower.
+
+## Lifecycle phases
+
+```
+[0] Start of day — pre-deployment
+    Activate /start-deployment; deployment issue templated;
+    worktree (dev) or main-tree (field); dev log seeded with
+    pre-flight tides / weather / currents.
+
+[1] Deployment session — field execution
+    Sterile cockpit bites. Per-host logs append-mostly. New
+    bugs / observations filed as follow-up issues. In-deployment
+    fixes commit to gitcloud during the session.
+
+[2] Recovery — boat-side, pre-shutdown
+    Safety-critical checklist: field agent logs pushed to
+    gitcloud; bag data offloaded; screenshots / supplemental
+    offloaded; stack cleanly shut down.
+
+[3] Wrap-up — dev-side
+    Contract relaxes. Import field changes; review-loop import
+    PRs; consolidate logs; extract bag DB; run standard
+    analyses; file analysis sub-issues; merge wrap-up PR
+    (closes deployment issue).
+
+[4] Next deployment-issue drafted from analysis outputs.
+```
+
+The phases map onto the SRE Prepare → Detect → Respond → Recover → Learn loop.
+Phases [0]–[2] are under the urgency contract; [3] relaxes it; [4] is
+deployment-mode-off (planning, not live).
+
+## Log-naming convention
+
+Per-host, per-deployment files in the project repo's logs directory
+(`docs/logs/<YYYY>/` for `unh_echoboats_project11`; other projects configure
+`log_dir`):
+
+```
+<YYYY-MM-DD>_<label>_logs.md
+```
+
+- **`<YYYY-MM-DD>`** is the deployment **start date**, not the date the file
+  is being appended to. Multi-day deployments keep the same date on the
+  filename; per-day sections inside the file use `## <YYYY-MM-DD>` headers.
+- **`<label>`** is:
+  - `dev` for dev-side sessions (regardless of host), so that wrap-up agents
+    can reliably find the dev log.
+  - `hostname -s` (short hostname) for field-side sessions — `gabby`,
+    `salmon`, `mercat`, etc.
+- The host is determined by `field_mode.sh` against the project repo's
+  origin, not by where the physical hardware lives. A dev workstation
+  working in a gitcloud-origin clone is in field mode for that repo, and
+  uses its short hostname accordingly.
+
+## What to write
+
+The principle is **overlog, but write what happens, not what was proposed**.
+
+Append to the dev log (during phase [3], or dev-side pre-flight in phase [0]):
+
+- Per-day `## Pre-flight` section with tides, weather, currents (see format
+  below).
+- Operator decisions and their rationale, in quote form where possible.
+- What was tried, what worked, what didn't.
+- Bag paths, run identifiers, screenshot paths.
+- Cross-references to follow-up issues filed during the session.
+
+Append to the field log (during phase [1]):
+
+- Run identifiers and rough timestamps.
+- Symptoms observed, mitigations applied, results.
+- Hardware events (power cycles, sensor swaps, link drops).
+- Quotes from operator chatter that influenced decisions.
+
+What stays in chat (does **not** go in either log):
+
+- Speculation about causes that wasn't acted on.
+- "We should consider X for next time" — that's a follow-up issue, not a log
+  entry, if it's worth keeping.
+- Long debugging traces that resolved in-session — summarize the outcome.
+
+### Tides / weather / currents format
+
+Dev-only. Asked first, fetched only on operator deferral. Logged in the dev
+log's `## Pre-flight` section for that day:
+
+- **Tide heights in metres** (matching local hydrographic convention).
+- **Tide times with explicit TZ in both local and UTC**, e.g.
+  `L 04:23 EDT (08:23 UTC)`. Never assume the reader's TZ matches the
+  operator's.
+- **Currents and winds in conventional marine units** (knots; nautical miles).
+- **Temperatures as the source gives them.** Don't convert.
+- **Source-station identifiers preserved** — NOAA station IDs, NDBC buoy
+  numbers — so the data is reproducible.
+
+Default station(s) live in the project's `.agents/deployment.yaml` under
+`tides:` / `currents:` / `weather:` so the skill can fetch without asking the
+operator every time.
+
+## Three-state detection
+
+The skill detects which of three states the current invocation is in, based on
+on-disk artifacts that already exist:
+
+| State | Evidence | Skill action |
+|---|---|---|
+| **Create new** | No open `deployment`-labeled issue (per `issue_sync`) | Offer to create; operator approves scope; templated issue body. |
+| **Activate first time** | Open issue exists, but no local worktree (dev) / no host log (field) | Rename issue title to `Deployment YYYY-MM-DD: <scope>` if not already in that format; ensure `## Logs` section present in body; create worktree (dev) or prepare main-tree (field); initialize host log; run `issue_sync.dev_push` so field hosts see the changes. |
+| **Resume ongoing** | Open issue + worktree+log (dev) / log file (field) | Re-attach: load the urgency contract into context, summarize state from the deployment issue body and the last ~20 entries of the current host's log. No artifacts created. |
+
+"Ensure essentials" on the deployment issue body is limited to:
+
+- Rename the title (only if it's not already in `Deployment YYYY-MM-DD: <scope>`
+  form).
+- Append a `## Logs` section if absent (the skill stamps per-host log file
+  links here as they appear).
+- Operator-authored sections (Purpose, Must-verify, Operators, Hosts in use,
+  Notes) are left untouched.
+- No automatic wrap-up checklist (the future `/wrap-up-deployment` skill owns
+  that procedure).
+- If the body is suspiciously empty, warn — don't impose structure.
+
+## Project-config schema (`.agents/deployment.yaml`)
+
+Each adopting project ships a small per-project config that the skill reads at
+invocation time. Template lives at
+[`.agent/templates/deployment_config.yaml`](../templates/deployment_config.yaml);
+copy it to `<project_repo>/.agents/deployment.yaml` and fill in.
+
+```yaml
+platform: <short name>            # e.g. "BizzyBoat"
+default_branch: <branch>          # e.g. "jazzy" — repo's default branch
+layer: <layer>                    # e.g. "platforms" — workspace layer
+packages: [<repo1>, …]            # project repos to include in worktrees
+labels: [deployment, …]           # labels applied to the deployment issue
+log_dir: <path>                   # e.g. "docs/logs" — relative to project repo
+
+hosts:
+  dev: <list of dev hostnames>    # informational
+  field: <list of field hostnames>  # informational; field_mode.sh is authoritative
+
+# Pluggable issue-sync mechanism (no git-bug-shaped default — see ADR-0003).
+# If issue_sync is absent, the skill skips the sync step and notes
+# "no issue_sync configured" so the operator can ensure all hosts see
+# the deployment issue by other means.
+issue_sync:
+  field_pull: <command>           # field: refresh issues from share
+  field_list_open: <command>      # field: list open deployment issues
+  field_show: <command>           # field: show issue body — uses {id}
+  dev_push: <command>             # dev: propagate changes to field-visible source
+  failure_hint: <message>         # actionable error printed on failure
+
+# Default data sources for pre-flight (all optional; dev-only).
+tides:
+  station: <NOAA station ID>
+  units: metres                   # always metres for tides
+currents:
+  station: <NOAA station ID>      # e.g. "ACT0731" for Clark Island
+weather:
+  source: <source>                # e.g. NWS office identifier
+```
+
+## Side detection (dev vs field)
+
+`field_mode.sh` against the **project repo's origin URL** drives the dev /
+field branch in the skill:
+
+- **Dev-mode** project repo (origin on the GitHub allowlist) → worktree +
+  draft PR per the existing convention.
+- **Field-mode** project repo (origin not on the GitHub allowlist) → direct
+  commit to the default branch per
+  [ADR-0011](../../docs/decisions/0011-field-mode-for-non-github-origins.md),
+  no PR.
+
+If field hosts ever get GitHub access *and* the project repo's origin moves
+to GitHub, the skill auto-switches without any code change.
+
+## What's NOT in deployment mode v1
+
+Tracked separately under [#495](https://github.com/rolker/ros2_agent_workspace/issues/495):
+
+- `/wrap-up-deployment` — phase [3] orchestration (review-loop, log
+  integration, analysis kickoff).
+- `/next-deployment` — phase [4] drafting of the next deployment issue from
+  analysis outputs.
+- Framework-level hook for auto-injecting the urgency contract into every
+  turn (rejected for v1 — would over-broadcast across unrelated sessions).
+- Recovery checklist skill ([#496](https://github.com/rolker/ros2_agent_workspace/issues/496))
+  — phase [2] safety-critical checks.
+- A general "agent operating modes" framework ADR — deferred per ADR-0014
+  until ≥3 mode instances are formalized.
+
+## References
+
+- [ADR-0014](../../docs/decisions/0014-deployment-mode.md) — decision record
+- [ADR-0011](../../docs/decisions/0011-field-mode-for-non-github-origins.md) — sibling mode (where commits go)
+- [ADR-0003](../../docs/decisions/0003-workspace-infrastructure-is-project-agnostic.md) — three-tier content split
+- [`.claude/skills/start-deployment/SKILL.md`](../../.claude/skills/start-deployment/SKILL.md) — the skill
+- [`.agent/templates/deployment_config.yaml`](../templates/deployment_config.yaml) — sample project config
+- Workspace research digest entry "Operational-Assistant Behavior Under Live Time Pressure" — grounding for the urgency contract
+- [#495](https://github.com/rolker/ros2_agent_workspace/issues/495) — umbrella for the full lifecycle
+- [#501](https://github.com/rolker/ros2_agent_workspace/issues/501) — v1 skill issue

--- a/.agent/templates/deployment_config.yaml
+++ b/.agent/templates/deployment_config.yaml
@@ -1,0 +1,134 @@
+# Deployment Mode — Per-Project Config Template
+#
+# Usage: Copy to <project_repo>/.agents/deployment.yaml in the project
+#        repo (NOT the workspace repo). Fill in the values marked TODO.
+#        The /start-deployment skill reads this file at invocation time
+#        and uses it to drive issue creation, worktree setup, side
+#        detection, and pre-flight data fetching.
+#
+# Reference: .agent/knowledge/deployment_mode.md (operational how-to)
+#            ADR-0014 (decision record)
+#            .claude/skills/start-deployment/SKILL.md (the skill)
+#
+# Schema philosophy: per ADR-0003, the skill is project-agnostic. Every
+# project-specific value lives here. The skill hardcodes no repo, label,
+# branch, log path, or `issue_sync` mechanism.
+
+# ---------------------------------------------------------------------
+# Platform identity
+# ---------------------------------------------------------------------
+
+# Short human-readable name for the platform.
+# Used in skill prompts and log file labels.
+# Example: "BizzyBoat", "IzzyBoat", "dora"
+platform: TODO
+
+# The project repo's default branch (NOT the workspace's default).
+# Used by the field-mode commit path and worktree creation.
+# Example: "jazzy", "main"
+default_branch: TODO
+
+# Workspace layer the project repo lives in.
+# Used by the dev-mode worktree path: layers/main/<layer>_ws/src/<repo>/
+# Example: "platforms", "underlay"
+layer: TODO
+
+# Project repos to include in deployment worktrees.
+# The first entry is the primary; others are included for cross-cutting
+# work. Names must match directory names under layers/main/<layer>_ws/src/.
+# Example: ["unh_echoboats_project11"]
+packages:
+  - TODO
+
+# Labels applied to the deployment issue when created.
+# At minimum include "deployment" so the three-state detection works.
+# Example: ["deployment", "bizzyboat"]
+labels:
+  - deployment
+
+# Log directory, relative to the project repo root.
+# Per-host log files land at <log_dir>/<YYYY>/<YYYY-MM-DD>_<label>_logs.md
+# Example: "docs/logs"
+log_dir: TODO
+
+# ---------------------------------------------------------------------
+# Host inventory (informational only)
+# ---------------------------------------------------------------------
+#
+# This lists known hosts for human reference. The skill does NOT trust
+# these lists for dev/field detection — `field_mode.sh` against the
+# project repo's origin URL is authoritative. A dev workstation working
+# in a gitcloud-origin clone is in field mode for that repo, regardless
+# of what `hostname -s` returns.
+
+hosts:
+  dev:
+    - TODO  # e.g. "salmon"
+  field:
+    - TODO  # e.g. "gabby"
+    - TODO  # e.g. "mercat"
+
+# ---------------------------------------------------------------------
+# Pluggable issue-sync mechanism
+# ---------------------------------------------------------------------
+#
+# The skill does NOT hard-code git-bug. Each command below is a shell
+# string invoked by the skill at the appropriate point in the flow.
+# Use {id} as a placeholder for an issue identifier where needed.
+#
+# If this entire section is OMITTED, the skill skips the sync step and
+# notes "no issue_sync configured — ensure all hosts see the deployment
+# issue by other means." No git-bug-shaped default is baked in.
+
+issue_sync:
+  # Field side, at deployment start: pull/refresh issues from the share.
+  # Example for git-bug + a shared field remote:
+  #   field_pull: "git bug pull gitcloud"
+  field_pull: TODO
+
+  # Field side: list open issues with the deployment label.
+  # Output should be parseable (one issue per line, id first).
+  # Example: "git bug ls --label deployment --status open"
+  field_list_open: TODO
+
+  # Field side: show the body of a specific issue.
+  # {id} is replaced with the issue identifier.
+  # Example: "git bug show {id}"
+  field_show: TODO
+
+  # Dev side, after creating / editing the deployment issue: propagate
+  # changes to the field-visible source so field hosts see them on their
+  # next pull.
+  # Example for git-bug + gitcloud:
+  #   dev_push: "git bug push gitcloud"
+  dev_push: TODO
+
+  # One-line actionable error printed when any of the above fails.
+  # Example: "Check gitcloud connectivity; see reference_gitbug_gitcloud_propagation.md"
+  failure_hint: TODO
+
+# ---------------------------------------------------------------------
+# Pre-flight data sources (dev-only)
+# ---------------------------------------------------------------------
+#
+# All optional. If omitted, the skill asks the operator each deployment.
+# Tide heights are ALWAYS in metres regardless of unit specified here
+# (matching local hydrographic convention).
+
+tides:
+  # NOAA / hydrographic-office station ID for tide heights.
+  # Example: "8423898" (Fort Point, NH)
+  station: TODO
+
+currents:
+  # NOAA station ID for currents (if relevant — many sites have none).
+  # Pick the station that matches the actual flow geometry, not just
+  # the nearest one. See reference_noaa_currents_portsmouth.md for an
+  # example of why this matters.
+  # Example: "ACT0731" (Clark Island main channel)
+  station: TODO
+
+weather:
+  # Weather data source identifier.
+  # Example: "GYX" (NWS Gray, ME office) or a specific buoy ID
+  source: TODO

--- a/.agent/templates/deployment_config.yaml
+++ b/.agent/templates/deployment_config.yaml
@@ -76,9 +76,16 @@ hosts:
 # string invoked by the skill at the appropriate point in the flow.
 # Use {id} as a placeholder for an issue identifier where needed.
 #
-# If this entire section is OMITTED, the skill skips the sync step and
-# notes "no issue_sync configured — ensure all hosts see the deployment
-# issue by other means." No git-bug-shaped default is baked in.
+# Dev side: issue_sync is fully optional. `gh` (run inside the project
+# repo) handles issue discovery, listing, viewing, and editing on its
+# own — omitting issue_sync just disables dev_push.
+#
+# Field side: field_pull, field_list_open, and field_show are
+# HARD-REQUIRED. Field hosts have no `gh` access, so without these
+# three commands the skill literally cannot list or read deployment
+# issues — it stops with an explicit error directing the operator to
+# configure them. Only omit issue_sync entirely for dev-only projects.
+# No git-bug-shaped default is baked in.
 
 issue_sync:
   # Field side, at deployment start: pull/refresh issues from the share.

--- a/.agent/templates/deployment_config.yaml
+++ b/.agent/templates/deployment_config.yaml
@@ -112,8 +112,8 @@ issue_sync:
 # ---------------------------------------------------------------------
 #
 # All optional. If omitted, the skill asks the operator each deployment.
-# Tide heights are ALWAYS in metres regardless of unit specified here
-# (matching local hydrographic convention).
+# Tide heights are always logged in metres (matching local hydrographic
+# convention).
 
 tides:
   # NOAA / hydrographic-office station ID for tide heights.

--- a/.agent/work-plans/issue-501/plan.md
+++ b/.agent/work-plans/issue-501/plan.md
@@ -1,0 +1,67 @@
+# Plan: v1 /start-deployment skill + activation marker (deployment-mode gap 1)
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/501
+
+(Design decisions locked in [issue comment](https://github.com/rolker/ros2_agent_workspace/issues/501#issuecomment-4560650816) — the issue title's "+ activation marker" phrase is **stale**; the locked design drops the marker. See Open Questions for rename.)
+
+## Context
+
+[ADR-0014](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0014-deployment-mode.md) (Draft, PR [#500](https://github.com/rolker/ros2_agent_workspace/pull/500)) defines deployment mode as a phase-aware behavioral autonomy mode (urgency contract) + lifecycle tooling that runs inside it. This PR ships the *first* lifecycle tool: `/start-deployment`, which activates a *single* agent session into deployment mode and either creates / first-activates / resumes a deployment.
+
+The design comment on #501 is the authoritative spec; this plan is the structural / governance / consequences view.
+
+## Approach
+
+1. **Knowledge doc first** (`.agent/knowledge/deployment_mode.md`) — write the canonical reference: lifecycle phases, log-naming convention (per-host file, deployment-start date, dev/`hostname -s` label rule), what-to-write guidance, the `issue_sync` config schema, the project-config schema, and pointers to ADR-0014 and the skill.
+2. **Template** (`.agent/templates/deployment_config.yaml`) — a fully-commented sample project deployment config (`issue_sync` interface with empty values + comments; `platform`, `default_branch`, `layer`, `packages`, `labels`, `log_dir`, `hosts`, optional defaults for tides stations). Adopters copy + fill.
+3. **Skill** (`.claude/skills/start-deployment/SKILL.md`) — the load-bearing artifact. Frontmatter (`name` + `description`); embedded urgency contract (11 rules verbatim); procedure with three-state detection (create-new / activate-first-time / resume-ongoing) branching on side (`field_mode.sh`); steps invoke configured `issue_sync` commands rather than hard-coded `git bug`; "ensure-essentials" limited to `## Logs` section; rename title to `Deployment YYYY-MM-DD: <scope>` only if not already in that format; tides/weather/currents into the dev log's per-day `## Pre-flight` section, dev-only.
+4. **No marker, no `.gitignore` edit, no hook** — explicitly out of scope per the locked design.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/knowledge/deployment_mode.md` | **create** — canonical reference doc |
+| `.agent/templates/deployment_config.yaml` | **create** — commented sample project config |
+| `.claude/skills/start-deployment/SKILL.md` | **create** — the skill (urgency contract embedded, three-state procedure) |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Workspace vs. project separation | Skill is generic; all platform-specific values come from project `.agents/deployment.yaml`. Hardcodes no repo, label, path, or `git bug` mechanism. |
+| Workspace improvements cascade to projects | Skill works for any project that supplies the config; BizzyBoat first, IzzyBoat/dora later. |
+| Only what's needed | Marker file + hook + `.gitignore` edit dropped from earlier draft. Three files, no state. |
+| Improve incrementally | v1 ships `/start-deployment` only; `/wrap-up-deployment`, `/next-deployment`, hook-based auto-injection are separate sub-issues of #495. |
+| Human control / tight-by-default, relaxable | Activation is per-session and operator-driven (slash command). No global behavior change. |
+| Capture decisions | ADR-0014 already captures the *what*; this PR is the *implementation*. |
+| A change includes its consequences | Fast-follow PRs tracked as tasks #9 (`docs/logs/README.md` shrink) and #10 (echoboats `.agents/deployment.yaml`). |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| [ADR-0003](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0003-workspace-infrastructure-is-project-agnostic.md) (workspace generic) | **Yes** | Skill is mechanism-agnostic; project config in project repo. |
+| [ADR-0011](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0011-field-mode-for-non-github-origins.md) (field mode) | **Yes** | Side detection via `field_mode.sh`; field commits direct to default branch, dev uses worktree+PR. No hardcoded assumption. |
+| [ADR-0013](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0013-progress-md-entry-type-vocabulary.md) (progress.md vocabulary) | **Yes** | `## Plan Authored` entry (this commit) + future `## Implementation` per the standard schema. |
+| [ADR-0014](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0014-deployment-mode.md) (deployment mode, Draft) | **Yes** | This PR is the first concrete implementation; embeds the urgency contract verbatim in SKILL.md. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Add `/start-deployment` skill | `unh_echoboats_project11/.agents/deployment.yaml` so the skill has a BizzyBoat config to consume | **Follow-up** (task #10, separate project-repo PR) |
+| Embed lifecycle ownership in the skill | `unh_echoboats_project11/docs/logs/README.md` (shrink: point at skill + workspace doc, keep only boat-specific overrides) | **Follow-up** (task #9, separate project-repo PR) |
+| Ship ADR-0014's first implementation | ADR-0014 Status: Proposed → Accepted (after v1 lands + first deployment uses it) | **Future** (post-deployment) |
+| AGENTS.md / CLAUDE.md reference to the skill | One-line pointer to `/start-deployment` under Skill Worktree Exception or a new "Deployment skills" subsection | **Open Question** below — not in v1 |
+
+## Open Questions
+
+- **Rename #501 title?** Drop "+ activation marker" since the marker is dropped from the design. (Cosmetic; the design comment supersedes.)
+- **AGENTS.md / CLAUDE.md pointer to `/start-deployment`** — add a one-line reference now, or defer until `/wrap-up-deployment` lands so they're added together? Modifying AGENTS.md is "ask first" per the Boundaries section.
+
+## Estimated Scope
+
+**Single workspace PR** (this issue, ~3 files, ~300-400 lines total — SKILL.md is the longest). Two fast-follow project-repo PRs on `unh_echoboats_project11` tracked separately.

--- a/.agent/work-plans/issue-501/plan.md
+++ b/.agent/work-plans/issue-501/plan.md
@@ -1,4 +1,4 @@
-# Plan: v1 /start-deployment skill + activation marker (deployment-mode gap 1)
+# Plan: v1 /start-deployment skill (deployment-mode gap 1)
 
 ## Issue
 
@@ -26,6 +26,11 @@ The design comment on #501 is the authoritative spec; this plan is the structura
 | `.agent/knowledge/deployment_mode.md` | **create** — canonical reference doc |
 | `.agent/templates/deployment_config.yaml` | **create** — commented sample project config |
 | `.claude/skills/start-deployment/SKILL.md` | **create** — the skill (urgency contract embedded, three-state procedure) |
+| `AGENTS.md` | **edit** — add small `### Deployment mode` subsection after Skill Worktree Exception, pointing at `/start-deployment` + ADR-0014 + knowledge doc (open-question 2 resolution, 2026-05-28) |
+| `.github/copilot-instructions.md` | **edit** — add `/start-deployment` to the skill inventory (per [`principles_review_guide.md`](.agent/knowledge/principles_review_guide.md) Consequences Map) |
+| `.agent/instructions/gemini-cli.instructions.md` | **edit** — add `/start-deployment` to the skill inventory (Consequences Map) |
+| `.agent/AGENT_ONBOARDING.md` | **edit** — add `/start-deployment` to the skill inventory (Consequences Map) |
+| `.agent/work-plans/issue-501/progress.md` | **edit** — `## Plan Authored`, `## Plan Review`, future `## Implementation` entries per [ADR-0013](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0013-progress-md-entry-type-vocabulary.md) |
 
 ## Principles Self-Check
 
@@ -37,7 +42,8 @@ The design comment on #501 is the authoritative spec; this plan is the structura
 | Improve incrementally | v1 ships `/start-deployment` only; `/wrap-up-deployment`, `/next-deployment`, hook-based auto-injection are separate sub-issues of #495. |
 | Human control / tight-by-default, relaxable | Activation is per-session and operator-driven (slash command). No global behavior change. |
 | Capture decisions | ADR-0014 already captures the *what*; this PR is the *implementation*. |
-| A change includes its consequences | Fast-follow PRs tracked as tasks #9 (`docs/logs/README.md` shrink) and #10 (echoboats `.agents/deployment.yaml`). |
+| A change includes its consequences | Fast-follow PRs tracked as tasks #9 (`docs/logs/README.md` shrink) and #10 (echoboats `.agents/deployment.yaml`). Non-Claude adapter skill lists + AGENTS.md pointer landed in this PR per the Consequences Map. |
+| Enforcement over documentation ([ADR-0004](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0004-enforcement-hierarchy-for-agent-compliance.md)) | v1 lands at the **instruction tier only** (SKILL.md urgency contract + knowledge doc). The behavioral half is operator-set and skill-invoked, not hook-enforced. Hook-based auto-injection was rejected in the locked design (would over-broadcast); tracked as a separate fast-follow under umbrella [#495](https://github.com/rolker/ros2_agent_workspace/issues/495). |
 
 ## ADR Compliance
 
@@ -55,13 +61,15 @@ The design comment on #501 is the authoritative spec; this plan is the structura
 | Add `/start-deployment` skill | `unh_echoboats_project11/.agents/deployment.yaml` so the skill has a BizzyBoat config to consume | **Follow-up** (task #10, separate project-repo PR) |
 | Embed lifecycle ownership in the skill | `unh_echoboats_project11/docs/logs/README.md` (shrink: point at skill + workspace doc, keep only boat-specific overrides) | **Follow-up** (task #9, separate project-repo PR) |
 | Ship ADR-0014's first implementation | ADR-0014 Status: Proposed → Accepted (after v1 lands + first deployment uses it) | **Future** (post-deployment) |
-| AGENTS.md / CLAUDE.md reference to the skill | One-line pointer to `/start-deployment` under Skill Worktree Exception or a new "Deployment skills" subsection | **Open Question** below — not in v1 |
+| AGENTS.md reference to the skill | Small `### Deployment mode` subsection after Skill Worktree Exception | **In this PR** (resolved 2026-05-28 — see Files to Change) |
+| Non-Claude adapter skill lists | Add `/start-deployment` to `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md` | **In this PR** (per Consequences Map) |
 
 ## Open Questions
 
-- **Rename #501 title?** Drop "+ activation marker" since the marker is dropped from the design. (Cosmetic; the design comment supersedes.)
-- **AGENTS.md / CLAUDE.md pointer to `/start-deployment`** — add a one-line reference now, or defer until `/wrap-up-deployment` lands so they're added together? Modifying AGENTS.md is "ask first" per the Boundaries section.
+- **Rename #501 title?** Drop "+ activation marker" since the marker is dropped from the design. (Cosmetic; the design comment supersedes. Plan file H1 renamed 2026-05-28.)
+- **~~AGENTS.md / CLAUDE.md pointer to `/start-deployment`~~** — **Resolved 2026-05-28**: add a small `### Deployment mode` subsection to AGENTS.md after Skill Worktree Exception (pointing at `/start-deployment` + ADR-0014 + the knowledge doc) in this PR. CLAUDE.md untouched (Claude auto-discovers skills). Non-Claude adapter skill lists also updated in this PR per the Consequences Map.
+- **ADR-0014 marker-language reconciliation** — ADR-0014 draft ([PR #500](https://github.com/rolker/ros2_agent_workspace/pull/500)) still describes an "operator-set marker" in Activation and lists it in the Modes table, but the locked design comment and this implementation drop the marker. Options: (a) amend ADR-0014 in *this* PR before/with the skill landing; (b) push an amendment as part of PR #500 (the ADR draft) so the two land coherently; (c) open a follow-up issue and call out the drift in the PR body. Surfaced 2026-05-28 — decision pending.
 
 ## Estimated Scope
 
-**Single workspace PR** (this issue, ~3 files, ~300-400 lines total — SKILL.md is the longest). Two fast-follow project-repo PRs on `unh_echoboats_project11` tracked separately.
+**Single workspace PR** (this issue, ~7 files: 3 new + 4 small edits to instruction / adapter files, ~350-450 lines total — SKILL.md is the longest). Two fast-follow project-repo PRs on `unh_echoboats_project11` tracked separately.

--- a/.agent/work-plans/issue-501/plan.md
+++ b/.agent/work-plans/issue-501/plan.md
@@ -27,7 +27,7 @@ The design comment on #501 is the authoritative spec; this plan is the structura
 | `.agent/templates/deployment_config.yaml` | **create** — commented sample project config |
 | `.claude/skills/start-deployment/SKILL.md` | **create** — the skill (urgency contract embedded, three-state procedure) |
 | `AGENTS.md` | **edit** — add small `### Deployment mode` subsection after Skill Worktree Exception, pointing at `/start-deployment` + ADR-0014 + knowledge doc (open-question 2 resolution, 2026-05-28) |
-| `.github/copilot-instructions.md` | **edit** — add `/start-deployment` to the skill inventory (per [`principles_review_guide.md`](.agent/knowledge/principles_review_guide.md) Consequences Map) |
+| `.github/copilot-instructions.md` | **edit** — add `/start-deployment` to the skill inventory (per [`principles_review_guide.md`](../../knowledge/principles_review_guide.md) Consequences Map) |
 | `.agent/instructions/gemini-cli.instructions.md` | **edit** — add `/start-deployment` to the skill inventory (Consequences Map) |
 | `.agent/AGENT_ONBOARDING.md` | **edit** — add `/start-deployment` to the skill inventory (Consequences Map) |
 | `.agent/work-plans/issue-501/progress.md` | **edit** — `## Plan Authored`, `## Plan Review`, future `## Implementation` entries per [ADR-0013](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0013-progress-md-entry-type-vocabulary.md) |

--- a/.agent/work-plans/issue-501/plan.md
+++ b/.agent/work-plans/issue-501/plan.md
@@ -68,7 +68,7 @@ The design comment on #501 is the authoritative spec; this plan is the structura
 
 - **Rename #501 title?** Drop "+ activation marker" since the marker is dropped from the design. (Cosmetic; the design comment supersedes. Plan file H1 renamed 2026-05-28.)
 - **~~AGENTS.md / CLAUDE.md pointer to `/start-deployment`~~** — **Resolved 2026-05-28**: add a small `### Deployment mode` subsection to AGENTS.md after Skill Worktree Exception (pointing at `/start-deployment` + ADR-0014 + the knowledge doc) in this PR. CLAUDE.md untouched (Claude auto-discovers skills). Non-Claude adapter skill lists also updated in this PR per the Consequences Map.
-- **ADR-0014 marker-language reconciliation** — ADR-0014 draft ([PR #500](https://github.com/rolker/ros2_agent_workspace/pull/500)) still describes an "operator-set marker" in Activation and lists it in the Modes table, but the locked design comment and this implementation drop the marker. Options: (a) amend ADR-0014 in *this* PR before/with the skill landing; (b) push an amendment as part of PR #500 (the ADR draft) so the two land coherently; (c) open a follow-up issue and call out the drift in the PR body. Surfaced 2026-05-28 — decision pending.
+- **~~ADR-0014 marker-language reconciliation~~** — **Resolved 2026-05-28**: amend ADR-0014 in [PR #500](https://github.com/rolker/ros2_agent_workspace/pull/500) (the ADR draft itself) to drop "operator-set marker" language in Activation, the Modes table, and the negatives; replace with per-session activation matching the locked design comment. This PR (#503) lands the skill against the (soon-to-be-updated) ADR; no ADR edits in #503. PR body for #503 will note PR #500 amendment is the coordinated step.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-501/progress.md
+++ b/.agent/work-plans/issue-501/progress.md
@@ -15,7 +15,7 @@ issue: 501
 
 ### Open questions
 - [ ] Rename #501 title to drop the stale "+ activation marker" phrase (marker dropped from design)
-- [ ] Add a one-line AGENTS.md / CLAUDE.md pointer to `/start-deployment` now, or defer until `/wrap-up-deployment` lands (modifying AGENTS.md is "ask first" per Boundaries)
+- [x] ~~Add a one-line AGENTS.md / CLAUDE.md pointer to `/start-deployment`~~ → **Resolved 2026-05-28**: add a small `### Deployment mode` subsection to AGENTS.md after Skill Worktree Exception (pointing at `/start-deployment` + ADR-0014 + the knowledge doc) in this PR. CLAUDE.md untouched. Non-Claude adapter skill lists also updated in this PR per the Consequences Map.
 
 ## Plan Review
 **Status**: complete

--- a/.agent/work-plans/issue-501/progress.md
+++ b/.agent/work-plans/issue-501/progress.md
@@ -16,3 +16,25 @@ issue: 501
 ### Open questions
 - [ ] Rename #501 title to drop the stale "+ activation marker" phrase (marker dropped from design)
 - [ ] Add a one-line AGENTS.md / CLAUDE.md pointer to `/start-deployment` now, or defer until `/wrap-up-deployment` lands (modifying AGENTS.md is "ask first" per Boundaries)
+
+## Plan Review
+**Status**: complete
+**When**: 2026-05-28 08:37 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context)) (in-context — author self-review, delegated to fresh-context sub-agent)
+
+**Plan**: `.agent/work-plans/issue-501/plan.md` at `bb9f40e`
+**PR**: https://github.com/rolker/ros2_agent_workspace/pull/503
+**Verdict**: changes-requested
+
+### Findings
+- [ ] (must-fix) ADR-0014 marker-language drift — ADR-0014 draft (PR #500) still describes "operator-set marker" in Activation and the Modes table, but the locked design (issue #501 design comment) and this plan drop the marker. Plan should either amend ADR-0014 in this PR or open a follow-up + flag it in the PR body. — `plan.md:51` (Consequences / ADR-0014 row)
+- [ ] (must-fix) Non-Claude adapter skill lists missing from Consequences — `principles_review_guide.md` Consequences Map requires updating `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, and `.agent/AGENT_ONBOARDING.md` skill inventories when a workflow skill is added. Add to Files to Change for this PR; don't defer. — `plan.md:23-28` (Files to Change), `plan.md:53-58` (Consequences)
+- [ ] (suggestion) ADR-0004 / "Enforcement over documentation" not in Principles Self-Check — v1 lands at instruction tier only (SKILL.md + knowledge doc), which is defensible but should be stated. Add a row noting hook-based auto-injection is tracked as fast-follow under #495. — `plan.md:30-39`
+- [ ] (suggestion) Plan file H1 still reads "+ activation marker" — rename to drop the stale phrase; the issue rename is the operator's call but the plan file's title is the author's. — `plan.md:1`
+- [ ] (suggestion) `progress.md` Plan Authored / Plan Review entries not listed in Files to Change — ADR-0013 makes them required artifacts; minor under-statement of the table. — `plan.md:23-28`
+- [ ] (process) Surface the AGENTS.md/CLAUDE.md pointer Open Question to the operator before implementation — per `feedback_surface_ux_decisions.md` ask, don't defer in the plan body.
+
+### Notes
+- Scope sizing is right (3 files, ~300–400 lines, SKILL.md as load-bearing artifact).
+- Plan matches the locked design comment item-for-item on substance (no marker, three-state detection, side-detection via `field_mode.sh`, pluggable `issue_sync`, dev-only tides in metres + explicit TZ, urgency contract embedded, ensure-essentials limited to `## Logs`).
+- Independence caveat: the original plan author and this skill's invoking agent are the same identity (Claude Code Agent / Claude Opus 4.7 (1M context)). Evaluation was delegated to a fresh-context sub-agent to mitigate; downstream consumers should weight accordingly.

--- a/.agent/work-plans/issue-501/progress.md
+++ b/.agent/work-plans/issue-501/progress.md
@@ -2,7 +2,7 @@
 issue: 501
 ---
 
-# Issue #501 — v1 /start-deployment skill + activation marker (deployment-mode gap 1)
+# Issue #501 — v1 /start-deployment skill (deployment-mode gap 1)
 
 ## Plan Authored
 **Status**: complete

--- a/.agent/work-plans/issue-501/progress.md
+++ b/.agent/work-plans/issue-501/progress.md
@@ -27,7 +27,7 @@ issue: 501
 **Verdict**: changes-requested
 
 ### Findings
-- [ ] (must-fix) ADR-0014 marker-language drift — ADR-0014 draft (PR #500) still describes "operator-set marker" in Activation and the Modes table, but the locked design (issue #501 design comment) and this plan drop the marker. Plan should either amend ADR-0014 in this PR or open a follow-up + flag it in the PR body. — `plan.md:51` (Consequences / ADR-0014 row)
+- [x] ~~(must-fix) ADR-0014 marker-language drift~~ → **Resolved 2026-05-28**: amend ADR-0014 in PR #500 (the ADR draft) to match the locked markerless design (Activation, Modes table, negatives). PR #503 just lands the skill; no ADR edits in #503; PR body will note PR #500 amendment is the coordinated step.
 - [ ] (must-fix) Non-Claude adapter skill lists missing from Consequences — `principles_review_guide.md` Consequences Map requires updating `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, and `.agent/AGENT_ONBOARDING.md` skill inventories when a workflow skill is added. Add to Files to Change for this PR; don't defer. — `plan.md:23-28` (Files to Change), `plan.md:53-58` (Consequences)
 - [ ] (suggestion) ADR-0004 / "Enforcement over documentation" not in Principles Self-Check — v1 lands at instruction tier only (SKILL.md + knowledge doc), which is defensible but should be stated. Add a row noting hook-based auto-injection is tracked as fast-follow under #495. — `plan.md:30-39`
 - [ ] (suggestion) Plan file H1 still reads "+ activation marker" — rename to drop the stale phrase; the issue rename is the operator's call but the plan file's title is the author's. — `plan.md:1`

--- a/.agent/work-plans/issue-501/progress.md
+++ b/.agent/work-plans/issue-501/progress.md
@@ -28,6 +28,39 @@ issue: 501
 
 ### Findings
 - [x] ~~(must-fix) ADR-0014 marker-language drift~~ → **Resolved 2026-05-28**: amend ADR-0014 in PR #500 (the ADR draft) to match the locked markerless design (Activation, Modes table, negatives). PR #503 just lands the skill; no ADR edits in #503; PR body will note PR #500 amendment is the coordinated step.
+
+## Implementation
+**Status**: complete (local; not yet pushed at write-time)
+**When**: 2026-05-28 09:25 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Plan**: `.agent/work-plans/issue-501/plan.md` at `2fcd2d2`
+**PR**: https://github.com/rolker/ros2_agent_workspace/pull/503
+**Commits** (this PR's implementation, on `feature/issue-501`):
+- `d1582f7` — Add /start-deployment skill, knowledge doc, and project-config template (3 new files, 756 insertions)
+- `0b9abce` — Wire /start-deployment into adapter / instruction files (AGENTS.md subsection + 3 skill-list updates)
+- `e9a7e72` — /start-deployment: address pre-push review findings (4 procedural gaps in SKILL.md + tides.units cleanup)
+
+**Coordinated commits** (separate PR):
+- `05a4a42` on PR [#500](https://github.com/rolker/ros2_agent_workspace/pull/500) — ADR-0014 drops marker language to match the locked markerless design (Activation, Modes table, negatives). Pushed 2026-05-28; merge order is `#500 → #503` so the ADR text is coherent when the skill lands.
+
+### Outcome vs plan
+All 7 files from the amended plan landed:
+- `.agent/knowledge/deployment_mode.md` — canonical reference (~250 lines)
+- `.agent/templates/deployment_config.yaml` — commented sample config
+- `.claude/skills/start-deployment/SKILL.md` — the skill (urgency contract embedded; 3-state detection; dev/field branching)
+- `AGENTS.md` — `### Deployment mode` subsection after Skill Worktree Exception
+- `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md` — `start-deployment` appended to each skill inventory
+
+### Reviews
+- [x] Plan review (`949819c`) — verdict: changes-requested. All 5 findings addressed in plan amendments (commits `b909c6f`, `2fcd2d2`).
+- [x] Pre-push fresh-context review (sub-agent, 2026-05-28 09:18) — verdict: 4 should-address procedural gaps + 4 polish suggestions. All 4 should-address items + 2 polish wins folded into `e9a7e72`. Suggestion 7 (adapter ordering) and suggestion 8 (AGENTS.md placement) intentionally left as-is per plan resolution.
+
+### Open follow-ups (not in this PR)
+- Fast-follow PRs on `unh_echoboats_project11`:
+  - `.agents/deployment.yaml` — BizzyBoat config populating the schema
+  - `docs/logs/README.md` — shrink to BizzyBoat-specific overrides; point at workspace docs + skill
+- ADR-0014 status flip from Proposed → Accepted after the first deployment uses `/start-deployment` (post-deployment task).
 - [ ] (must-fix) Non-Claude adapter skill lists missing from Consequences — `principles_review_guide.md` Consequences Map requires updating `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, and `.agent/AGENT_ONBOARDING.md` skill inventories when a workflow skill is added. Add to Files to Change for this PR; don't defer. — `plan.md:23-28` (Files to Change), `plan.md:53-58` (Consequences)
 - [ ] (suggestion) ADR-0004 / "Enforcement over documentation" not in Principles Self-Check — v1 lands at instruction tier only (SKILL.md + knowledge doc), which is defensible but should be stated. Add a row noting hook-based auto-injection is tracked as fast-follow under #495. — `plan.md:30-39`
 - [ ] (suggestion) Plan file H1 still reads "+ activation marker" — rename to drop the stale phrase; the issue rename is the operator's call but the plan file's title is the author's. — `plan.md:1`

--- a/.agent/work-plans/issue-501/progress.md
+++ b/.agent/work-plans/issue-501/progress.md
@@ -1,0 +1,18 @@
+---
+issue: 501
+---
+
+# Issue #501 — v1 /start-deployment skill + activation marker (deployment-mode gap 1)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-05-27 23:44 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Plan**: `.agent/work-plans/issue-501/plan.md` at `bb9f40e`
+**PR**: https://github.com/rolker/ros2_agent_workspace/pull/503 (`[PLAN]` prefix)
+**Phases**: single
+
+### Open questions
+- [ ] Rename #501 title to drop the stale "+ activation marker" phrase (marker dropped from design)
+- [ ] Add a one-line AGENTS.md / CLAUDE.md pointer to `/start-deployment` now, or defer until `/wrap-up-deployment` lands (modifying AGENTS.md is "ask first" per Boundaries)

--- a/.agent/work-plans/issue-501/progress.md
+++ b/.agent/work-plans/issue-501/progress.md
@@ -110,9 +110,32 @@ None.
 **CI**: all-pass (Lint, Validate Documentation, commit identity)
 
 ### Findings
-- [ ] (must-fix, Copilot R4) Worktree scripts use CWD-relative `.agent/scripts/worktree_create.sh` paths, but step 2's workspace-root discovery means CWD may be inside a project repo where `.agent/scripts/` doesn't exist. Prefix consistently with `<workspace_root>/` — `SKILL.md:244-250`
-- [ ] (must-fix, Copilot R4) "Claude-Code-native" hyphenated — repo convention is "Claude Code" (with space, no hyphen). Regression from R3 C3 fix. — `AGENTS.md:241`
-- [ ] (must-fix, Copilot R4) Field-side three-state detection relies on `issue_sync.field_list_open`, but absent-`issue_sync` warning text only mentions skipping the *sync* step. Without `field_list_open` the skill literally cannot list issues on field side. Make `field_list_open` + `field_show` hard-required on field side; stop with explicit error if absent (dev side can still treat `issue_sync` as fully optional). — `SKILL.md:182-188`
+- [x] (must-fix, Copilot R4) Worktree scripts CWD-relative — `SKILL.md:244-250` **(resolved in `27b3cfd`)**
+- [x] (must-fix, Copilot R4) "Claude-Code-native" hyphenation regression — `AGENTS.md:241` **(resolved in `27b3cfd`)**
+- [x] (must-fix, Copilot R4) Field-side `issue_sync` silent break — `SKILL.md:182-188` **(resolved in `27b3cfd` — hard-required on field side; explicit stop)**
 
 ### False positives
 - (Copilot R4, `plan.md:30`) Claimed `../../knowledge/principles_review_guide.md` resolves under `.agent/work-plans/knowledge/`, suggested `../../../knowledge/...`. Verified by `ls` from `.agent/work-plans/issue-501/`: `../../knowledge/principles_review_guide.md` resolves to `.agent/knowledge/principles_review_guide.md` (file exists). Copilot's suggested `../../../knowledge/...` would resolve to `<repo-root>/knowledge/` (does not exist). The R3-round fix is correct; this is a directory-level miscalculation by the bot.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-05-28 10:25 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #503 at `27b3cfd`
+**Sources**: 2 (Copilot R5 @ `27b3cfd`, prior Integrated Reviews @ `7174388` + `b41adbd`)
+**Cross-source confirmations**: 0
+**CI**: all-pass (Lint, Validate Documentation, commit identity)
+
+### Findings
+- [ ] (must-fix, Copilot R5) Usage section claims discovery via `gh` / `field_mode.sh` / filesystem, but field side has no `gh`. Qualify `gh` as dev-side-only; mention `issue_sync` for field side — `SKILL.md:14-16`
+- [ ] (must-fix, Copilot R5) `gh -R <owner/repo>` placeholder used across multiple steps, but the skill never explains how to derive `<owner/repo>` (not in `.agents/deployment.yaml`). Drop `-R` and rely on running `gh` from the project-repo CWD (cleanest), or add a derivation step. — `SKILL.md:181` and other `gh -R` callsites
+- [ ] (must-fix, Copilot R5) Step 4c "Resume ongoing" command `gh -R issue view` is incomplete — missing repo arg AND issue number. Same root cause as the previous finding. Complete to `gh issue view <N> --json title,url` — `SKILL.md:333`
+- [ ] (must-fix, Copilot R5) AGENTS.md overview says "either creates a new deployment, first-activates …, or resumes" but field-side cannot create (no GitHub access; stops with "start from dev first" message). Qualify "creates" as dev-side-only — `AGENTS.md:244-247`
+- [ ] (must-fix, Copilot R5) Template comment says omitting `issue_sync` "skips the sync step", but post-R4 fix `field_pull`/`field_list_open`/`field_show` are hard-required on field side. Clarify: omitting is dev-only-valid; field hosts must configure — `deployment_config.yaml:79-81`
+
+### Notes
+- Cohesive pattern across all 5 findings: the *prose* (Usage, AGENTS.md overview, template comment, incomplete commands) still leaks dev-side assumptions, while the procedure body was tightened by R3/R4. Suggests one focused pass to align the prose with the now-strict field-side gating.
+
+### False positives
+None.

--- a/.agent/work-plans/issue-501/progress.md
+++ b/.agent/work-plans/issue-501/progress.md
@@ -73,13 +73,13 @@ All 7 files from the amended plan landed:
 **CI**: all-pass (Lint, Validate Documentation, commit identity)
 
 ### Findings
-- [ ] (must-fix, Copilot R2) Broken relative link to `principles_review_guide.md` — resolves under `.agent/work-plans/issue-501/` not `.agent/`; use `../../knowledge/principles_review_guide.md` — `plan.md:30`
-- [ ] (must-fix, Copilot R3) `progress.md` H1 still has "+ activation marker" (matches issue title, which is still pending rename — coordinates with the open-question #1) — `progress.md:5`
-- [ ] (must-fix, Copilot R3) Vestigial schema-comment in template — "regardless of unit specified here" references a `units` field that was dropped in `e9a7e72`; reword to "always logged in metres" — `deployment_config.yaml:115`
-- [ ] (must-fix, Copilot R3) "(Claude Code)" parenthetical implies framework-specificity, but the concept is framework-agnostic (other adapter skill lists include `start-deployment`); drop or clarify — `AGENTS.md:238`
-- [ ] (must-fix, Copilot R3) `<workspace_root>` placeholder undefined in step 2 — specify discovery (walk up to `.agent/scripts/setup.bash` parent, or hardcode 5-level relative) — `SKILL.md:143`
-- [ ] (must-fix, Copilot R3) Step 4b instructs "log a warning to the host log" before the host log is initialized later in the same step; warnings dropped. Reorder to init log first, or print warnings in chat and defer write — `SKILL.md:235-246`
-- [ ] (suggestion, Copilot R2) Plan Review entry's `plan.md:<line>` refs point at pre-amendment line numbers; findings already resolved so it's archival, but future Plan Review entries should use section/heading anchors — `progress.md:67`
+- [x] (must-fix, Copilot R2) Broken relative link to `principles_review_guide.md` — `plan.md:30` **(resolved in `b41adbd`)**
+- [x] (must-fix, Copilot R3) `progress.md` H1 still has "+ activation marker" — `progress.md:5` **(resolved in `b41adbd` — issue renamed + H1 synced)**
+- [x] (must-fix, Copilot R3) Vestigial schema-comment in template — `deployment_config.yaml:115` **(resolved in `b41adbd`)**
+- [x] (must-fix, Copilot R3) "(Claude Code)" parenthetical — `AGENTS.md:238` **(addressed in `b41adbd`; new R4 finding C3 introduced by the fix — see R4 entry below)**
+- [x] (must-fix, Copilot R3) `<workspace_root>` placeholder undefined — `SKILL.md:143` **(resolved in `b41adbd` — discovery defined)**
+- [x] (must-fix, Copilot R3) Step 4b log-init ordering — `SKILL.md:235-246` **(resolved in `b41adbd` — reordered)**
+- [ ] (suggestion, Copilot R2) Plan Review entry's `plan.md:<line>` refs stale — `progress.md:67` (intentional skip — archival)
 
 ### Addressed by subsequent commits (no action needed)
 - (Copilot R1, `plan.md:8`) Plan H1 stale phrase — renamed in `b909c6f`
@@ -98,3 +98,21 @@ None.
 - Scope sizing is right (3 files, ~300–400 lines, SKILL.md as load-bearing artifact).
 - Plan matches the locked design comment item-for-item on substance (no marker, three-state detection, side-detection via `field_mode.sh`, pluggable `issue_sync`, dev-only tides in metres + explicit TZ, urgency contract embedded, ensure-essentials limited to `## Logs`).
 - Independence caveat: the original plan author and this skill's invoking agent are the same identity (Claude Code Agent / Claude Opus 4.7 (1M context)). Evaluation was delegated to a fresh-context sub-agent to mitigate; downstream consumers should weight accordingly.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-05-28 10:00 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #503 at `b41adbd`
+**Sources**: 2 (Copilot R4 @ `b41adbd`, prior Integrated Review @ `7174388`)
+**Cross-source confirmations**: 0
+**CI**: all-pass (Lint, Validate Documentation, commit identity)
+
+### Findings
+- [ ] (must-fix, Copilot R4) Worktree scripts use CWD-relative `.agent/scripts/worktree_create.sh` paths, but step 2's workspace-root discovery means CWD may be inside a project repo where `.agent/scripts/` doesn't exist. Prefix consistently with `<workspace_root>/` — `SKILL.md:244-250`
+- [ ] (must-fix, Copilot R4) "Claude-Code-native" hyphenated — repo convention is "Claude Code" (with space, no hyphen). Regression from R3 C3 fix. — `AGENTS.md:241`
+- [ ] (must-fix, Copilot R4) Field-side three-state detection relies on `issue_sync.field_list_open`, but absent-`issue_sync` warning text only mentions skipping the *sync* step. Without `field_list_open` the skill literally cannot list issues on field side. Make `field_list_open` + `field_show` hard-required on field side; stop with explicit error if absent (dev side can still treat `issue_sync` as fully optional). — `SKILL.md:182-188`
+
+### False positives
+- (Copilot R4, `plan.md:30`) Claimed `../../knowledge/principles_review_guide.md` resolves under `.agent/work-plans/knowledge/`, suggested `../../../knowledge/...`. Verified by `ls` from `.agent/work-plans/issue-501/`: `../../knowledge/principles_review_guide.md` resolves to `.agent/knowledge/principles_review_guide.md` (file exists). Copilot's suggested `../../../knowledge/...` would resolve to `<repo-root>/knowledge/` (does not exist). The R3-round fix is correct; this is a directory-level miscalculation by the bot.

--- a/.agent/work-plans/issue-501/progress.md
+++ b/.agent/work-plans/issue-501/progress.md
@@ -61,6 +61,33 @@ All 7 files from the amended plan landed:
   - `.agents/deployment.yaml` — BizzyBoat config populating the schema
   - `docs/logs/README.md` — shrink to BizzyBoat-specific overrides; point at workspace docs + skill
 - ADR-0014 status flip from Proposed → Accepted after the first deployment uses `/start-deployment` (post-deployment task).
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-05-28 09:35 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #503 at `7174388`
+**Sources**: 4 (Copilot R1 @ `2985882`, Copilot R2 @ `2fcd2d2`, Copilot R3 @ `7174388`, Plan Review @ `bb9f40e`)
+**Cross-source confirmations**: 0 at the same head SHA. Substantive overlap (not strict cross-confirm): the Plan Review's H1-rename finding and Copilot R1 C1 + R3 C1 all surface the same stale "+ activation marker" phrase — flagged at different correlation keys (plan SHA vs head SHA vs progress.md H1), but the issue-rename unblocks them all.
+**CI**: all-pass (Lint, Validate Documentation, commit identity)
+
+### Findings
+- [ ] (must-fix, Copilot R2) Broken relative link to `principles_review_guide.md` — resolves under `.agent/work-plans/issue-501/` not `.agent/`; use `../../knowledge/principles_review_guide.md` — `plan.md:30`
+- [ ] (must-fix, Copilot R3) `progress.md` H1 still has "+ activation marker" (matches issue title, which is still pending rename — coordinates with the open-question #1) — `progress.md:5`
+- [ ] (must-fix, Copilot R3) Vestigial schema-comment in template — "regardless of unit specified here" references a `units` field that was dropped in `e9a7e72`; reword to "always logged in metres" — `deployment_config.yaml:115`
+- [ ] (must-fix, Copilot R3) "(Claude Code)" parenthetical implies framework-specificity, but the concept is framework-agnostic (other adapter skill lists include `start-deployment`); drop or clarify — `AGENTS.md:238`
+- [ ] (must-fix, Copilot R3) `<workspace_root>` placeholder undefined in step 2 — specify discovery (walk up to `.agent/scripts/setup.bash` parent, or hardcode 5-level relative) — `SKILL.md:143`
+- [ ] (must-fix, Copilot R3) Step 4b instructs "log a warning to the host log" before the host log is initialized later in the same step; warnings dropped. Reorder to init log first, or print warnings in chat and defer write — `SKILL.md:235-246`
+- [ ] (suggestion, Copilot R2) Plan Review entry's `plan.md:<line>` refs point at pre-amendment line numbers; findings already resolved so it's archival, but future Plan Review entries should use section/heading anchors — `progress.md:67`
+
+### Addressed by subsequent commits (no action needed)
+- (Copilot R1, `plan.md:8`) Plan H1 stale phrase — renamed in `b909c6f`
+- (Copilot R1, `plan.md:13`) Plan-only PR vs "ships first lifecycle tool" framing — PR is no longer plan-only; implementation landed in `d1582f7`/`0b9abce`/`e9a7e72`
+- (Copilot R2, `progress.md:18`) "Adapter skill-list updates" ambiguous tense — implementation landed; past tense is now accurate
+
+### False positives
+None.
 - [ ] (must-fix) Non-Claude adapter skill lists missing from Consequences — `principles_review_guide.md` Consequences Map requires updating `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, and `.agent/AGENT_ONBOARDING.md` skill inventories when a workflow skill is added. Add to Files to Change for this PR; don't defer. — `plan.md:23-28` (Files to Change), `plan.md:53-58` (Consequences)
 - [ ] (suggestion) ADR-0004 / "Enforcement over documentation" not in Principles Self-Check — v1 lands at instruction tier only (SKILL.md + knowledge doc), which is defensible but should be stated. Add a row noting hook-based auto-injection is tracked as fast-follow under #495. — `plan.md:30-39`
 - [ ] (suggestion) Plan file H1 still reads "+ activation marker" — rename to drop the stale phrase; the issue rename is the operator's call but the plan file's title is the author's. — `plan.md:1`

--- a/.claude/skills/start-deployment/SKILL.md
+++ b/.claude/skills/start-deployment/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: start-deployment
+description: Activate deployment mode for a live field deployment. Discovers the project's deployment config, detects dev/field side via field_mode.sh, and either creates a new deployment, first-activates an existing one (worktree/main-tree + per-host log + issue-sync push), or resumes an ongoing one. Loads the urgency contract (sterile-cockpit / mitigate-before-diagnose / time-box) into the current agent session.
+---
+
+# Start Deployment
+
+## Usage
+
+```
+/start-deployment
+```
+
+No arguments. The skill discovers everything it needs from the current
+working directory's project config plus `gh` / `field_mode.sh` / the
+project repo's filesystem.
+
+## Overview
+
+Activate **deployment mode** ([ADR-0014](../../../docs/decisions/0014-deployment-mode.md))
+in the current agent session for a live field deployment of an autonomous
+robot boat. Operationally: collapse the manual deployment-start steps
+(open issue, create worktree, seed log, push to field share) into one
+command, and put the urgency contract in this session's context so the
+agent stays fast and operator-responsive during live ops.
+
+**Lifecycle position**: [0] start (this skill) → [1] session → [2] recovery → [3] wrap-up → [4] next
+
+**Activation is per-agent-session.** Other agent sessions on the same
+host are NOT affected. No filesystem marker, no host-wide hook. On-disk
+evidence of an ongoing deployment is the open `deployment`-labeled issue
+plus the worktree (dev) or host log file (field) that already exist
+naturally — see the three-state detection in step 4.
+
+The fuller operational reference is
+[`.agent/knowledge/deployment_mode.md`](../../../.agent/knowledge/deployment_mode.md).
+If this SKILL.md and the knowledge doc drift on the urgency-contract
+wording, **this file wins** — it's what's in context when the skill runs.
+
+## The Urgency Contract
+
+You are now operating under the deployment-mode urgency contract. These
+rules apply for the rest of this agent session (until the operator
+explicitly invokes the wrap-up flow or activates a different mode).
+
+1. **You are an assistant, not an investigator.** During live ops the
+   operator is running the boat; your job is to make the operator
+   faster, not to pursue an investigation independently.
+2. **Mitigate before diagnose.** Stabilize the symptom now — turn down a
+   rate, swap a topic, restart a node — and defer root-cause analysis to
+   wrap-up. A live deployment is not a debugging session.
+3. **Time-box / confidence handoff.** If a path is taking more than ~1–2
+   minutes or your confidence is low, stop, summarize what you've
+   checked and what you'd try next, and hand back to the operator.
+   Don't spiral.
+4. **Append, don't commit.** Batch commits at natural breakpoints
+   (between runs, at recovery). Each commit is a permission prompt and
+   a context switch; live ops absorb neither well.
+5. **Overlog rather than underlog.** Appending to a log file is
+   near-zero cost. Commits are what cause the prompts. Capture
+   observations liberally; sort them out at wrap-up.
+6. **Avoid permission prompts.** Use `git -C <path>`, absolute paths,
+   `gh -R`, and the file tools over heredocs / find / cat. The
+   allowlist defeats itself when commands are wrapped in `cd && …`.
+   Timestamps: `date '+%Y-%m-%d %H:%M %:z'`, never `date | sed`.
+7. **Sterile cockpit.** During live on-water ops, do *only*
+   operation-essential work — no doc polish, refactors, or "while we're
+   here" cleanups. Write them down for wrap-up.
+8. **Tides / weather / currents are dev-only.** Field hosts skip
+   pre-flight data entirely. Dev sessions ingest them (after asking the
+   operator) and log them in the dev-side log's per-day `## Pre-flight`
+   section.
+9. **Suggestions are conversation, not log entries.** "What if we tried
+   X?" stays in chat unless the operator decides to act on it. The log
+   records what *happened*, not what was proposed.
+10. **Operator notes are quotes plus factual context only.** No invented
+    mechanisms. If the operator says "felt sluggish," log the quote and
+    the nearest objective measurement; don't extrapolate to "thrust
+    loss."
+11. **No self-imposed hard gates.** Don't write "⛔ Mandatory" /
+    "sim-verify required before…" into issues or PRs during live ops.
+    Risk-acceptance gates are the operator's call.
+
+The contract is **phase-aware**. Sterile-cockpit bites hardest during
+live ops [1] and **relaxes at wrap-up [3]**, where deep analysis is the
+expected work.
+
+**Invariants the contract does NOT relax**: safety-critical correctness
+(boat control, collision avoidance), pre-commit hooks, AI signature,
+atomic commits, no secrets, no destructive ops without operator
+approval. *Defer is not skip* — deferred RCA / tests / docs go on the
+wrap-up checklist, follow-up issues, or the roadmap.
+
+## Steps
+
+### 1. Read the project config
+
+The skill runs against a project repo. Locate `<project_repo>/.agents/deployment.yaml`:
+
+- If the current working directory is inside a project repo, the config
+  is at `<repo_root>/.agents/deployment.yaml`.
+- If the current working directory is the workspace root, ask the
+  operator which platform's deployment is starting and look up the
+  project repo from the user response (only one platform is typically
+  active at a time).
+
+If the config file is missing, stop with:
+
+> `<project_repo>/.agents/deployment.yaml` not found. See
+> `.agent/templates/deployment_config.yaml` for the template, and
+> `.agent/knowledge/deployment_mode.md` for the schema.
+
+Read the config and extract: `platform`, `default_branch`, `layer`,
+`packages`, `labels`, `log_dir`, `issue_sync` (optional), `tides` /
+`currents` / `weather` (optional).
+
+### 2. Detect side (dev vs field)
+
+Run `field_mode.sh` against the project repo's path:
+
+```bash
+.agent/scripts/field_mode.sh --describe layers/main/<layer>_ws/src/<packages[0]>
+```
+
+- **Dev side**: origin on the GitHub allowlist → worktree + draft PR flow.
+- **Field side**: origin not on the GitHub allowlist → direct-commit to
+  default branch per [ADR-0011](../../../docs/decisions/0011-field-mode-for-non-github-origins.md).
+
+Record the side; it branches several steps below.
+
+### 3. Determine the per-host log label
+
+- **Dev side**: label is the literal string `dev` (regardless of
+  hostname), so wrap-up tooling can reliably find the dev log.
+- **Field side**: label is `$(hostname -s)` (short hostname).
+
+Log filename is `<log_dir>/<YYYY>/<YYYY-MM-DD>_<label>_logs.md`. The
+date is the deployment **start** date, NOT today's date if resuming a
+multi-day deployment — step 4 picks the right date from the existing
+deployment issue.
+
+### 4. Three-state detection
+
+Probe for an open `deployment`-labeled issue in the project repo, then
+for local artifacts that indicate first-activation vs resume.
+
+**Issue lookup** depends on side:
+
+- **Dev side**: `gh -R <owner/repo> issue list --label deployment --state open --json number,title,createdAt,body`
+- **Field side**: run the configured `issue_sync.field_pull` first,
+  then `issue_sync.field_list_open`. If `issue_sync` is absent, skip
+  the sync step and warn:
+  > No `issue_sync` configured in `.agents/deployment.yaml`. The skill
+  > can't refresh the field share's view of issues. If this host
+  > already has a recent copy, the local view will be used; otherwise,
+  > ensure all hosts see the deployment issue by other means.
+
+Then branch on state:
+
+| State | Evidence | Action (this step) |
+|---|---|---|
+| **Create new** | No open deployment issue | Step 4a |
+| **Activate first time** | Issue exists, no local worktree (dev) / no host log (field) | Step 4b |
+| **Resume ongoing** | Issue exists + worktree+log (dev) / log file (field) | Step 4c |
+
+If multiple open deployment issues are found, list them and ask the
+operator which one this session is joining.
+
+#### 4a. Create new
+
+Ask the operator for the scope of this deployment (one or two sentences;
+this becomes the issue title's `<scope>` portion and the body's first
+paragraph). Confirm before creating.
+
+Open the deployment issue with `gh -R <owner/repo> issue create`:
+
+- **Title**: `Deployment <YYYY-MM-DD>: <scope>` (today's date).
+- **Labels**: from `labels` in the project config.
+- **Body**: minimal template — `## Purpose` (scope sentence), `## Hosts
+  in use` (placeholder), `## Logs` (empty section the skill will stamp
+  links into), AI signature.
+
+Then proceed to step 4b's first-activation flow against the just-created
+issue.
+
+#### 4b. Activate first time
+
+**Verify the issue title**: if it's not already in
+`Deployment <YYYY-MM-DD>: <scope>` format, ask the operator to confirm
+the deployment-start date (default: the issue's `createdAt` date in the
+operator's TZ), then update the title via `gh issue edit`.
+
+**Ensure essentials on the body** — only:
+
+- Append a `## Logs` section if absent (the skill will stamp per-host
+  log file links into this section as they appear).
+- If the body is suspiciously empty (no operator-authored sections),
+  warn but do NOT impose structure. Operator-authored sections
+  (Purpose, Must-verify, Operators, Hosts in use, Notes) are left
+  untouched.
+
+**Create the worktree (dev side only)**:
+
+```bash
+.agent/scripts/worktree_create.sh \
+    --issue <N> \
+    --type layer \
+    --layer <layer> \
+    --packages <packages,comma-separated>
+```
+
+Then `source .agent/scripts/worktree_enter.sh --issue <N>`.
+
+Field side: ensure the project repo is on its default branch
+(`<default_branch>` from the config) and the tree is clean. Do NOT
+create a worktree.
+
+**Initialize the per-host log file**:
+
+```bash
+<project_repo>/<log_dir>/<YYYY>/<YYYY-MM-DD>_<label>_logs.md
+```
+
+(Create the `<YYYY>` parent dir if missing.) Seed with a minimal header:
+
+```markdown
+# <YYYY-MM-DD> — <label> log (<platform> deployment #<N>)
+
+Deployment issue: <issue URL>
+Host: <hostname>
+Side: <dev|field>
+Started: <YYYY-MM-DD HH:MM ±HH:MM>
+```
+
+Stamp a link to this log file in the issue body's `## Logs` section
+(`<log_dir>/<YYYY>/<YYYY-MM-DD>_<label>_logs.md` relative to the project
+repo).
+
+**Run `issue_sync.dev_push` (dev side, if configured)** to propagate
+the issue title / body / label changes to the field-visible source.
+On failure, print `issue_sync.failure_hint`.
+
+Proceed to step 5 (dev pre-flight) if dev side; otherwise the skill is
+done.
+
+#### 4c. Resume ongoing
+
+Re-attach this session to the existing deployment. No artifacts created.
+
+- Print the deployment issue's URL and title.
+- Print the current host's log file path.
+- Read the last ~20 entries of the current host's log and summarize them
+  in chat so the operator can confirm context.
+- The urgency contract above is already loaded. Confirm to the operator
+  that this session is now in deployment mode.
+
+Skip step 5 (no new pre-flight on resume).
+
+### 5. Dev pre-flight (dev side only, first-activation only)
+
+Ask the operator: *"Pulling pre-flight tides / currents / weather for
+today's session — proceed, or skip?"*
+
+- If the operator wants to enter them manually, skip the fetches; they
+  log it themselves.
+- If the operator defers ("you do it"), fetch using the defaults in the
+  config's `tides` / `currents` / `weather` sections.
+
+Log results in the dev log under a per-day `## Pre-flight` section
+(today's date as the day header inside the file):
+
+- **Tide heights in metres.**
+- **Tide times with explicit TZ in both local and UTC**, e.g.
+  `L 04:23 EDT (08:23 UTC)`.
+- **Currents and winds in conventional marine units** (knots, nm).
+- **Temperatures as the source gives them** — don't convert.
+- **Preserve source-station identifiers** (NOAA / NDBC) so the data is
+  reproducible.
+
+The pre-flight section goes in the **dev log**, never the issue body.
+
+## Guidelines
+
+- **The urgency contract is the load-bearing part of this skill.** The
+  artifact creation matters, but the contract is what changes how the
+  rest of the session behaves. Re-read it if you find yourself
+  spiraling.
+- **One platform at a time.** The skill assumes a single active
+  deployment per project repo. If a project ever needs concurrent
+  multi-deployment, that's a redesign, not a parameter.
+- **Don't impose structure on the operator's issue body.** Ensure the
+  `## Logs` section exists; leave everything else alone.
+- **Field-side has no GitHub.** Every GitHub call (`gh issue …`,
+  `gh pr …`) is gated on dev-side detection. Field-side uses
+  `issue_sync` commands instead.
+- **Multi-day deployments keep the original date.** The filename's date
+  is the deployment **start**, not the date of any given session. Per-day
+  sections inside the log use `## <YYYY-MM-DD>` headers.
+- **Wrap-up is a separate skill.** Don't try to close the deployment
+  issue from here. `/wrap-up-deployment` (tracked under [#495](https://github.com/rolker/ros2_agent_workspace/issues/495))
+  owns the wrap-up procedure.
+
+## References
+
+- [ADR-0014](../../../docs/decisions/0014-deployment-mode.md) — decision record
+- [ADR-0011](../../../docs/decisions/0011-field-mode-for-non-github-origins.md) — sibling mode (`field_mode.sh` is the side-detection authority)
+- [ADR-0003](../../../docs/decisions/0003-workspace-infrastructure-is-project-agnostic.md) — three-tier content split (this skill is generic; all project specifics in `.agents/deployment.yaml`)
+- [`.agent/knowledge/deployment_mode.md`](../../../.agent/knowledge/deployment_mode.md) — operational reference (fuller treatment of contract, lifecycle, schema)
+- [`.agent/templates/deployment_config.yaml`](../../../.agent/templates/deployment_config.yaml) — per-project config template
+- [#495](https://github.com/rolker/ros2_agent_workspace/issues/495) — umbrella for the full deployment lifecycle (wrap-up / next-deployment / recovery skills tracked there)
+- [#501](https://github.com/rolker/ros2_agent_workspace/issues/501) — v1 implementation

--- a/.claude/skills/start-deployment/SKILL.md
+++ b/.claude/skills/start-deployment/SKILL.md
@@ -114,13 +114,36 @@ Read the config and extract: `platform`, `default_branch`, `layer`,
 `packages`, `labels`, `log_dir`, `issue_sync` (optional), `tides` /
 `currents` / `weather` (optional).
 
+**Validation**: if any required value is the literal string `TODO`
+(or empty / null where required), stop with:
+
+> `<key>` is unconfigured in `<project_repo>/.agents/deployment.yaml` —
+> fill in before running `/start-deployment`. See
+> `.agent/templates/deployment_config.yaml` for the schema.
+
+Required keys: `platform`, `default_branch`, `layer`, `packages[0]`,
+`log_dir`. (`issue_sync` and the pre-flight sections are optional;
+absent values disable their respective steps.) This is a hard stop —
+half-filled configs cause silent failures mid-procedure (the skill
+would otherwise build paths like `layers/main/TODO_ws/src/TODO/`).
+
 ### 2. Detect side (dev vs field)
 
-Run `field_mode.sh` against the project repo's path:
+Run `field_mode.sh` against the project repo's path. The script lives at
+the workspace root and is not on `PATH` — invoke by explicit path. Pick
+whichever form matches the current working directory:
 
 ```bash
+# Form A — when CWD is the workspace root, pass the repo path:
 .agent/scripts/field_mode.sh --describe layers/main/<layer>_ws/src/<packages[0]>
+
+# Form B — when CWD is already inside the project repo, reference the
+# script via the workspace root and pass no path (defaults to $PWD):
+<workspace_root>/.agent/scripts/field_mode.sh --describe
 ```
+
+The repo identity comes from the origin URL either way; only the
+relative path plumbing differs.
 
 - **Dev side**: origin on the GitHub allowlist → worktree + draft PR flow.
 - **Field side**: origin not on the GitHub allowlist → direct-commit to
@@ -168,9 +191,16 @@ operator which one this session is joining.
 
 #### 4a. Create new
 
-Ask the operator for the scope of this deployment (one or two sentences;
-this becomes the issue title's `<scope>` portion and the body's first
-paragraph). Confirm before creating.
+**Field side**: cannot create the issue (no GitHub access). Stop with:
+
+> No open deployment issue found via `issue_sync`. Start the deployment
+> from a dev host first (where `gh` can create the issue and configure
+> labels), then run `issue_sync.dev_push` so this field host sees it on
+> the next `issue_sync.field_pull`.
+
+**Dev side**: ask the operator for the scope of this deployment (one or
+two sentences; this becomes the issue title's `<scope>` portion and the
+body's first paragraph). Confirm before creating.
 
 Open the deployment issue with `gh -R <owner/repo> issue create`:
 
@@ -185,35 +215,53 @@ issue.
 
 #### 4b. Activate first time
 
-**Verify the issue title**: if it's not already in
-`Deployment <YYYY-MM-DD>: <scope>` format, ask the operator to confirm
-the deployment-start date (default: the issue's `createdAt` date in the
-operator's TZ), then update the title via `gh issue edit`.
+This step has two branches — dev-side edits the canonical issue,
+field-side reads it and warns on drift. The locked design's intended
+order is **dev-first-then-field**: the operator runs `/start-deployment`
+on dev first (where rename / body edits happen and `dev_push`
+propagates them), then on each field host as those come online.
 
-**Ensure essentials on the body** — only:
+**On both sides — read the issue body** to drive the state checks below.
 
-- Append a `## Logs` section if absent (the skill will stamp per-host
-  log file links into this section as they appear).
-- If the body is suspiciously empty (no operator-authored sections),
-  warn but do NOT impose structure. Operator-authored sections
-  (Purpose, Must-verify, Operators, Hosts in use, Notes) are left
-  untouched.
+- Dev: `gh -R <owner/repo> issue view <N> --json title,body,createdAt`
+- Field: `issue_sync.field_show` with `{id}` substituted for `<N>`.
 
-**Create the worktree (dev side only)**:
+**Verify the issue title** (form: `Deployment <YYYY-MM-DD>: <scope>`):
 
-```bash
-.agent/scripts/worktree_create.sh \
-    --issue <N> \
-    --type layer \
-    --layer <layer> \
-    --packages <packages,comma-separated>
-```
+- **Dev side**: if not already in that form, ask the operator to
+  confirm the deployment-start date (default: the issue's `createdAt`
+  date in the operator's TZ), then update the title via
+  `gh -R <owner/repo> issue edit <N> --title "..."`.
+- **Field side**: if not already in that form, log a warning to the
+  host log: *"Deployment issue title not in canonical form; run
+  `/start-deployment` from dev first to rename + push."* Do not edit
+  on field side — `issue_sync` has no edit verb, and edits would
+  diverge from dev's view.
 
-Then `source .agent/scripts/worktree_enter.sh --issue <N>`.
+**Ensure essentials on the body** (only the `## Logs` section is
+managed; everything else is operator-authored and untouched):
 
-Field side: ensure the project repo is on its default branch
-(`<default_branch>` from the config) and the tree is clean. Do NOT
-create a worktree.
+- **Dev side**: append a `## Logs` section if absent.
+- **Field side**: read-only — if `## Logs` is absent, log the same
+  "rename + push from dev" warning to the host log; do not edit.
+- If the body is suspiciously empty on either side (no operator-authored
+  sections), warn but do NOT impose structure.
+
+**Create the worktree / prepare main-tree** — branch on side:
+
+- **Dev side**: create the worktree:
+  ```bash
+  .agent/scripts/worktree_create.sh \
+      --issue <N> \
+      --type layer \
+      --layer <layer> \
+      --packages <packages,comma-separated>
+  ```
+  Then `source .agent/scripts/worktree_enter.sh --issue <N>`.
+- **Field side**: ensure the project repo is on its default branch
+  (`<default_branch>` from the config) and the tree is clean. Do NOT
+  create a worktree (per [ADR-0011](../../../docs/decisions/0011-field-mode-for-non-github-origins.md),
+  field-mode repos edit and commit on the default branch).
 
 **Initialize the per-host log file**:
 
@@ -232,13 +280,22 @@ Side: <dev|field>
 Started: <YYYY-MM-DD HH:MM ±HH:MM>
 ```
 
-Stamp a link to this log file in the issue body's `## Logs` section
-(`<log_dir>/<YYYY>/<YYYY-MM-DD>_<label>_logs.md` relative to the project
-repo).
+**Stamp the log file link in the issue body's `## Logs` section** —
+branch on side:
 
-**Run `issue_sync.dev_push` (dev side, if configured)** to propagate
-the issue title / body / label changes to the field-visible source.
-On failure, print `issue_sync.failure_hint`.
+- **Dev side**: edit the issue body via `gh -R <owner/repo> issue edit
+  <N> --body-file <tmpfile>` to add a line under `## Logs`:
+  `- [<label> log](<log_dir>/<YYYY>/<YYYY-MM-DD>_<label>_logs.md)`.
+- **Field side**: do not edit. Log the new log file's path to the host
+  log itself with a note: *"Stamp this link under the deployment
+  issue's `## Logs` section from dev next time `/start-deployment`
+  runs there."* Dev's next invocation reads the field log directory
+  and can add missing entries.
+
+**Run `issue_sync.dev_push` (dev side only, if configured)** to
+propagate the title / body changes to the field-visible source. Skip
+silently on field side (the field host is the consumer of the share,
+not a producer). On failure, print `issue_sync.failure_hint`.
 
 Proceed to step 5 (dev pre-flight) if dev side; otherwise the skill is
 done.
@@ -247,7 +304,8 @@ done.
 
 Re-attach this session to the existing deployment. No artifacts created.
 
-- Print the deployment issue's URL and title.
+- Print the deployment issue's URL and title (dev: `gh -R issue view`;
+  field: `issue_sync.field_show {N}`).
 - Print the current host's log file path.
 - Read the last ~20 entries of the current host's log and summarize them
   in chat so the operator can confirm context.

--- a/.claude/skills/start-deployment/SKILL.md
+++ b/.claude/skills/start-deployment/SKILL.md
@@ -12,8 +12,12 @@ description: Activate deployment mode for a live field deployment. Discovers the
 ```
 
 No arguments. The skill discovers everything it needs from the current
-working directory's project config plus `gh` / `field_mode.sh` / the
-project repo's filesystem.
+working directory's project config plus `field_mode.sh` and the project
+repo's filesystem. On **dev side**, it additionally uses `gh` (running
+inside the project repo, so origin auto-detection picks the right
+remote). On **field side**, there is no `gh` access — all issue
+discovery and reads go through the configured `issue_sync` commands
+instead.
 
 ## Overview
 
@@ -176,9 +180,12 @@ deployment issue.
 Probe for an open `deployment`-labeled issue in the project repo, then
 for local artifacts that indicate first-activation vs resume.
 
-**Issue lookup** depends on side:
+**Issue lookup** depends on side. **All dev-side `gh` calls in this and
+subsequent steps run from inside the project repo** (main tree before
+step 4b's worktree creation, worktree after); `gh` auto-detects the
+correct remote from `origin`, so no `-R <owner/repo>` flag is needed.
 
-- **Dev side**: `gh -R <owner/repo> issue list --label deployment --state open --json number,title,createdAt,body`. `issue_sync` is fully
+- **Dev side**: `gh issue list --label deployment --state open --json number,title,createdAt,body`. `issue_sync` is fully
   optional here — `gh` alone handles discovery, listing, and editing.
 - **Field side**: run the configured `issue_sync.field_pull` first
   (refreshes the local view), then `issue_sync.field_list_open` (lists
@@ -218,7 +225,8 @@ operator which one this session is joining.
 two sentences; this becomes the issue title's `<scope>` portion and the
 body's first paragraph). Confirm before creating.
 
-Open the deployment issue with `gh -R <owner/repo> issue create`:
+Open the deployment issue with `gh issue create` (run from inside the
+project repo's main tree — `gh` auto-detects the remote):
 
 - **Title**: `Deployment <YYYY-MM-DD>: <scope>` (today's date).
 - **Labels**: from `labels` in the project config.
@@ -239,7 +247,7 @@ propagates them), then on each field host as those come online.
 
 **On both sides — read the issue body** to drive the state checks below.
 
-- Dev: `gh -R <owner/repo> issue view <N> --json title,body,createdAt`
+- Dev: `gh issue view <N> --json title,body,createdAt`
 - Field: `issue_sync.field_show` with `{id}` substituted for `<N>`.
 
 **Create the worktree / prepare main-tree** — branch on side. This is
@@ -288,7 +296,7 @@ also appends here for parity.
 - **Dev side**: if not already in that form, ask the operator to
   confirm the deployment-start date (default: the issue's `createdAt`
   date in the operator's TZ), then update the title via
-  `gh -R <owner/repo> issue edit <N> --title "..."`.
+  `gh issue edit <N> --title "..."`.
 - **Field side**: if not already in that form, append a warning to the
   per-host log file (initialized above): *"Deployment issue title not
   in canonical form; run `/start-deployment` from dev first to rename
@@ -308,8 +316,8 @@ managed; everything else is operator-authored and untouched):
 **Stamp the log file link in the issue body's `## Logs` section** —
 branch on side:
 
-- **Dev side**: edit the issue body via `gh -R <owner/repo> issue edit
-  <N> --body-file <tmpfile>` to add a line under `## Logs`:
+- **Dev side**: edit the issue body via `gh issue edit <N> --body-file <tmpfile>`
+  to add a line under `## Logs`:
   `- [<label> log](<log_dir>/<YYYY>/<YYYY-MM-DD>_<label>_logs.md)`.
 - **Field side**: do not edit. Log the new log file's path to the host
   log itself with a note: *"Stamp this link under the deployment
@@ -329,8 +337,8 @@ done.
 
 Re-attach this session to the existing deployment. No artifacts created.
 
-- Print the deployment issue's URL and title (dev: `gh -R issue view`;
-  field: `issue_sync.field_show {N}`).
+- Print the deployment issue's URL and title (dev: `gh issue view <N> --json title,url`;
+  field: `issue_sync.field_show` with `{id}` substituted for `<N>`).
 - Print the current host's log file path.
 - Read the last ~20 entries of the current host's log and summarize them
   in chat so the operator can confirm context.

--- a/.claude/skills/start-deployment/SKILL.md
+++ b/.claude/skills/start-deployment/SKILL.md
@@ -178,14 +178,21 @@ for local artifacts that indicate first-activation vs resume.
 
 **Issue lookup** depends on side:
 
-- **Dev side**: `gh -R <owner/repo> issue list --label deployment --state open --json number,title,createdAt,body`
-- **Field side**: run the configured `issue_sync.field_pull` first,
-  then `issue_sync.field_list_open`. If `issue_sync` is absent, skip
-  the sync step and warn:
-  > No `issue_sync` configured in `.agents/deployment.yaml`. The skill
-  > can't refresh the field share's view of issues. If this host
-  > already has a recent copy, the local view will be used; otherwise,
-  > ensure all hosts see the deployment issue by other means.
+- **Dev side**: `gh -R <owner/repo> issue list --label deployment --state open --json number,title,createdAt,body`. `issue_sync` is fully
+  optional here — `gh` alone handles discovery, listing, and editing.
+- **Field side**: run the configured `issue_sync.field_pull` first
+  (refreshes the local view), then `issue_sync.field_list_open` (lists
+  open deployment issues), and `issue_sync.field_show` (used later in
+  step 4b to read each issue's body). These three commands are
+  **hard-required on field side** — without them the skill has no way
+  to discover or read deployment issues (there is no `gh` fallback).
+  If any of `issue_sync.field_pull` / `field_list_open` / `field_show`
+  is missing from `.agents/deployment.yaml`, stop with:
+  > Field-side `/start-deployment` requires `issue_sync.field_pull`,
+  > `field_list_open`, and `field_show` in `.agents/deployment.yaml`
+  > (no `gh` access on field hosts). Configure them — see
+  > `.agent/templates/deployment_config.yaml` for examples — then
+  > re-invoke.
 
 Then branch on state:
 
@@ -239,15 +246,17 @@ propagates them), then on each field host as those come online.
 done *before* the title/body checks so the per-host log (initialized
 next) exists by the time any warnings need to land in it.
 
-- **Dev side**: create the worktree:
+- **Dev side**: create the worktree, using the workspace-root prefix
+  discovered in step 2 (the skill may be running from inside the
+  project repo, where `.agent/scripts/` does not exist):
   ```bash
-  .agent/scripts/worktree_create.sh \
+  <workspace_root>/.agent/scripts/worktree_create.sh \
       --issue <N> \
       --type layer \
       --layer <layer> \
       --packages <packages,comma-separated>
   ```
-  Then `source .agent/scripts/worktree_enter.sh --issue <N>`.
+  Then `source <workspace_root>/.agent/scripts/worktree_enter.sh --issue <N>`.
 - **Field side**: ensure the project repo is on its default branch
   (`<default_branch>` from the config) and the tree is clean. Do NOT
   create a worktree (per [ADR-0011](../../../docs/decisions/0011-field-mode-for-non-github-origins.md),

--- a/.claude/skills/start-deployment/SKILL.md
+++ b/.claude/skills/start-deployment/SKILL.md
@@ -130,15 +130,24 @@ would otherwise build paths like `layers/main/TODO_ws/src/TODO/`).
 ### 2. Detect side (dev vs field)
 
 Run `field_mode.sh` against the project repo's path. The script lives at
-the workspace root and is not on `PATH` — invoke by explicit path. Pick
-whichever form matches the current working directory:
+the workspace root and is not on `PATH` — invoke by explicit path.
+
+**Discovering the workspace root**: walk up from `$PWD` until a directory
+is found that contains `.agent/scripts/setup.bash` (the canonical marker
+for the workspace root). For the standard layer structure, a project
+repo at `layers/main/<layer>_ws/src/<repo>/` is exactly 5 levels below
+the workspace root (`../../../../../`), but don't hardcode — projects
+may reorganize.
+
+Then pick whichever form matches the current working directory:
 
 ```bash
 # Form A — when CWD is the workspace root, pass the repo path:
 .agent/scripts/field_mode.sh --describe layers/main/<layer>_ws/src/<packages[0]>
 
 # Form B — when CWD is already inside the project repo, reference the
-# script via the workspace root and pass no path (defaults to $PWD):
+# script via the discovered workspace root and pass no path (defaults
+# to $PWD):
 <workspace_root>/.agent/scripts/field_mode.sh --describe
 ```
 
@@ -226,28 +235,9 @@ propagates them), then on each field host as those come online.
 - Dev: `gh -R <owner/repo> issue view <N> --json title,body,createdAt`
 - Field: `issue_sync.field_show` with `{id}` substituted for `<N>`.
 
-**Verify the issue title** (form: `Deployment <YYYY-MM-DD>: <scope>`):
-
-- **Dev side**: if not already in that form, ask the operator to
-  confirm the deployment-start date (default: the issue's `createdAt`
-  date in the operator's TZ), then update the title via
-  `gh -R <owner/repo> issue edit <N> --title "..."`.
-- **Field side**: if not already in that form, log a warning to the
-  host log: *"Deployment issue title not in canonical form; run
-  `/start-deployment` from dev first to rename + push."* Do not edit
-  on field side — `issue_sync` has no edit verb, and edits would
-  diverge from dev's view.
-
-**Ensure essentials on the body** (only the `## Logs` section is
-managed; everything else is operator-authored and untouched):
-
-- **Dev side**: append a `## Logs` section if absent.
-- **Field side**: read-only — if `## Logs` is absent, log the same
-  "rename + push from dev" warning to the host log; do not edit.
-- If the body is suspiciously empty on either side (no operator-authored
-  sections), warn but do NOT impose structure.
-
-**Create the worktree / prepare main-tree** — branch on side:
+**Create the worktree / prepare main-tree** — branch on side. This is
+done *before* the title/body checks so the per-host log (initialized
+next) exists by the time any warnings need to land in it.
 
 - **Dev side**: create the worktree:
   ```bash
@@ -279,6 +269,32 @@ Host: <hostname>
 Side: <dev|field>
 Started: <YYYY-MM-DD HH:MM ±HH:MM>
 ```
+
+Any title / body / log-stamp warnings emitted below append to this
+file. It is the canonical sink for field-side drift warnings; dev side
+also appends here for parity.
+
+**Verify the issue title** (form: `Deployment <YYYY-MM-DD>: <scope>`):
+
+- **Dev side**: if not already in that form, ask the operator to
+  confirm the deployment-start date (default: the issue's `createdAt`
+  date in the operator's TZ), then update the title via
+  `gh -R <owner/repo> issue edit <N> --title "..."`.
+- **Field side**: if not already in that form, append a warning to the
+  per-host log file (initialized above): *"Deployment issue title not
+  in canonical form; run `/start-deployment` from dev first to rename
+  + push."* Do not edit on field side — `issue_sync` has no edit verb,
+  and edits would diverge from dev's view.
+
+**Ensure essentials on the body** (only the `## Logs` section is
+managed; everything else is operator-authored and untouched):
+
+- **Dev side**: append a `## Logs` section if absent.
+- **Field side**: read-only — if `## Logs` is absent, append the same
+  "rename + push from dev" warning to the per-host log file; do not
+  edit the issue.
+- If the body is suspiciously empty on either side (no operator-authored
+  sections), warn but do NOT impose structure.
 
 **Stamp the log file link in the issue body's `## Logs` section** —
 branch on side:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,7 +94,8 @@ Available workflow skills: `review-issue`, `plan-task`, `review-plan`,
 `review-code`, `brainstorm`, `research`, `audit-workspace`, `audit-project`,
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
 `triage-reviews`, `skill-importer`, `document-package`, `issue-triage`,
-`test-engineering`, `inspiration-tracker`, `import-field-changes`.
+`test-engineering`, `inspiration-tracker`, `import-field-changes`,
+`start-deployment`.
 
 ## References
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ For live field deployments of an autonomous robot boat, activate **deployment
 mode** in the current agent session with `/start-deployment`. The procedure
 is framework-agnostic markdown (see
 [`.claude/skills/start-deployment/SKILL.md`](.claude/skills/start-deployment/SKILL.md));
-slash-command invocation is Claude-Code-native, but other runtimes can
+slash-command invocation is Claude Code native, but other runtimes can
 adapt the same steps. The skill discovers the project's
 `.agents/deployment.yaml` config, branches
 on dev vs field side via `field_mode.sh`, and either creates a new deployment,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,10 +241,12 @@ is framework-agnostic markdown (see
 slash-command invocation is Claude Code native, but other runtimes can
 adapt the same steps. The skill discovers the project's
 `.agents/deployment.yaml` config, branches
-on dev vs field side via `field_mode.sh`, and either creates a new deployment,
-first-activates an existing one (worktree/main-tree + per-host log + issue
-sync), or resumes an ongoing one. Activation is per-agent-session; other
-sessions on the same host are unaffected.
+on dev vs field side via `field_mode.sh`, and either creates a new deployment
+(dev side only — field side has no GitHub access and instructs the operator
+to start from a dev host first), first-activates an existing one
+(worktree on dev / main-tree on field + per-host log + issue sync), or
+resumes an ongoing one. Activation is per-agent-session; other sessions
+on the same host are unaffected.
 
 See [ADR-0014](docs/decisions/0014-deployment-mode.md) for the decision record
 and [`.agent/knowledge/deployment_mode.md`](.agent/knowledge/deployment_mode.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,22 @@ source .agent/scripts/worktree_enter.sh --skill research
 the only exception is that no GitHub issue is needed. All other rules (atomic commits,
 AI signature, pre-commit hooks) still apply.
 
+### Deployment mode
+
+For live field deployments of an autonomous robot boat, activate **deployment
+mode** in the current agent session with `/start-deployment` (Claude Code).
+The skill discovers the project's `.agents/deployment.yaml` config, branches
+on dev vs field side via `field_mode.sh`, and either creates a new deployment,
+first-activates an existing one (worktree/main-tree + per-host log + issue
+sync), or resumes an ongoing one. Activation is per-agent-session; other
+sessions on the same host are unaffected.
+
+See [ADR-0014](docs/decisions/0014-deployment-mode.md) for the decision record
+and [`.agent/knowledge/deployment_mode.md`](.agent/knowledge/deployment_mode.md)
+for the operational reference (urgency contract, lifecycle phases, log-naming
+convention, project-config schema). The wrap-up half (`/wrap-up-deployment`)
+and recovery checklist are tracked under umbrella [#495](https://github.com/rolker/ros2_agent_workspace/issues/495).
+
 ## AI Signature (Required on all GitHub Issues/PRs/Comments)
 
 ```markdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,8 +235,12 @@ AI signature, pre-commit hooks) still apply.
 ### Deployment mode
 
 For live field deployments of an autonomous robot boat, activate **deployment
-mode** in the current agent session with `/start-deployment` (Claude Code).
-The skill discovers the project's `.agents/deployment.yaml` config, branches
+mode** in the current agent session with `/start-deployment`. The procedure
+is framework-agnostic markdown (see
+[`.claude/skills/start-deployment/SKILL.md`](.claude/skills/start-deployment/SKILL.md));
+slash-command invocation is Claude-Code-native, but other runtimes can
+adapt the same steps. The skill discovers the project's
+`.agents/deployment.yaml` config, branches
 on dev vs field side via `field_mode.sh`, and either creates a new deployment,
 first-activates an existing one (worktree/main-tree + per-host log + issue
 sync), or resumes an ongoing one. Activation is per-agent-session; other


### PR DESCRIPTION
Closes #501

# Plan: v1 /start-deployment skill + activation marker (deployment-mode gap 1)

## Issue

https://github.com/rolker/ros2_agent_workspace/issues/501

(Design decisions locked in [issue comment](https://github.com/rolker/ros2_agent_workspace/issues/501#issuecomment-4560650816) — the issue title's "+ activation marker" phrase is **stale**; the locked design drops the marker. See Open Questions for rename.)

## Context

[ADR-0014](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0014-deployment-mode.md) (Draft, PR [#500](https://github.com/rolker/ros2_agent_workspace/pull/500)) defines deployment mode as a phase-aware behavioral autonomy mode (urgency contract) + lifecycle tooling that runs inside it. This PR ships the *first* lifecycle tool: `/start-deployment`, which activates a *single* agent session into deployment mode and either creates / first-activates / resumes a deployment.

The design comment on #501 is the authoritative spec; this plan is the structural / governance / consequences view.

## Approach

1. **Knowledge doc first** (`.agent/knowledge/deployment_mode.md`) — write the canonical reference: lifecycle phases, log-naming convention (per-host file, deployment-start date, dev/`hostname -s` label rule), what-to-write guidance, the `issue_sync` config schema, the project-config schema, and pointers to ADR-0014 and the skill.
2. **Template** (`.agent/templates/deployment_config.yaml`) — a fully-commented sample project deployment config (`issue_sync` interface with empty values + comments; `platform`, `default_branch`, `layer`, `packages`, `labels`, `log_dir`, `hosts`, optional defaults for tides stations). Adopters copy + fill.
3. **Skill** (`.claude/skills/start-deployment/SKILL.md`) — the load-bearing artifact. Frontmatter (`name` + `description`); embedded urgency contract (11 rules verbatim); procedure with three-state detection (create-new / activate-first-time / resume-ongoing) branching on side (`field_mode.sh`); steps invoke configured `issue_sync` commands rather than hard-coded `git bug`; "ensure-essentials" limited to `## Logs` section; rename title to `Deployment YYYY-MM-DD: <scope>` only if not already in that format; tides/weather/currents into the dev log's per-day `## Pre-flight` section, dev-only.
4. **No marker, no `.gitignore` edit, no hook** — explicitly out of scope per the locked design.

## Files to Change

| File | Change |
|------|--------|
| `.agent/knowledge/deployment_mode.md` | **create** — canonical reference doc |
| `.agent/templates/deployment_config.yaml` | **create** — commented sample project config |
| `.claude/skills/start-deployment/SKILL.md` | **create** — the skill (urgency contract embedded, three-state procedure) |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Workspace vs. project separation | Skill is generic; all platform-specific values come from project `.agents/deployment.yaml`. Hardcodes no repo, label, path, or `git bug` mechanism. |
| Workspace improvements cascade to projects | Skill works for any project that supplies the config; BizzyBoat first, IzzyBoat/dora later. |
| Only what's needed | Marker file + hook + `.gitignore` edit dropped from earlier draft. Three files, no state. |
| Improve incrementally | v1 ships `/start-deployment` only; `/wrap-up-deployment`, `/next-deployment`, hook-based auto-injection are separate sub-issues of #495. |
| Human control / tight-by-default, relaxable | Activation is per-session and operator-driven (slash command). No global behavior change. |
| Capture decisions | ADR-0014 already captures the *what*; this PR is the *implementation*. |
| A change includes its consequences | Fast-follow PRs tracked as tasks #9 (`docs/logs/README.md` shrink) and #10 (echoboats `.agents/deployment.yaml`). |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| [ADR-0003](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0003-workspace-infrastructure-is-project-agnostic.md) (workspace generic) | **Yes** | Skill is mechanism-agnostic; project config in project repo. |
| [ADR-0011](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0011-field-mode-for-non-github-origins.md) (field mode) | **Yes** | Side detection via `field_mode.sh`; field commits direct to default branch, dev uses worktree+PR. No hardcoded assumption. |
| [ADR-0013](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0013-progress-md-entry-type-vocabulary.md) (progress.md vocabulary) | **Yes** | `## Plan Authored` entry (this commit) + future `## Implementation` per the standard schema. |
| [ADR-0014](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0014-deployment-mode.md) (deployment mode, Draft) | **Yes** | This PR is the first concrete implementation; embeds the urgency contract verbatim in SKILL.md. |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| Add `/start-deployment` skill | `unh_echoboats_project11/.agents/deployment.yaml` so the skill has a BizzyBoat config to consume | **Follow-up** (task #10, separate project-repo PR) |
| Embed lifecycle ownership in the skill | `unh_echoboats_project11/docs/logs/README.md` (shrink: point at skill + workspace doc, keep only boat-specific overrides) | **Follow-up** (task #9, separate project-repo PR) |
| Ship ADR-0014's first implementation | ADR-0014 Status: Proposed → Accepted (after v1 lands + first deployment uses it) | **Future** (post-deployment) |
| AGENTS.md / CLAUDE.md reference to the skill | One-line pointer to `/start-deployment` under Skill Worktree Exception or a new "Deployment skills" subsection | **Open Question** below — not in v1 |

## Open Questions

- **Rename #501 title?** Drop "+ activation marker" since the marker is dropped from the design. (Cosmetic; the design comment supersedes.)
- **AGENTS.md / CLAUDE.md pointer to `/start-deployment`** — add a one-line reference now, or defer until `/wrap-up-deployment` lands so they're added together? Modifying AGENTS.md is "ask first" per the Boundaries section.

## Estimated Scope

**Single workspace PR** (this issue, ~3 files, ~300-400 lines total — SKILL.md is the longest). Two fast-follow project-repo PRs on `unh_echoboats_project11` tracked separately.
