### PR TITLE
research: full re-survey of Feb–Mar 2026 landscape entries

### DIFF
--- a/.agent/knowledge/research_digest.md
+++ b/.agent/knowledge/research_digest.md
@@ -1,31 +1,33 @@
 # Research Digest: Workspace
 
-<!-- Last updated: 2026-05-27 -->
+<!-- Last updated: 2026-05-28 -->
 <!-- If older than 30 days, consider running /research --refresh; entries older than 90 days should be flagged for review -->
-<!-- 2026-05-27 pass: added "Operational-Assistant Behavior Under Live Time Pressure" and refreshed "Claude Code Agent Teams". The Feb–Mar 2026 landscape entries below retain their original survey dates and are due a fuller re-survey. -->
+<!-- 2026-05-28 full re-survey: refreshed all Feb–Mar 2026 landscape entries (the prior 2026-05-27 pass had only touched two). Original "Added" dates preserved; "Updated" stamps mark this pass. "Operational-Assistant Behavior Under Live Time Pressure" (2026-05-27) was already fresh and left as-is. Workspace-wide note: Opus 4.6 is no longer the current model — Opus 4.7 (2026-04-16) and Opus 4.8 (2026-05-28) shipped in this window; treat any "Opus 4.6 is current" framing elsewhere as stale. -->
 
 ## Command Runner Alternatives to Make
 
