### PR TITLE
Run .agent/scripts/tests in CI via make test-scripts (closes #509)

### DIFF
--- a/.agent/scripts/tests/run_script_tests.sh
+++ b/.agent/scripts/tests/run_script_tests.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# .agent/scripts/tests/run_script_tests.sh
+# Runs every script-level test and aggregates the result:
+#   - test_*.sh  → executed with bash (each self-reports and exits non-zero on failure).
+#                  Covers both .agent/scripts/tests/ and the few sibling tests that
+#                  live directly in .agent/scripts/ (e.g. test_check_commit_identity.sh).
+#   - test_*.py  → run via pytest, which collects both unittest-style
+#                  (test_progress_read.py) and pytest-style (test_build_report_generator.py)
+# Exits non-zero if any test file fails. The tests are hermetic (temp sandboxes,
+# stubbed `gh`, no network, no ROS), so this is safe to run in lightweight CI.
+#
+# PYTHON env var selects the interpreter for pytest (default: python3); it must
+# have pytest installed. Not on PATH — run by absolute path or via `make test-scripts`.
+set -uo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(dirname "$TESTS_DIR")"
+PYTHON="${PYTHON:-python3}"
+fail=0
+shopt -s nullglob
+
+echo "=== Shell tests ==="
+# Sibling tests in scripts/ first, then the tests/ dir. The non-recursive globs
+# don't overlap (tests/ is a subdir, not matched by "$SCRIPTS_DIR"/test_*.sh).
+for f in "$SCRIPTS_DIR"/test_*.sh "$TESTS_DIR"/test_*.sh; do
+    name=$(basename "$f")
+    if out=$(bash "$f" 2>&1); then
+        echo "  ✅ $name"
+    else
+        echo "  ❌ $name"
+        echo "$out" | sed 's/^/      /'
+        fail=1
+    fi
+done
+
+echo ""
+echo "=== Python tests (pytest) ==="
+py_tests=("$TESTS_DIR"/test_*.py)
+if [ "${#py_tests[@]}" -gt 0 ]; then
+    if ! "$PYTHON" -m pytest "$TESTS_DIR" -q; then
+        fail=1
+    fi
+else
+    echo "  (none)"
+fi
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+    echo "✅ All script tests passed."
+else
+    echo "❌ Some script tests failed."
+fi
+exit "$fail"

--- a/.agent/scripts/tests/test_detect_cli_env.sh
+++ b/.agent/scripts/tests/test_detect_cli_env.sh
@@ -1,133 +1,63 @@
 #!/bin/bash
 # .agent/scripts/tests/test_detect_cli_env.sh
-# Basic tests for framework detection
+# Tests the framework-detection contract of detect_cli_env.sh.
+#
+# detect_cli_env.sh keys ONLY on session-specific signals — deliberately NOT on
+# API credentials (GEMINI_API_KEY / ANTHROPIC_API_KEY / CLAUDE_API_KEY), which
+# users commonly have in their profile and which do not indicate an active
+# session. The negative cases below pin that intentional behavior.
+#
+# Each case runs detection in a fresh `env -i` subshell so exactly one signal is
+# present — the suite itself runs inside an agent session (e.g. Claude Code sets
+# CLAUDECODE), which would otherwise leak in and mask non-claude expectations.
+#
+# Run: bash .agent/scripts/tests/test_detect_cli_env.sh
 
-set -e
-
+set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DETECT="$SCRIPT_DIR/../detect_cli_env.sh"
 TEST_PASS=0
 TEST_FAIL=0
 
-echo "=== Testing Framework Detection ==="
-echo ""
-
-# Test 1: Copilot CLI detection (if gh is available)
-echo "Test 1: Copilot CLI detection"
-if command -v gh &> /dev/null && gh copilot --version &> /dev/null 2>&1; then
-    source "$SCRIPT_DIR/../detect_cli_env.sh"
-    if [ "$AGENT_FRAMEWORK" == "copilot-cli" ]; then
-        echo "✅ PASS: Detected copilot-cli"
-        TEST_PASS=$((TEST_PASS + 1))
+# assert_framework <desc> <expected> [VAR=val ...]
+# Runs detection with ONLY the given vars set (clean env + PATH for `command -v`).
+# `source ... || true` guards the unknown-case `return 1`; AGENT_FRAMEWORK is
+# always assigned ("unknown") before that return, so the value is meaningful.
+assert_framework() {
+    local desc="$1" expected="$2"; shift 2
+    local got
+    got=$(env -i PATH="$PATH" DETECT="$DETECT" "$@" bash -c 'source "$DETECT" 2>/dev/null || true; printf "%s" "$AGENT_FRAMEWORK"')
+    if [ "$got" = "$expected" ]; then
+        echo "  ✅ $desc"; TEST_PASS=$((TEST_PASS + 1))
     else
-        echo "❌ FAIL: Expected copilot-cli, got $AGENT_FRAMEWORK"
-        TEST_FAIL=$((TEST_FAIL + 1))
+        echo "  ❌ $desc (expected '$expected', got '$got')"; TEST_FAIL=$((TEST_FAIL + 1))
     fi
-else
-    echo "⊘  SKIP: GitHub CLI not available or copilot extension not installed"
-fi
+}
+
+echo "=== Testing detect_cli_env.sh detection contract ==="
 echo ""
 
-# Test 2: Gemini detection via environment variable
-echo "Test 2: Gemini CLI detection via GEMINI_API_KEY"
-(
-    export GEMINI_API_KEY="test_key"
-    source "$SCRIPT_DIR/../detect_cli_env.sh"
-    if [ "$AGENT_FRAMEWORK" == "gemini-cli" ]; then
-        echo "✅ PASS: Detected gemini-cli via API key"
-        exit 0
-    else
-        echo "❌ FAIL: Expected gemini-cli, got $AGENT_FRAMEWORK"
-        exit 1
-    fi
-)
-if [ $? -eq 0 ]; then
-    TEST_PASS=$((TEST_PASS + 1))
-else
-    TEST_FAIL=$((TEST_FAIL + 1))
-fi
+echo "Positive cases (session-specific signals):"
+assert_framework "Copilot via COPILOT_API_URL"            copilot-cli  COPILOT_API_URL="https://example"
+assert_framework "Copilot via COPILOT_AGENT_CALLBACK_URL" copilot-cli  COPILOT_AGENT_CALLBACK_URL="https://example"
+assert_framework "Gemini via GEMINI_SESSION"              gemini-cli   GEMINI_SESSION="1"
+assert_framework "Gemini via gemini-ish USER"             gemini-cli   USER="gemini-bot"
+assert_framework "Antigravity via USER"                   antigravity  USER="antigravity"
+assert_framework "Antigravity via ANTIGRAVITY_SESSION"    antigravity  ANTIGRAVITY_SESSION="1"
+assert_framework "Claude via CLAUDECODE"                  claude-code  CLAUDECODE="1"
+assert_framework "Claude via CLAUDE_CODE"                 claude-code  CLAUDE_CODE="1"
+assert_framework "Claude via CLAUDE_CODE_ENTRYPOINT"      claude-code  CLAUDE_CODE_ENTRYPOINT="cli"
+assert_framework "Generic via AI_AGENT_NAME (lowercased)" foobot       AI_AGENT_NAME="FooBot"
 echo ""
 
-# Test 3: Antigravity detection via USER
-echo "Test 3: Antigravity detection via USER variable"
-(
-    export USER="antigravity"
-    source "$SCRIPT_DIR/../detect_cli_env.sh"
-    if [ "$AGENT_FRAMEWORK" == "antigravity" ]; then
-        echo "✅ PASS: Detected antigravity via USER"
-        exit 0
-    else
-        echo "❌ FAIL: Expected antigravity, got $AGENT_FRAMEWORK"
-        exit 1
-    fi
-)
-if [ $? -eq 0 ]; then
-    TEST_PASS=$((TEST_PASS + 1))
-else
-    TEST_FAIL=$((TEST_FAIL + 1))
-fi
+echo "Negative cases (no session signal → unknown):"
+assert_framework "Bare environment"                       unknown
+assert_framework "GEMINI_API_KEY is NOT a session signal" unknown      GEMINI_API_KEY="test_key"
+assert_framework "GOOGLE_API_KEY is NOT a session signal" unknown      GOOGLE_API_KEY="test_key"
+assert_framework "ANTHROPIC_API_KEY is NOT a session signal" unknown   ANTHROPIC_API_KEY="test_key"
+assert_framework "CLAUDE_API_KEY is NOT a session signal" unknown      CLAUDE_API_KEY="test_key"
 echo ""
 
-# Test 4: Claude Code detection via CLAUDE_CODE env var
-echo "Test 4: Claude Code detection via CLAUDE_CODE"
-(
-    export CLAUDE_CODE=1
-    source "$SCRIPT_DIR/../detect_cli_env.sh"
-    if [ "$AGENT_FRAMEWORK" == "claude-code" ]; then
-        echo "✅ PASS: Detected claude-code via CLAUDE_CODE"
-        exit 0
-    else
-        echo "❌ FAIL: Expected claude-code, got $AGENT_FRAMEWORK"
-        exit 1
-    fi
-)
-if [ $? -eq 0 ]; then
-    TEST_PASS=$((TEST_PASS + 1))
-else
-    TEST_FAIL=$((TEST_FAIL + 1))
-fi
-echo ""
-
-# Test 5: Claude Code detection via ANTHROPIC_API_KEY
-echo "Test 5: Claude Code detection via ANTHROPIC_API_KEY"
-(
-    export ANTHROPIC_API_KEY="test_key"
-    source "$SCRIPT_DIR/../detect_cli_env.sh"
-    if [ "$AGENT_FRAMEWORK" == "claude-code" ]; then
-        echo "✅ PASS: Detected claude-code via ANTHROPIC_API_KEY"
-        exit 0
-    else
-        echo "❌ FAIL: Expected claude-code, got $AGENT_FRAMEWORK"
-        exit 1
-    fi
-)
-if [ $? -eq 0 ]; then
-    TEST_PASS=$((TEST_PASS + 1))
-else
-    TEST_FAIL=$((TEST_FAIL + 1))
-fi
-echo ""
-
-# Test 6: Claude Code detection via CLAUDE_API_KEY
-echo "Test 6: Claude Code detection via CLAUDE_API_KEY"
-(
-    export CLAUDE_API_KEY="test_key"
-    source "$SCRIPT_DIR/../detect_cli_env.sh"
-    if [ "$AGENT_FRAMEWORK" == "claude-code" ]; then
-        echo "✅ PASS: Detected claude-code via CLAUDE_API_KEY"
-        exit 0
-    else
-        echo "❌ FAIL: Expected claude-code, got $AGENT_FRAMEWORK"
-        exit 1
-    fi
-)
-if [ $? -eq 0 ]; then
-    TEST_PASS=$((TEST_PASS + 1))
-else
-    TEST_FAIL=$((TEST_FAIL + 1))
-fi
-echo ""
-
-# Summary
 echo "========================================"
 echo "TEST RESULTS"
 echo "========================================"

--- a/.agent/scripts/tests/test_revert_feature.sh
+++ b/.agent/scripts/tests/test_revert_feature.sh
@@ -73,7 +73,11 @@ test_invalid_issue_number() {
     (
         setup_test_repo
         local output result
-        output=$("$REVERT_SCRIPT" --issue "abc" 2>&1 || true)
+        # No `|| true` here: it would make the substitution exit 0, so `result`
+        # would never capture the script's real (non-zero) exit code and the
+        # `[[ $result -ne 0 ]]` check below could never pass. The suite runs
+        # without `set -e`, so a non-zero rc here doesn't abort the test.
+        output=$("$REVERT_SCRIPT" --issue "abc" 2>&1)
         result=$?
         cleanup_test_repo
         [[ $result -ne 0 ]] && [[ "$output" =~ "must be numeric" ]]
@@ -86,7 +90,9 @@ test_no_commits_found() {
     (
         setup_test_repo
         local output result
-        output=$("$REVERT_SCRIPT" --issue 999 2>&1 || true)
+        # See the note in test_invalid_issue_number: dropping `|| true` lets
+        # `result` capture the script's real exit code (the suite has no `set -e`).
+        output=$("$REVERT_SCRIPT" --issue 999 2>&1)
         result=$?
         cleanup_test_repo
         [[ $result -ne 0 ]] && [[ "$output" =~ "No commits found" ]]

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -49,6 +49,27 @@ jobs:
           config-file: '.github/markdown-link-check.json'
         continue-on-error: true
 
+  script-tests:
+    name: Script tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Install pytest
+        run: python3 -m pip install --upgrade pip pytest
+
+      # Runs .agent/scripts/tests/ (shell via bash, python via pytest). These are
+      # hermetic (temp git sandboxes, stubbed gh, no network/ROS), so no build or
+      # workspace setup is needed — just git (preinstalled on the runner) + pytest.
+      - name: Run script tests
+        run: make test-scripts
+
   validate-commit-identity:
     name: Validate commit identity (Mechanism C)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 LAYER_STAMPS := $(patsubst %,$(STAMP)/layer-%.done,$(LAYERS))
 
 # --- Phony targets ---
-.PHONY: help build _build-layers test lint clean setup-all _setup-all-layers dashboard dashboard-ui test-dashboard validate sync lock unlock revert-feature pr-triage generate-skills skip-bootstrap skip-git-bug agent-build agent-run agent-shell push-gateway add-remote push-remote pull-remote merge-pr
+.PHONY: help build _build-layers test test-scripts lint clean setup-all _setup-all-layers dashboard dashboard-ui test-dashboard validate sync lock unlock revert-feature pr-triage generate-skills skip-bootstrap skip-git-bug agent-build agent-run agent-shell push-gateway add-remote push-remote pull-remote merge-pr
 
 # =============================================================================
 # Tier 2 — Developer workflow
@@ -64,6 +64,7 @@ help:
 	@echo "  dashboard QUICK=1 - Quick mode (skip sync and GitHub API)"
 	@echo "  dashboard-ui  - Start web-based dashboard (http://localhost:3000)"
 	@echo "  test-dashboard - Run dashboard unit/integration tests (ephemeral port)"
+	@echo "  test-scripts  - Run .agent/scripts/tests/ (shell + pytest, no ROS build)"
 	@echo "  validate      - Validate workspace config (CI-oriented, pass/fail)"
 	@echo ""
 	@echo "Remote sync:"
@@ -132,6 +133,10 @@ dashboard-ui:
 test-dashboard:
 	@PYTHON=$$([ -x "$(VENV_BIN)/python3" ] && echo "$(VENV_BIN)/python3" || echo "python3"); \
 	$$PYTHON -m unittest discover .agent/tools/dashboard/tests -v
+
+test-scripts:
+	@PYTHON=$$([ -x "$(VENV_BIN)/python3" ] && echo "$(VENV_BIN)/python3" || echo "python3"); \
+	PYTHON=$$PYTHON ./.agent/scripts/tests/run_script_tests.sh
 
 validate:
 	@python3 ./.agent/scripts/validate_workspace.py


### PR DESCRIPTION
Closes #509.

## Problem

The script-level tests under `.agent/scripts/tests/` (and two siblings directly
in `.agent/scripts/`) were never run by CI, the Makefile, or pre-commit — only
manually. So regressions in workspace scripts weren't caught automatically.
Auditing for this change found **two test files silently failing**, never noticed
because nothing ran them.

## What's here

**1. Fix the two silently-failing test files** (separate commits; both were *test*
bugs — the scripts under test were correct):
- `test_revert_feature.sh` — tests 3-4 wrote `output=$(… || true); result=$?`,
  so `result` could never capture the script's non-zero exit and the
  `[[ $result -ne 0 ]]` checks never asserted anything. Dropped `|| true`.
- `test_detect_cli_env.sh` — encoded an **old** detection contract: expected API
  credentials (`GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, `CLAUDE_API_KEY`) to imply a
  framework, and gated copilot on `gh copilot` being installed. The script
  deliberately keys only on session-specific signals. Rewrote to assert the real
  contract — each case in an isolated `env -i` subshell, with negative cases
  pinning the intentional non-detection of API creds.

**2. Wire them into CI:**
- `run_script_tests.sh` — runs every `test_*.sh` with bash and the `test_*.py`
  files with pytest (collects both unittest- and pytest-style suites). Covers
  `.agent/scripts/tests/` **and** the sibling `test_*.sh` in `.agent/scripts/`
  (`test_check_commit_identity.sh`, `test_identity_introspection.sh`). Aggregates,
  exits non-zero on any failure.
- `make test-scripts` (+ `.PHONY` + help), same venv-or-python3 selection as
  `test-dashboard`, no prerequisites (won't trigger a build).
- `Script tests` job in `validate.yml`: setup-python + `pip install pytest` +
  `make test-scripts`.

## Coverage & hermeticity

All script tests now run: **10 shell files + 2 python files (51 pytest cases)**.
Verified hermetic — the shell tests pass with an **unauthenticated `gh`** stubbed
on `PATH` (temp git sandboxes, no network, no ROS), so the lightweight CI job
needs only `git` (preinstalled) + pytest.

Reviewed pre-push by a fresh-context adversarial sub-agent (APPROVE; its one
suggestion — fold in the two `.agent/scripts/` siblings — is included here).

## Test plan
- [x] `make test-scripts` → 10 shell + 51 pytest, all pass
- [x] Confirmed the two fixed tests fail on the pre-fix code, pass after
- [x] Shell tests pass with a failing/stubbed `gh` on PATH (CI hermeticity)
- [x] pre-commit (shellcheck, yamllint) clean

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