-**Added**: 2026-02-27 | **Sources**: [just](https://github.com/casey/just), [Task](https://github.com/go-task/task), [mise](https://github.com/jdx/mise)
+**Added**: 2026-02-27 | **Updated**: 2026-05-28 | **Sources**: [just](https://github.com/casey/just), [just CHANGELOG](https://github.com/casey/just/blob/master/CHANGELOG.md), [just-mcp](https://github.com/promptexecution/just-mcp), [Task](https://taskfile.dev/docs/changelog), [mise](https://github.com/jdx/mise)
 
 Key takeaways:
-- `just` is the strongest candidate for replacing Make as a command runner — closest syntax, built-in `just --list`, no `.PHONY` needed, multi-language recipes
-- `just-mcp` provides an MCP adapter, enabling any MCP-compatible agent to invoke workspace commands
-- `task` (Go/YAML) offers namespace includes but is more verbose; `mise` (Rust/TOML) bundles tool version management but adds little for ROS 2 where `apt`/`rosdep` manage toolchains
+- `just` (now **v1.51.0**, ~May 2026) remains the strongest Make-replacement candidate — `just --list`, no `.PHONY`, multi-language recipes; recent additions: `[env]` module-level export overrides, graceful recursion failure (was stack overflow)
+- **`just-mcp` has matured from "adapter" to a production-ready MCP server**: discover/execute/introspect justfile recipes over MCP (`--stdio` + Docker run modes), explicitly agent-oriented and context-saving (the LLM gets command + params + hints without reading the bash/Python body), small-model (8k–32k) friendly
+- `task` (Go/YAML) active on v3: added `if:` task conditions, runtime prompts for required vars, TLS/mTLS for remote Taskfiles, `TASK_`-prefixed env overrides — better CI/container ergonomics, but still more verbose than just
+- `mise` (Rust/TOML, CalVer) added monorepo task support; still bundles tool-version management but adds little for ROS 2 where `apt`/`rosdep` manage toolchains
 - `colcon defaults.yaml` can absorb build flags currently hardcoded in scripts, regardless of which runner is chosen
 
-**Relevance**: The workspace uses Make purely as a command runner, not for dependency-based builds. Switching to `just` would reduce boilerplate and provide a pathway to MCP-accessible commands.
+**Relevance**: The workspace uses Make purely as a command runner, not for dependency-based builds. Switching to `just` would reduce boilerplate; just-mcp's maturation makes the MCP-accessible-commands pathway more concrete than at last survey.
 
 ---
 
 ## AGENTS.md — Cross-Platform Agent Instruction Standard
 
-**Added**: 2026-02-27 | **Sources**: [agents.md spec](https://agents.md/), [GitHub repo](https://github.com/agentsmd/agents.md), [OpenAI Codex guide](https://developers.openai.com/codex/guides/agents-md/), [Agentic AI Foundation](https://openai.com/index/agentic-ai-foundation/), [deep dive](https://prpm.dev/blog/agents-md-deep-dive), [sync strategy](https://kau.sh/blog/agents-md/)
+**Added**: 2026-02-27 | **Updated**: 2026-05-28 | **Sources**: [agents.md spec](https://agents.md/), [AAIF adds 43 members (LF, 2026-05-18)](https://www.linuxfoundation.org/press/agentic-ai-foundation-adds-43-new-members-as-enterprise-and-government-adoption-of-open-agent-standards-accelerates), [aaif.io press](https://aaif.io/press/agentic-ai-foundation-adds-43-new-members-as-enterprise-and-government-adoption-of-open-agent-standards-accelerates/), [OpenAI Codex guide](https://developers.openai.com/codex/guides/agents-md/)
 
 Key takeaways:
-- Vendor-neutral spec stewarded by the Agentic AI Foundation (Linux Foundation), with contributions from OpenAI, Anthropic, and others
-- 60,000+ open-source projects adopted; measured 28.6% median runtime reduction, 16.6% token reduction
-- Supported by Codex, Cursor, Devin, Gemini CLI, GitHub Copilot, Jules, VS Code, and more
+- Vendor-neutral spec stewarded by the Agentic AI Foundation (Linux Foundation); **membership ~190 organizations** as of 2026-05-18 (43 added: 4 Gold incl. F5/GoDaddy/Stripe/TRON, 27 Silver, 12 Associate) — up from "170+" in April; enterprise + government adoption highlighted
+- **60,000+ open-source projects adopted** — still the cited figure in the May release, so treat as a floor that may be stale (it hasn't visibly grown despite member growth); measured 28.6% median runtime reduction, 16.6% token reduction
+- Official supported-tool list expanded: **Amp, Codex, Cursor, Devin, Factory, Gemini CLI, GitHub Copilot, Jules, VS Code** (adds Amp + Factory vs. last survey)
+- AAIF announced a **2026 global events program (AGNTCon + MCPCon, North America + Europe)**
 - Recommended size: ≤150 lines; closest `AGENTS.md` to the edited file wins; user prompts override all
 - For multi-tool workspaces, the `@AGENTS.md` import pattern in framework-specific files (e.g., CLAUDE.md) is preferred over symlinking
 
@@ -35,49 +37,44 @@ Key takeaways:
 
 ## AI Agent Spec Writing Best Practices
 
-**Added**: 2026-02-27 | **Sources**: [Osmani, "How to Write a Good Spec for AI Agents" (O'Reilly, Jan 2026)](https://www.oreilly.com/radar/how-to-write-a-good-spec-for-ai-agents/), [addyosmani.com](https://addyosmani.com/blog/good-spec/)
+**Added**: 2026-02-27 | **Updated**: 2026-05-28 | **Sources**: [Osmani, "How to Write a Good Spec for AI Agents" (O'Reilly, Jan 2026)](https://www.oreilly.com/radar/how-to-write-a-good-spec-for-ai-agents/), [Stack Overflow: shared coding guidelines for AI (Mar 2026)](https://stackoverflow.blog/2026/03/26/coding-guidelines-for-ai-agents-and-people-too/), [Augment Code: how to build AGENTS.md](https://www.augmentcode.com/guides/how-to-build-agents-md)
 
 Key takeaways:
-- Informed by GitHub's analysis of 2,500+ agent configuration files
+- Informed by GitHub's analysis of 2,500+ agent configuration files; "never commit secrets" confirmed as the single most common helpful constraint
 - **Three-tier boundary system**: categorize rules as "Always" (autonomous), "Ask first" (human approval), or "Never" (hard stop) — more effective than flat rule lists
-- **Self-audit instruction**: tell agents to compare results against the spec and list unmet items
-- **SPEC.md as session anchor**: persistent spec file survives context resets across sessions
-- **Conformance suites**: language-independent tests that any implementation must pass
-- **Two-phase task pattern**: draft spec first (plan mode), then execute incrementally
+- **Self-audit instruction**, **SPEC.md as session anchor**, **conformance suites**, and the **two-phase task pattern** (draft spec in plan mode, then execute) all still hold
+- New refinements since last survey: **"Agent Experience (AX)" design** — OpenAPI schemas, `llms.txt`, explicit type defs for agent-consumed surfaces; and **per-role agent personas** (`@docs-agent`, `@test-agent`, `@security-agent` with role-scoped AGENTS.md)
+- Line guidance now commonly stated as **150–200 lines, then split into nested/subdirectory files**
 
-**Relevance**: The Always/Ask/Never taxonomy was adopted directly into AGENTS.md. The self-audit pattern maps to our post-task verification checklist.
+**Relevance**: The Always/Ask/Never taxonomy was adopted directly into AGENTS.md. The self-audit pattern maps to our post-task verification checklist. The per-role-persona idea maps to our specialist review sub-agents.
 
 ---
 
 ## Harness Engineering — Production-Scale Agent-First Development
 
-**Added**: 2026-02-27 | **Sources**: [OpenAI blog (Lopopolo, Feb 2026)](https://openai.com/index/harness-engineering/), [Böckeler analysis (martinfowler.com)](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html), [InfoQ coverage](https://www.infoq.com/news/2026/02/openai-harness-engineering-codex/)
+**Added**: 2026-02-27 | **Updated**: 2026-05-28 | **Sources**: [Latent Space deep-dive interview w/ Lopopolo](https://www.latent.space/p/harness-eng), [OpenAI blog (Lopopolo, Feb 2026)](https://openai.com/index/harness-engineering/), [Fowler, "Harness engineering"](https://martinfowler.com/articles/harness-engineering.html), [Hanchung, "Hidden Technical Debt: Agent Harness"](https://leehanchung.github.io/blogs/2026/05/08/hidden-technical-debt-agent-harness/)
 
 Key takeaways:
-- Team of 3–7 engineers built ~1M LOC product with zero human-written code over 5 months using Codex; 3.5 PRs/engineer/day
+- Team of 3–7 engineers built ~1M LOC product via Codex with **zero human-written code AND zero human code review** over 5 months; ~1,500 PRs; throughput scaled from ~¼ engineer-equivalent/person to **3–10 engineers' worth/person** (the earlier "3.5 PRs/eng/day" was a narrow slice of this)
 - The **harness** (environment, constraints, feedback loops) matters more than the agent's capabilities — early slowness came from an underspecified environment, not incapable models
 - Three harness components: **context engineering** (instruction files), **architectural constraints** (linters, structural tests), **garbage collection** (background agents fighting entropy)
-- AGENTS.md should be a ~150-line **map** (table of contents), not an encyclopedia — deep rules live in referenced knowledge files
-- **Lint error messages as agent teaching**: custom linters should include remediation instructions so failures become learning context
-- **Garbage collection agents**: background tasks that scan for drift and open small fix-up PRs on a recurring cadence
-- **"Anything not in-context doesn't exist"**: only repo-local versioned artifacts are visible to agents; knowledge in chat, docs, or heads is invisible
-- **"Corrections are cheap, waiting is expensive"**: favor fast feedback loops over blocking gates for agent-generated work
+- AGENTS.md should be a ~150-line **map**, not an encyclopedia; **lint errors as agent teaching**; **"anything not in-context doesn't exist"**; **"corrections are cheap, waiting is expensive"**
+- Now formalized as the **"fourth paradigm of AI engineering"** (Fowler article + `awesome-harness-engineering` list)
+- **Criticism / limitations** (this pass): EU regulatory blind spot (GDPR / AI Act / CLOUD Act data-sovereignty); a documented "hidden technical debt of the agent harness"; **"optimism asymmetry"** — agents predict fixes well but regressions poorly (cited fix precision ~33.7% vs regression precision ~11.8%), which directly stresses the 0%-human-review claim
 
-**Relevance**: Validates several workspace patterns (worktree isolation, progressive disclosure, artifact-based communication). The map-vs-encyclopedia principle guides AGENTS.md/CLAUDE.md sizing. Garbage collection agents are a future pattern once multi-agent workflows are adopted.
+**Relevance**: Validates several workspace patterns (worktree isolation, progressive disclosure, artifact-based communication). The map-vs-encyclopedia principle guides AGENTS.md/CLAUDE.md sizing. The optimism-asymmetry/regression-blindness finding reinforces our Quality Standard's insistence on tests + adversarial review rather than trusting agent self-assessment — especially for marine-safety code.
 
 ---
 
 ## Multi-Agent Engineering Patterns
 
-**Added**: 2026-02-27 | **Sources**: [GitHub blog, "Multi-agent workflows often fail" (Feb 2026)](https://github.blog/ai-and-ml/generative-ai/multi-agent-workflows-often-fail-heres-how-to-engineer-ones-that-dont/)
+**Added**: 2026-02-27 | **Updated**: 2026-05-28 | **Sources**: [GitHub blog, "Multi-agent workflows often fail" (Feb 2026)](https://github.blog/ai-and-ml/generative-ai/multi-agent-workflows-often-fail-heres-how-to-engineer-ones-that-dont/), [Shah, "The Problem Isn't the Model"](https://medium.com/@malav399/multi-agent-workflows-keep-failing-the-problem-isnt-the-model-1fa032218755), [awesome-harness-engineering](https://github.com/ai-boost/awesome-harness-engineering)
 
 Key takeaways:
 - Core thesis: most multi-agent failures come from **missing structure**, not model capability — treat agents as distributed system components
-- **Typed schemas** for inter-agent data: machine-checkable contracts (Zod, JSON Schema) prevent field name drift and ambiguous types
-- **Action schemas** (discriminated unions): constrain what agents can do — prevents contradictory actions like one agent closing an issue another just opened
-- **MCP as enforcement layer**: validates tool inputs/outputs before execution, making instruction-level rules mechanically enforceable
+- **Typed schemas** for inter-agent data (Zod, JSON Schema) prevent field-name drift; **action schemas** (discriminated unions) prevent contradictory actions; **MCP as enforcement layer** validates tool I/O before execution
 - **Distributed systems principles apply**: design for failure, validate at boundaries, constrain before scaling, log intermediate state, design for idempotency
-- **Constrain the solution space** to increase trust (Böckeler): restrict what agents can do to increase confidence in what they do
+- All original facts verified unchanged; the post drove substantial secondary coverage since, and these patterns are now bundled under the broader **"harness engineering"** umbrella in the literature (orchestration, MCP, permissions, observability) — the two topics are converging
 
 **Relevance**: Not immediately actionable for single-agent workflows, but provides the engineering framework for when Agent Teams or multi-agent orchestration is adopted. The workspace's worktree isolation already maps well to distributed systems best practices.
 
@@ -85,155 +82,153 @@ Key takeaways:
 
 ## Claude Code Agent Teams
 
-**Added**: 2026-02-27 | **Updated**: 2026-05-27 | **Sources**: [Claude Code Agent Teams docs](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/agent-teams), [CloudZero: Agent View/Subagents/Teams](https://www.cloudzero.com/blog/claude-code-agents/), [Developers Digest 2026 playbook](https://www.developersdigest.tech/blog/claude-code-agent-teams-subagents-2026)
+**Added**: 2026-02-27 | **Updated**: 2026-05-28 | **Sources**: [Claude Code Agent Teams docs](https://code.claude.com/docs/en/agent-teams), [Anthropic: Claude Opus 4.8](https://www.anthropic.com/news/claude-opus-4-8), [Claude model history](https://en.wikipedia.org/wiki/Claude_(language_model))
 
 Key takeaways:
-- Released 2026-02-05 alongside Opus 4.6; **still experimental, disabled by default** (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`)
-- One session is team lead; teammates are full independent Claude Code instances, each with its own context window and tool access, that **talk peer-to-peer** via a mailbox and **claim work off a shared task list** — unlike subagents, which only report to their parent and can't message each other
-- **Subagents vs. Teams**: subagents for cleanly decomposable, coordination-free work (search usages, write tests for one module); teams for dependent work spanning multiple parts (a feature across frontend/backend/db, investigating a bug from multiple angles)
-- **Agent View** dashboard manages background sessions; subagents are reusable prompt+tool configs
+- Released 2026-02-05 alongside Opus 4.6; **still experimental, still disabled by default** (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) as of 2026-05-28 — no GA, no default-on flip (re-verified this pass). Requires **Claude Code v2.1.32+**
+- Note the model context has moved on: **Opus 4.7 (2026-04-16) and Opus 4.8 (2026-05-28) are now current** — the "released with Opus 4.6" pairing is history, not the current model
+- One session is team lead; teammates are full independent Claude Code instances, each with its own context window and tool access, that **talk peer-to-peer** via a mailbox and **claim work off a shared task list** — unlike subagents, which only report to their parent
+- Capabilities matured since release: **plan-approval mode for teammates**, **subagent definitions reusable as teammates**, teammate **hooks** (`TeammateIdle`, `TaskCreated`, `TaskCompleted`) for quality gates, **task dependencies with auto-unblock**, **file-locking on task claims**, and `teammateMode` (in-process vs split-pane)
+- **Subagents vs. Teams**: subagents for cleanly decomposable, coordination-free work; teams for dependent work spanning multiple parts
 - **Cost is linear in parallelism** — no separate agent pricing; N agents burn quota Nx
 
-**Relevance**: The workspace's worktree infrastructure already provides the isolation Teams assume — each teammate works in its own worktree. The shared-task-list + peer mailbox model is directly relevant to the multi-host, multi-agent deployment lifecycle ([#495](https://github.com/rolker/ros2_agent_workspace/issues/495), [#470](https://github.com/rolker/ros2_agent_workspace/issues/470)): a deployment could run as a team (per-host loggers + a lead) rather than uncoordinated parallel sessions. Subagent-vs-team distinction informs when deployment sub-tasks need coordination vs. fire-and-forget.
+**Relevance**: The workspace's worktree infrastructure already provides the isolation Teams assume — each teammate works in its own worktree. The shared-task-list + peer-mailbox model (plus the new task-dependency + file-locking primitives) is directly relevant to the multi-host, multi-agent deployment lifecycle ([#495](https://github.com/rolker/ros2_agent_workspace/issues/495), [#470](https://github.com/rolker/ros2_agent_workspace/issues/470)): a deployment could run as a team (per-host loggers + a lead) rather than uncoordinated parallel sessions. Still experimental, so not yet a dependency to build on.
 
 ---
 
 ## Model Context Protocol (MCP) — Industry Standard
 
-**Added**: 2026-02-27 | **Sources**: [MCP spec](https://spec.modelcontextprotocol.io/), [Agentic AI Foundation](https://www.linuxfoundation.org/press/linux-foundation-launches-the-agentic-ai-foundation)
+**Added**: 2026-02-27 | **Updated**: 2026-05-28 | **Sources**: [MCP first-anniversary / 2025-11-25 spec](https://blog.modelcontextprotocol.io/posts/2025-11-25-first-mcp-anniversary/), [MCP 2026-07-28 release candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/), [ros-mcp-server release (Open Robotics Discourse)](https://discourse.openrobotics.org/t/ros-mcp-server-release/50024)
 
 Key takeaways:
-- Donated to the Linux Foundation's Agentic AI Foundation (Dec 2025) — now the cross-vendor standard adopted by OpenAI, Google, Anthropic, and others
-- Thousands of community servers; universal protocol for connecting agents to tools and data
-- **ROS 2-specific MCP servers** emerging: ROSBag MCP Server (natural language queries over bag files, [arXiv:2511.03497](https://arxiv.org/abs/2511.03497)), ROS 2 Robot Control MCP Server (agent access to topics/services/actions)
-- Beyond tool connection, MCP adds a **validation layer** — can enforce contracts that soft instruction rules cannot
+- Governed by the Linux Foundation's **Agentic AI Foundation** (since Dec 2025), a sibling founding project to AGENTS.md and Block's goose — now the cross-vendor standard (OpenAI, Google, Anthropic, ...)
+- **Current GA is the 2025-11-25 spec**: formalized async **Tasks**, server identity, Client ID Metadata Documents, client security requirements, elicitation/enhanced sampling, and the **Extensions system** (reverse-DNS extension IDs, capability negotiation)
+- **Next major cut: the 2026-07-28 release candidate** (still upcoming) — stateless protocol core, Extensions framework, Tasks demoted to an extension, **MCP Apps** (server-rendered UIs), auth hardening (OAuth/OIDC, DPoP, Workload Identity Federation), formal deprecation policy
+- **Registry GA** with enterprise governance/discoverability; gateway+registry patterns maturing
+- **ROS 2 MCP servers expanding**: ROSBag MCP Server (NL queries over bag files, [arXiv:2511.03497](https://arxiv.org/abs/2511.03497)); **kakimochi/ros2-robot-control** and **lpigeon/ros-mcp-server** (ROS 1 & 2, `/cmd_vel`, model-agnostic, no robot-code changes) — the **validation layer** is better attributed to these server implementations than to the core protocol
 
-**Relevance**: Strategic for this workspace. `just-mcp` could expose workspace commands to any agent. ROS 2 MCP servers could enable runtime system inspection during development. MCP enforcement is the cross-agent equivalent of Claude Code hooks.
+**Relevance**: Strategic for this workspace. `just-mcp` could expose workspace commands to any agent. ROS 2 MCP servers could enable runtime system inspection during development — and the `/cmd_vel`-focused servers map directly onto our cmd_vel-only autonomy stack. MCP enforcement is the cross-agent equivalent of Claude Code hooks.
 
 ---
 
 ## ROS 2 Agent Frameworks
 
-**Added**: 2026-02-27 | **Sources**: [ROSA (NASA JPL)](https://github.com/nasa-jpl/rosa), [RAI (RobotecAI)](https://github.com/RobotecAI/rai), [ROS-LLM (Auromix)](https://github.com/Auromix/ROS-LLM), [EmbodiedAgents (Automatika)](https://automatika-robotics.github.io/embodied-agents/)
+**Added**: 2026-02-27 | **Updated**: 2026-05-28 | **Sources**: [RAI (RobotecAI) releases](https://github.com/RobotecAI/rai/releases), [RAI paper arXiv:2505.07532](https://arxiv.org/abs/2505.07532), [ROSClaw arXiv:2603.26997](https://arxiv.org/abs/2603.26997), [ROSA (NASA JPL)](https://github.com/nasa-jpl/rosa)
 
 Key takeaways:
-- **ROSA** (NASA JPL): natural language interaction with ROS 1/2 systems — inspect nodes, query topics, diagnose issues; published at IROS 2024
-- **RAI** (RobotecAI): vendor-agnostic agentic framework for Physical AI; integrates with ROS 2 navigation, manipulation, perception
-- **ROS-LLM**: LLM-based code generation for robot behaviors (sequences, behavior trees, state machines)
-- **EmbodiedAgents**: production-grade deployment of Physical AI on real robots via ROS 2
-- These operate at **runtime** (inspect, diagnose, operate robots) vs. our workspace which operates at **development-time** (write code, manage PRs) — complementary, not competing
-- MCP bridges the gap: a development agent could invoke a ROSA MCP server to inspect a running system while debugging
+- **RAI (RobotecAI) → 2.0**: a near-from-scratch rewrite (new packages, unified architecture, simpler embodied-agent build path); still the strongest "Physical AI" runtime contender (ROS 2 + LLM/VLM + voice + scenario tasks)
+- **ROSA (NASA JPL)**: still LangChain-based NL interaction with ROS 1/2 (inspect nodes, query topics, diagnose; param validation/constraint safety); new direction is an **NVIDIA IsaacSim integration** (control robots and IsaacSim itself)
+- **New entrant — ROSClaw** (arXiv:2603.26997, Mar 2026): model-agnostic executive layer bridging the OpenClaw runtime to ROS 2 — dynamic capability discovery + affordance injection, multimodal observation normalization, **pre-execution action validation within a configurable safety envelope**, structured audit/provenance logging; model/robot swaps are config-only; quantifies up to 4.8× differences in out-of-policy action rates across foundation models
+- **ROS-LLM** (Auromix, now with a Nature Machine Intelligence write-up) and **EmbodiedAgents** (Automatika) facts unchanged
+- No framework has become dominant — the field is still fragmented and operates at **runtime** (inspect, diagnose, operate) vs. our **development-time** workspace; MCP bridges the two
 
-**Relevance**: ROSA is the most immediately relevant for diagnosing integration issues by querying a running simulation from within a coding session. Others are worth monitoring.
+**Relevance**: ROSA is the most immediately relevant for diagnosing integration issues by querying a running simulation from a coding session. ROSClaw's safety-envelope + audit-logging design is a convergent pattern with the ROS MCP servers and directly echoes our Quality Standard for the cmd_vel-only stack — worth watching even though it's runtime-side.
 
 ---
 
 ## Agentic Coding Market and Tool Landscape
 
-**Added**: 2026-02-27 | **Sources**: [GitHub blog](https://github.blog/ai-and-ml/generative-ai/multi-agent-workflows-often-fail-heres-how-to-engineer-ones-that-dont/), [Anthropic engineering](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
+**Added**: 2026-02-27 | **Updated**: 2026-05-28 | **Sources**: [Anthropic 2026 Agentic Coding Trends Report](https://resources.anthropic.com/2026-agentic-coding-trends-report), [SevenOlives: $4B market consolidation 2026](https://sevenolives.com/blog/ai-coding-agents-4-billion-market-consolidation-2026), [GitHub Agentic Workflows technical preview](https://github.blog/changelog/2026-02-13-github-agentic-workflows-are-now-in-technical-preview/)
 
 Key takeaways:
-- Market grew from $550M to $4B in one year; 57% of companies run AI agents in production (Jan 2026)
-- Gartner reports 1,445% surge in multi-agent system inquiries (Q1 2024 → Q2 2025)
-- Quality concern: 40% quality deficit projected — more code enters pipelines than reviewers can validate; Google DORA 2025 found 90% AI adoption increase correlates with 9% higher bug rates, 91% more review time, 154% larger PRs
-- **Worktree isolation is converging as an industry standard**: ccswarm, agentree, git-worktree-runner, Cursor 2.0, OpenAI Codex all independently adopted it
-- **mini-swe-agent** (100 lines of Python, 65–74% on SWE-bench Verified) validates radical simplicity — a minimal harness with good context engineering outperforms complex frameworks
-- **GitHub Agentic Workflows** (technical preview): define CI automation in Markdown instead of YAML; AI agents figure out execution
+- **Market sizing revised sharply upward**: enterprise AI coding-agent market now ~**$9.8B–$11B annualized (Apr 2026)** (the "$550M→$4B" figure is now the prior-year baseline)
+- **Consolidation is the new headline**: top three (Cursor, Copilot, Claude Code) hold **70%+ share** ("winner-take-most"); M&A wave — OpenAI 6 acquisitions in early 2026, Google's $2.4B Windsurf/Codeium acqui-hire, Anthropic acquired Vercept
+- **Anthropic 2026 Trends Report** stats: 78% of Q1 2026 Claude Code sessions are multi-file edits (up from 34% Q1 2025); avg session 4min→23min; well-maintained context files → 40% fewer errors / 55% faster
+- **Adoption-vs-production gap** reframed: ~79% adoption vs ~11% actually in production (the older "57% in prod" framing overstates it); Gartner's 1,445% multi-agent inquiry surge still valid
+- Quality concern persists: more code enters pipelines than reviewers can validate; **worktree isolation has converged as an industry standard**; mini-swe-agent validates radical simplicity
+- **GitHub Copilot CLI reached GA (Apr 2026)**, but **GitHub Agentic Workflows remains in technical preview, not GA** — don't conflate the two
 
-**Relevance**: The convergence on worktree isolation validates our architecture. The quality deficit numbers reinforce the importance of the harness (lints, CI, structural enforcement) over raw agent throughput. GitHub Agentic Workflows are worth monitoring for issue triage and CI failure investigation automation.
+**Relevance**: The convergence on worktree isolation validates our architecture. The quality-deficit numbers and adoption/production gap reinforce the importance of the harness (lints, CI, structural enforcement) over raw agent throughput. GitHub Agentic Workflows are still worth monitoring for issue triage and CI-failure-investigation automation.
 
 ---
 
 ## GitHub Outage Resilience and Offline Development
 
-**Added**: 2026-03-04 | **Sources**: [SecureSlate: GitHub outage resilience](https://getsecureslate.com/blog/what-the-github-outage-taught-us-about-resilience-and-compliance-2026), [GitHub down Feb 2026](https://serenitiesai.com/articles/github-down-ai-coding-tools-dependency-2026), [GitHub June 2025 outage](https://www.webpronews.com/githubs-june-2025-outage-how-a-routine-database-migration-cascaded-into-a-platform-wide-crisis/), [Self-hosted git platforms 2026](https://dasroot.net/posts/2026/01/self-hosted-git-platforms-gitlab-gitea-forgejo-2026/)
+**Added**: 2026-03-04 | **Updated**: 2026-05-28 | **Sources**: [GitHub availability report, April 2026](https://github.blog/news-insights/company-news/github-availability-report-april-2026/), [CNBC: Microsoft/AI coding outages (2026-05-22)](https://www.cnbc.com/2026/05/22/microsoft-was-positioned-to-win-in-ai-coding-outages-got-in-the-way.html), [byteiota: GitHub reliability crisis](https://byteiota.com/github-reliability-crisis-three-nines/)
 
 Key takeaways:
-- GitHub has had multiple major outages in 2025–2026, partly due to its ongoing datacenter-to-Azure migration; Feb 2026 outage blocked pushes, CI, and PR reviews globally
-- **Multi-remote strategy** is the most common resilience pattern: keep GitHub as primary, add a secondary remote (Forgejo, GitLab, Gitea) as failover — preserves existing integrations while enabling continued work during outages
-- **Forgejo** (community fork of Gitea) is lightweight, self-hostable, and has Forgejo Actions (GitHub Actions–compatible but not identical; some workflow tweaks needed). Supports offline runner registration.
-- **Gitea** offers a plugin-based microservices model; Gitea Actions provides closer GitHub Actions compatibility
-- Alternative workflows mentioned by developers during outages: `git-send-email`, Radicle (decentralized git protocol)
-- Core git operations (commit, branch, merge, diff, log) are fully local and unaffected by outages — the pain points are CI, PRs, issues, and code review
+- The outage pattern **continued and worsened** through Mar–May 2026 — characterized now as a sustained reliability crisis, not a one-off. **April 2026 tied February as the worst month (7 major incidents each)**; a dozen-plus 1hr+ incidents since March
+- New named incidents: an Apr 1–2 cluster (Copilot backend resource exhaustion → 2.7 hr outage) and the **Apr 23 Merge Queue bug** that produced *incorrect commits* — merge groups with >1 PR silently reverted prior merges (a **data-integrity** failure, not just availability)
+- **Official acknowledgment**: GitHub CTO attributed Feb–Mar failures to rapid load growth, architectural coupling allowing localized issues to cascade, and inability to shed load from misbehaving clients; GitHub published an availability report + public apology
+- **Azure migration is ongoing, not complete**: only ~12.5% of traffic on Azure (Iowa) as of March, targeting 50% by July 2026; load context ~275M commits/week (~14× YoY)
+- **Multi-remote strategy** remains the most common resilience pattern (GitHub primary + Forgejo/GitLab/Gitea failover); `git-send-email` / Radicle as alternative workflows
+- Core git operations (commit, branch, merge, diff, log) are local and unaffected by *availability* outages — **but the Apr 23 Merge Queue bug shows GitHub-side automation can still corrupt commit contents**, so "core git ops unaffected" needs that caveat
 
-**Relevance**: This workspace depends on GitHub for issues, PRs, CI, and Copilot reviews. During outages, local coding continues but the issue-first workflow, worktree scripts (which use `gh`), and the PR-based review process are blocked. A resilience strategy should address these specific dependencies.
+**Relevance**: This workspace depends on GitHub for issues, PRs, CI, and Copilot reviews. The sustained crisis strengthens the case for the offline-first resilience strategy already in progress ([#345](https://github.com/rolker/ros2_agent_workspace/issues/345)) — local coding continues during outages, but the issue-first workflow, `gh`-based worktree scripts, and PR review are blocked.
 
 ---
 
 ## git-bug — Distributed Offline-First Issue Tracker
 
-**Added**: 2026-03-04 | **Sources**: [git-bug repo](https://github.com/git-bug/git-bug), [BrightCoding overview](https://www.blog.brightcoding.dev/2025/06/01/git-bug-a-distributed-offline-first-bug-tracker-embedded-in-git/), [HN discussion](https://news.ycombinator.com/item?id=43971620)
+**Added**: 2026-03-04 | **Updated**: 2026-05-28 | **Sources**: [git-bug releases](https://github.com/git-bug/git-bug/releases), [git-bug repo](https://github.com/git-bug/git-bug)
 
 Key takeaways:
-- Stores issues as git objects (under `refs/bugs`), not files — no clutter in the working tree, full version history, distributed by default
-- **Offline-first**: create, edit, comment on issues without network; syncs via `git push/pull` to any remote
-- **Bidirectional bridges**: GitHub, GitLab, Jira, Launchpad — can pull issues from GitHub and push local issues back
-- Multiple interfaces: CLI, terminal UI (TUI), and web UI (significantly improved in recent releases)
-- Latest release: v0.10.1 (May 2025), active development with 2,400+ commits
-- **git-issue** (Spinellis) is a simpler alternative storing issues as files in a dedicated branch
+- Stores issues as git objects (under `refs/bugs`), not files — no working-tree clutter, full version history, distributed by default
+- **Offline-first**: create, edit, comment without network; syncs via `git push/pull` to any remote
+- **Bidirectional bridges**: GitHub, GitLab, Jira, Launchpad
+- Multiple interfaces: CLI, TUI, web UI
+- **v0.10.1 (May 2025) is still the latest release as of 2026-05-28** — no 2026 release; the post-v0.8.1→v0.10.1 burst has gone quiet, so v0.10.1 is now latest-but-aging (repo still live, 2,400+ commits)
+- **git-issue** (Spinellis) is a simpler file-based alternative
 
-**Relevance**: Could serve as a local issue cache that stays in sync with GitHub when online and continues working offline. The GitHub bridge would allow the workspace's issue-first workflow to continue during outages. The `refs/bugs` storage means no interference with the working tree or worktree isolation.
+**Relevance**: Could serve as a local issue cache that stays in sync with GitHub when online and continues working offline — directly relevant given the worsening GitHub outage picture. The quiet release cadence is worth weighing before depending on it. The workspace already uses it (`sync_repos.py` includes git-bug; `gh_create_issue.sh` has a `GITBUG_CREATE=1` offline path).
 
 ---
 
 ## Local CI with Act (nektos/act)
 
-**Added**: 2026-03-04 | **Sources**: [nektos/act repo](https://github.com/nektos/act), [CICube guide](https://cicube.io/blog/run-github-actions-locally/), [Microsoft guide](https://techcommunity.microsoft.com/blog/azureinfrastructureblog/using-act-to-test-github-workflows-locally-for-azure-deployments-cicd/4414310)
+**Added**: 2026-03-04 | **Updated**: 2026-05-28 | **Sources**: [nektos/act releases](https://github.com/nektos/act/releases), [act runners docs](https://nektosact.com/usage/runners.html), [Dagger vs GitHub Actions](https://computingforgeeks.com/dagger-vs-github-actions-comparison/)
 
 Key takeaways:
-- Runs GitHub Actions workflows locally using Docker — reads `.github/workflows/` and spins up containers matching the GitHub environment
-- **Works offline** with cached Docker images; no GitHub connectivity needed for execution
-- Eliminates the commit-push-wait cycle for CI feedback; saves GitHub Actions minutes
-- Can serve as a local task runner alongside or instead of Make
-- Limitations: not 100% compatible with all GitHub Actions features (marketplace actions may need adaptation), requires Docker
+- Runs GitHub Actions workflows locally using Docker; **works offline** with cached images; eliminates the commit-push-wait cycle
+- Now **v0.2.88** (~May 2026), actively maintained — mostly dependency updates; recent feature: scalar values + template expressions in matrix strategies (`${{ fromJSON(...) }}` dynamic matrices)
+- Usability addition: the **GitHub Local Actions VS Code extension** (GUI front-end for act)
+- Alternatives unchanged in substance: `gitlab-runner exec` still weak; **Dagger** remains complementary (pipelines-as-code that run identically on laptop and in CI), not a replacement
+- Limitations: not 100% compatible with all Actions features (some marketplace actions need adaptation), requires Docker
 
-**Relevance**: The workspace already generates CI workflow templates (`.agent/templates/ci_workflow.yml`) for project repos. `act` could run these locally as a pre-push check or during outages. Combined with pre-commit hooks (already in place), this would provide full local CI coverage. The ROS 2 container images used in CI (`ros:jazzy-ros-core`) work with `act` since they're standard Docker images.
+**Relevance**: The workspace generates CI workflow templates (`.agent/templates/ci_workflow.yml`) for project repos. `act` could run these locally as a pre-push check or during outages (now more compelling given the sustained GitHub reliability crisis). The ROS 2 container images used in CI (`ros:jazzy-ros-core`) work with `act` since they're standard Docker images.
 
 ---
 
 ## ROS 2 Offline Development Patterns
 
-**Added**: 2026-03-04 | **Sources**: [rosdep offline mirror PR](https://github.com/ros-infrastructure/rosdep/pull/839), [ROS Answers: rosdep offline](https://answers.ros.org/question/276942/can-sudo-rosdep-init-and-rosdep-update-be-done-offline/), [rosdep mirror guide](https://answers.ros.org/question/338122/how-do-i-deploy-a-rosdep-mirror/)
+**Added**: 2026-03-04 | **Updated**: 2026-05-28 | **Sources**: [ROS 2 Lyrical Luth release notes](https://docs.ros.org/en/rolling/Releases/Release-Lyrical-Luth.html), [Lyrical Luth released (Open Robotics Discourse)](https://discourse.openrobotics.org/t/ros-2-lyrical-luth-released/55021), [rosdep offline mirror guide](https://answers.ros.org/question/338122/how-do-i-deploy-a-rosdep-mirror/)
 
 Key takeaways:
-- `rosdep` can work offline by setting `ROSDISTRO_INDEX_URL=file:///path/to/local/index-v4.yaml` — clone the `rosdistro` repo locally and point to it
-- All ROS 2 binary packages can be cached via a local apt mirror or pre-installed in Docker images
-- `colcon build` and `colcon test` are fully local — no network needed once dependencies are installed
-- The main online dependencies are: initial `rosdep init/update`, `apt install` for new packages, and `git clone` for source dependencies not yet in rosdep
+- **New distro: ROS 2 Lyrical Luth** (~2026-05-22) — the 12th release and a new **LTS** supported through **May 2031**; **Jazzy (2024 LTS)** remains a supported parallel LTS and **Kilted Kaiju (May 2025)** is the non-LTS in between
+- Lyrical highlights (context): Callback Group Events Executor (~10–15% less CPU), `ros2 service info --verbose`, generic `resource_retriever_service`, Rust generator (`rosidl_generator_rs`) shipping as a default
+- **Offline mechanics unchanged**: `rosdep` offline via `ROSDISTRO_INDEX_URL=file:///path/to/local/index-v4.yaml`; local apt mirror or pre-installed Docker images; `colcon build`/`test` fully local
+- Online dependencies remain: initial `rosdep init/update`, `apt install` for new packages, `git clone` for source deps not yet in rosdep
 
-**Relevance**: ROS 2 development is inherently local-friendly. The workspace's build/test workflow (`make build`, `make test`) works offline once dependencies are installed. The gap is in the governance layer (issues, PRs, reviews), not the build layer.
+**Relevance**: ROS 2 development is inherently local-friendly; `make build`/`make test` work offline once dependencies are installed. The gap remains in the governance layer (issues, PRs, reviews), not the build layer. Lyrical Luth is the distro to evaluate for any new LTS work, though this workspace currently targets Jazzy.
 
 ---
 
 ## Lightweight Self-Hosted Git Forges (Forgejo / Gitea)
 
-**Added**: 2026-03-04 | **Sources**: [Self-hosted git platforms 2026](https://dasroot.net/posts/2026/01/self-hosted-git-platforms-gitlab-gitea-forgejo-2026/), [Forgejo comparison](https://forgejo.org/compare/), [Forgejo vs Gitea](https://forgejo.org/compare-to-gitea/), [Gitea comparison](https://docs.gitea.com/installation/comparison)
+**Added**: 2026-03-04 | **Updated**: 2026-05-28 | **Sources**: [Forgejo v15.0 (Apr 2026)](https://forgejo.org/2026-04-release-v15-0/), [Gitea 1.25.5 release](https://blog.gitea.com/release-of-1.25.5/), [Gitea releases](https://github.com/go-gitea/gitea/releases)
 
 Key takeaways:
-- **Gitea** and **Forgejo** (community fork of Gitea) are functionally near-identical: ~200MB RAM, single binary or Docker one-liner, run on Raspberry Pi
-- Both offer: repo hosting, built-in issue tracker, web UI, wiki, Actions-compatible CI runners
-- **GitLab CE** requires 4-8GB+ RAM — roughly 40x heavier for the same core git hosting role
-- Forgejo is community-governed (no corporate entity); Gitea has Gitea Ltd behind it. Forgejo is the safer long-term bet for governance stability
-- Forgejo Actions are GitHub Actions–compatible but not identical — minor workflow tweaks typically needed
-- Both support offline runner registration for CI in disconnected environments
+- Both are lightweight (~200MB RAM), single binary or Docker one-liner; offer repo hosting, built-in issue tracker, web UI, wiki, Actions-compatible CI runners; **GitLab CE is ~40× heavier**
+- **Versions have churned hard**: Forgejo shipped **v14.0 (Jan 2026)** and **v15.0 (Apr 2026)** plus v11.0.14 LTS (May 2026) on a rapid quarterly major cadence; Gitea is on the **v1.26.x** line (1.26.0 Apr, 1.26.2 May 2026) — any text citing Forgejo v11/v12 or Gitea v1.24 as current is now wrong
+- **Forgejo Actions matured substantially** (v15): OIDC token support (Runner v12.5.0+), `concurrency` blocks, matrix jobs, `runs-on` from earlier jobs, scheduled jobs, email-on-failure — narrows the "GH-compatible but not identical" gap meaningfully
+- The two are **increasingly divergent, not "near-identical"**: version schemes have fully decoupled (v15 vs v1.26) and Forgejo's faster cadence + Actions feature lead mean feature sets no longer track 1:1; Forgejo's independent release velocity reinforces the "community-governed = safer long-term" point
 
-**Relevance**: The workspace uses a GitLab instance on the robot network for repo sync. Forgejo/Gitea could replace it at a fraction of the resource cost while adding a built-in issue tracker and web UI. Combined with git-bug for distributed issue sync, this enables a fully local-first development workflow where GitHub becomes a publication channel rather than a dependency. See [#345](https://github.com/rolker/ros2_agent_workspace/issues/345).
+**Relevance**: The workspace uses a GitLab instance on the robot network for repo sync. Forgejo/Gitea could replace it at a fraction of the resource cost while adding a built-in issue tracker and web UI. Forgejo Actions' OIDC/concurrency/matrix maturation makes a local CI mirror more viable. Combined with git-bug, this enables a fully local-first workflow where GitHub becomes a publication channel rather than a dependency. See [#345](https://github.com/rolker/ros2_agent_workspace/issues/345).
 
 ---
 
 ## Agent Orchestrators for Parallel Coding Agents
 
-**Added**: 2026-03-11 | **Sources**: [ComposioHQ/agent-orchestrator](https://github.com/ComposioHQ/agent-orchestrator), [jayminwest/overstory](https://github.com/jayminwest/overstory), [awesome-agent-orchestrators](https://gist.github.com/sujayjayjay/d0e88d5f53a5198c4ba5bb007a859bdd), [Shipyard blog](https://shipyard.build/blog/claude-code-multi-agent/), [ainativedev parallelizing agents](https://ainativedev.io/news/how-to-parallelize-ai-coding-agents)
+**Added**: 2026-03-11 | **Updated**: 2026-05-28 | **Sources**: [ComposioHQ/agent-orchestrator](https://github.com/ComposioHQ/agent-orchestrator), [Augment Code: open-source agent orchestrators](https://www.augmentcode.com/tools/open-source-agent-orchestrators), [Deloitte 2026: AI agent orchestration](https://www.deloitte.com/us/en/insights/industry/technology/technology-media-and-telecom-predictions/2026/ai-agent-orchestration.html)
 
 Key takeaways:
-- **Agent-orchestrator** (ComposioHQ, 4.1k stars, MIT): spawns parallel coding agents each in its own git worktree/branch/PR; pluggable adapters for runtime (tmux/Docker/K8s), agent (Claude Code/Codex/Aider), workspace (worktree/clone), tracker (GitHub/Linear), and notifier (desktop/Slack)
-- **Reaction system**: configurable auto-responses to CI failures (agent retries fix), review comments (agent addresses feedback), and approved PRs (notify or auto-merge) — the key differentiator over manual multi-agent setups
-- **Overstory**: similar concept with SQLite-backed inter-agent messaging, 4-tier conflict resolution, and a watchdog daemon; pluggable AgentRuntime interface for Claude Code, Pi, Gemini CLI
-- **Convergent patterns across all orchestrators**: (1) git worktree isolation per agent, (2) supervisor/coordinator that decomposes tasks, (3) event-driven reactions to CI/review, (4) dashboard for human oversight, (5) YAML-based configuration
-- **Ecosystem is exploding**: 9+ purpose-built orchestrators emerged in early 2026 (Vibe Kanban, Superset, Symphony, dmux, agtx, Ralph, GoClaw, plus the above) — all converge on worktree isolation as the fundamental primitive
-- The bottleneck has shifted from "can AI write code?" to "how do I run multiple agents in parallel without chaos?" — orchestration is the 2026 scaling lever
+- **Agent-orchestrator** (ComposioHQ, MIT): spawns parallel coding agents each in its own git worktree/branch/PR; pluggable adapters (runtime, agent, workspace, tracker, notifier) with a **reaction system** for CI failures / review comments / approved PRs — the key differentiator over manual setups
+- **Vibe Kanban is sunsetting / now community-maintained** (last release v0.1.41, 2026-04-03, after Bloop's shutdown) — it was a flagship example at last survey, so this is the key correction
+- **Convergent patterns are now treated as industry-standard / table-stakes** rather than emerging: (1) git worktree isolation per agent, (2) supervisor/coordinator, (3) event-driven reactions to CI/review, (4) dashboard for human oversight, (5) YAML config
+- **Industry framing shifted to "orchestration is the competitive battleground"** (Deloitte 2026, Anthropic Trends Report's "orchestration era"); consolidation is happening at the model/platform layer, not (yet) among the standalone open-source orchestrators — no single one has emerged as outright winner
+- The bottleneck has shifted from "can AI write code?" to "how do I run multiple agents in parallel without chaos?"
 
-**Relevance**: This workspace already has the foundational primitives that all orchestrators build on: worktree isolation scripts, draft-PR visibility, workforce protocol, and multi-framework identity. The gaps relative to agent-orchestrator are: (1) **no reaction system** — CI failures and review comments require manual agent re-engagement; (2) **no dashboard** — `worktree_list.sh` shows status but lacks a unified view of agent progress, CI, and PRs; (3) **no automated task decomposition** — issues are manually assigned to agents; (4) **no inter-agent messaging** — agents can't coordinate or hand off work. Of these, a reaction system for CI failures and review feedback would deliver the most immediate value, since agents already create PRs but can't respond to CI/review events autonomously. See [#375](https://github.com/rolker/ros2_agent_workspace/issues/375).
+**Relevance**: This workspace already has the foundational primitives all orchestrators build on: worktree isolation scripts, draft-PR visibility, workforce protocol, multi-framework identity. The gaps relative to agent-orchestrator remain: (1) **no reaction system** — CI failures and review comments need manual agent re-engagement; (2) **no unified dashboard** of agent progress + CI + PRs; (3) **no automated task decomposition**; (4) **no inter-agent messaging** (Agent Teams, above, is the likeliest path to close this). A reaction system for CI/review events would deliver the most immediate value. See [#375](https://github.com/rolker/ros2_agent_workspace/issues/375).
 
 ---
 

--- a/.agent/knowledge/research_digest.md
+++ b/.agent/knowledge/research_digest.md
@@ -1,8 +1,9 @@
 # Research Digest: Workspace
 
-<!-- Last updated: 2026-05-28 -->
+<!-- Last updated: 2026-05-29 -->
 <!-- If older than 30 days, consider running /research --refresh; entries older than 90 days should be flagged for review -->
 <!-- 2026-05-28 full re-survey: refreshed all Feb–Mar 2026 landscape entries (the prior 2026-05-27 pass had only touched two). Original "Added" dates preserved; "Updated" stamps mark this pass. "Operational-Assistant Behavior Under Live Time Pressure" (2026-05-27) was already fresh and left as-is. Workspace-wide note: Opus 4.6 is no longer the current model — Opus 4.7 (2026-04-16) and Opus 4.8 (2026-05-28) shipped in this window; treat any "Opus 4.6 is current" framing elsewhere as stale. -->
+<!-- 2026-05-29 addendum: added "Claude Opus 4.8 — Model, Fast Mode & Dynamic Workflows" entry covering the 2026-05-28 release and the agentic-tooling features announced with it (Dynamic Workflows / ultracode, cheaper fast mode, the Agent View / background-session scaffolding). -->
 
 ## Command Runner Alternatives to Make
 
@@ -93,6 +94,21 @@ Key takeaways:
 - **Cost is linear in parallelism** — no separate agent pricing; N agents burn quota Nx
 
 **Relevance**: The workspace's worktree infrastructure already provides the isolation Teams assume — each teammate works in its own worktree. The shared-task-list + peer-mailbox model (plus the new task-dependency + file-locking primitives) is directly relevant to the multi-host, multi-agent deployment lifecycle ([#495](https://github.com/rolker/ros2_agent_workspace/issues/495), [#470](https://github.com/rolker/ros2_agent_workspace/issues/470)): a deployment could run as a team (per-host loggers + a lead) rather than uncoordinated parallel sessions. Still experimental, so not yet a dependency to build on.
+
+---
+
+## Claude Opus 4.8 — Model, Fast Mode & Dynamic Workflows
+
+**Added**: 2026-05-29 | **Sources**: [Introducing Claude Opus 4.8](https://www.anthropic.com/news/claude-opus-4-8), [Claude Code: Workflows](https://code.claude.com/docs/en/workflows), [Claude Code changelog](https://code.claude.com/docs/en/changelog), [Fast mode docs](https://platform.claude.com/docs/en/build-with-claude/fast-mode), [What's new in Opus 4.8](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-8)
+
+Key takeaways:
+- **Opus 4.8** (`claude-opus-4-8`, released 2026-05-28): pricing unchanged from 4.7 ($5/$25 per MTok); **1M-token context default** on the Claude API / Bedrock / Vertex (the tier this workspace runs on — note 1M went GA back with 4.6, not new here). Anthropic claims it is **~4× less likely than its predecessor to let code flaws pass unremarked** and is their strongest computer-use model (84% Online-Mind2Web). Quantitative benchmark numbers circulating (e.g. SWE-bench Verified ~88.6%) are **third-party (LLM-Stats et al.), unofficial pending the system card.**
+- **Dynamic Workflows** (research preview, Claude Code v2.1.154+, all paid plans): Claude authors a **JS orchestration script** that spins up background subagents while the session stays responsive — for codebase-scale migrations, bug sweeps, cross-checked research. Caps: **1,000 agents/run, 16 concurrent**. The script itself can't touch the filesystem/shell — only the spawned agents can; `/workflows` views runs. The new **`ultracode` effort** (`/effort ultracode`) = xhigh reasoning + automatic workflow orchestration per task.
+- **Fast mode** for Opus 4.8: ~2.5× output tokens/sec at a **much cheaper tier** than before (API $10/$50; ~3× cheaper than the old 4.6/4.7 fast rate); research preview, draws on usage credits. This is the `/fast` toggle in Claude Code.
+- **Supporting multi-agent scaffolding** (landed slightly earlier in May, not strictly part of the 4.8 post but relevant): **Agent View** dashboard (`claude agents`, research preview), `/goal` (work-until-condition-met), pinned background sessions (`Ctrl+T`), `/code-review` + `--fix`, `/simplify` (now cleanup-only), and `MessageDisplay`/`SessionStart` hooks. Subagents use **isolated context windows**, returning only relevant info to the orchestrator (explicit context-engineering rationale).
+- **API/context features** (mostly pre-existing, re-confirmed at this release): mid-conversation system messages that preserve prompt-cache hits (new, GA), `effort` defaulting to `high`, adaptive thinking, plus the memory tool / context editing / compaction APIs. **Agent SDK** (TS + Python) gains 4.8 via the bundled CLI; recent SDK additions include a `SessionStore` (S3/Redis/Postgres mirroring), an `EffortLevel` type, and Task tools.
+
+**Relevance**: **Dynamic Workflows is the in-product orchestration primitive** the "Agent Orchestrators" entry below was tracking as a workspace gap ([#375](https://github.com/rolker/ros2_agent_workspace/issues/375)) — Claude-authored fan-out over background subagents, each in an isolated context, composes naturally with our worktree isolation (subagents that mutate files can run in their own worktrees). Combined with Agent View + `/goal` + pinned sessions, it's a credible substrate for the multi-host, multi-agent deployment lifecycle ([#495](https://github.com/rolker/ros2_agent_workspace/issues/495)) — a lighter, single-lead alternative to the still-experimental Agent Teams. The "4× fewer unflagged code flaws" claim and the `/code-review --fix` / `ultracode` tooling map onto our Quality Standard and the `review-code` skill. **Caveat**: Dynamic Workflows, fast mode, `ultracode`, and Agent View are all **research preview** — useful now, not yet stable enough to hard-wire into governed scripts. Workflows can also burn tokens fast (up to 1,000 agents), so scope them deliberately.
 
 ---
 
@@ -228,7 +244,7 @@ Key takeaways:
 - **Industry framing shifted to "orchestration is the competitive battleground"** (Deloitte 2026, Anthropic Trends Report's "orchestration era"); consolidation is happening at the model/platform layer, not (yet) among the standalone open-source orchestrators — no single one has emerged as outright winner
 - The bottleneck has shifted from "can AI write code?" to "how do I run multiple agents in parallel without chaos?"
 
-**Relevance**: This workspace already has the foundational primitives all orchestrators build on: worktree isolation scripts, draft-PR visibility, workforce protocol, multi-framework identity. The gaps relative to agent-orchestrator remain: (1) **no reaction system** — CI failures and review comments need manual agent re-engagement; (2) **no unified dashboard** of agent progress + CI + PRs; (3) **no automated task decomposition**; (4) **no inter-agent messaging** (Agent Teams, above, is the likeliest path to close this). A reaction system for CI/review events would deliver the most immediate value. See [#375](https://github.com/rolker/ros2_agent_workspace/issues/375).
+**Relevance**: This workspace already has the foundational primitives all orchestrators build on: worktree isolation scripts, draft-PR visibility, workforce protocol, multi-framework identity. The gaps relative to agent-orchestrator remain: (1) **no reaction system** — CI failures and review comments need manual agent re-engagement; (2) **no unified dashboard** of agent progress + CI + PRs; (3) **no automated task decomposition**; (4) **no inter-agent messaging** (Agent Teams, above, is the likeliest path to close this). A reaction system for CI/review events would deliver the most immediate value. See [#375](https://github.com/rolker/ros2_agent_workspace/issues/375). **Update (2026-05-29)**: Claude Code's **Dynamic Workflows** (see the "Claude Opus 4.8" entry above) now provides an in-product version of primitives (1)–(2) for the Claude Code runtime specifically — Claude-authored fan-out over isolated-context background subagents — narrowing the gap without a third-party orchestrator.
 
 ---
 

--- a/.agent/knowledge/research_digest.md
+++ b/.agent/knowledge/research_digest.md
@@ -151,7 +151,7 @@ Key takeaways:
 - **Consolidation is the new headline**: top three (Cursor, Copilot, Claude Code) hold **70%+ share** ("winner-take-most"); M&A wave — OpenAI 6 acquisitions in early 2026, Google's $2.4B Windsurf/Codeium acqui-hire, Anthropic acquired Vercept
 - **Anthropic 2026 Trends Report** stats: 78% of Q1 2026 Claude Code sessions are multi-file edits (up from 34% Q1 2025); avg session 4min→23min; well-maintained context files → 40% fewer errors / 55% faster
 - **Adoption-vs-production gap** reframed: ~79% adoption vs ~11% actually in production (the older "57% in prod" framing overstates it); Gartner's 1,445% multi-agent inquiry surge still valid
-- Quality concern persists: more code enters pipelines than reviewers can validate; **worktree isolation has converged as an industry standard**; mini-swe-agent validates radical simplicity
+- Quality concern persists: more code enters pipelines than reviewers can validate; **worktree isolation has converged as an industry standard**; mini-swe-agent validates extreme minimalism
 - **GitHub Copilot CLI reached GA (Apr 2026)**, but **GitHub Agentic Workflows remains in technical preview, not GA** — don't conflate the two
 
 **Relevance**: The convergence on worktree isolation validates our architecture. The quality-deficit numbers and adoption/production gap reinforce the importance of the harness (lints, CI, structural enforcement) over raw agent throughput. GitHub Agentic Workflows are still worth monitoring for issue triage and CI-failure-investigation automation.


### PR DESCRIPTION
## Summary

Full `/research --refresh` of the workspace research digest
(`.agent/knowledge/research_digest.md`). The prior 2026-05-27 pass had only
refreshed *Claude Code Agent Teams* and added the *Operational-Assistant*
entry, leaving the 15 Feb–Mar 2026 landscape entries at their original survey
dates — now ~90 days old and at the digest's own review threshold. This pass
re-surveys all of them via parallel web research. Original **Added** dates are
preserved; **Updated: 2026-05-28** stamps mark what changed.

## Notable changes

- **Claude Code Agent Teams** — re-verified *still experimental / disabled by
  default* (no GA). Model context moved on: **Opus 4.7 (Apr 16) and Opus 4.8
  (May 28)** are now current, not 4.6. Added min v2.1.32 + new teammate hooks,
  plan-approval, task dependencies, file-locking.
- **Agentic Coding Market** — sizing revised up to **~$9.8–11B (Apr 2026)**;
  top-three (Cursor/Copilot/Claude Code) 70%+ consolidation + M&A wave; Anthropic
  2026 Trends Report stats; Copilot CLI went GA but Agentic Workflows is *still
  technical preview* (don't conflate).
- **Agent Orchestrators** — **Vibe Kanban is sunsetting/community-maintained**
  (was a flagship example); convergent patterns now table-stakes; "orchestration
  is the battleground" framing.
- **MCP** — **2025-11-25 spec is current GA**; **2026-07-28 RC** upcoming
  (stateless core, MCP Apps, auth hardening); AAIF/LF governance; added
  kakimochi + lpigeon ROS 2 MCP servers (`/cmd_vel`, model-agnostic).
- **ROS 2 Agent Frameworks** — RAI 2.0 rewrite; ROSA IsaacSim integration; new
  **ROSClaw** entrant (safety-envelope + audit-logging — echoes our Quality
  Standard for the cmd_vel-only stack).
- **Harness Engineering** — Latent Space primary interview (1,500 PRs, **0%
  human review**, ¼→3–10 eng-equivalent/person); now framed as the "fourth
  paradigm"; added a **criticism/limitations** note (optimism asymmetry —
  agents predict fixes well, regressions poorly).
- **AGENTS.md** — AAIF **~190 members** (43 added May 18); tool list adds
  Amp + Factory; AGNTCon/MCPCon events.
- **AI Spec Writing** — added Agent Experience (AX) design + per-role personas;
  line guidance widened to 150–200.
- **GitHub Outage Resilience** — reliability crisis **worsened** (Apr tied Feb
  as worst month); **Apr 23 Merge Queue data-corruption bug** (softens "core git
  ops unaffected"); Azure migration only ~12.5% complete. CTO root-cause statement.
- **Forgejo/Gitea** — Forgejo **v15.0** / Gitea **v1.26.x**; now *diverging*,
  not "near-identical"; Forgejo Actions added OIDC/concurrency/matrix.
- **Command runners** — `just` v1.51.0; **just-mcp** now production-ready.
- **ROS 2 Offline** — new distro **Lyrical Luth** (2026 LTS, to May 2031);
  offline mechanics unchanged.
- **git-bug** — v0.10.1 still latest (cadence quiet); **act** v0.2.88 (minor).
- **Multi-Agent Patterns** — facts unchanged; converging into the harness-eng
  literature.
- **Operational-Assistant** (2026-05-27) — left as-is (fresh).

## Method

Five parallel research sub-agents (themed clusters), each web-searching for
developments since the entries' dates; findings synthesized into the digest.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`


---

## Addendum (2026-05-29): Claude Opus 4.8 release entry

Added a new entry — **"Claude Opus 4.8 — Model, Fast Mode & Dynamic Workflows"** —
covering the 2026-05-28 release and the agentic-tooling features announced with it,
scoped to what's relevant to this workspace:

- **Opus 4.8 model**: 1M-token context default (the tier we run on), Anthropic's
  "~4× less likely to let code flaws pass unremarked" claim (Quality Standard
  relevance), pricing unchanged. Benchmark figures flagged as third-party/unofficial
  pending the system card.
- **Dynamic Workflows** (research preview, Claude Code v2.1.154+): Claude-authored
  JS orchestration over background subagents (caps 1,000/run, 16 concurrent),
  isolated subagent contexts, `/workflows`, `ultracode` effort — cross-linked to the
  Agent Orchestrators entry's [#375](https://github.com/rolker/ros2_agent_workspace/issues/375)
  gap analysis as the in-product orchestration primitive that was missing.
- Cheaper **fast mode** (the `/fast` toggle); the **Agent View / `/goal` / pinned
  background sessions / `/code-review --fix`** scaffolding.
- Context/API + Agent SDK additions noted as mostly pre-existing.

All preview-stage features flagged as not-yet-stable-to-hard-wire. Sourced from
Anthropic news + code.claude.com/docs + platform.claude.com docs.
