### PR TITLE
start-deployment: forbid typed timestamps + add dlog helper (closes #504)

### DIFF
--- a/.agent/knowledge/deployment_mode.md
+++ b/.agent/knowledge/deployment_mode.md
@@ -70,8 +70,14 @@ the skill puts the contract in context. The fuller treatment below explains
    them out at wrap-up.
 6. **Avoid permission prompts.** Use `git -C <path>`, absolute paths, `gh -R`,
    and the file tools over heredocs / find / cat. The allowlist defeats
-   itself when commands are wrapped in `cd && …`. Generate timestamps with
-   `date '+%Y-%m-%d %H:%M %:z'`, not `date | sed`.
+   itself when commands are wrapped in `cd && …`. **Generate every timestamp
+   by invoking `date '+%Y-%m-%d %H:%M %:z'` — never type a plausible-looking
+   time, even when typing feels faster under pressure.** A typed time is a
+   durable lie the wrap-up integration and downstream analysis will trust;
+   for an operator-reported event, `date`-stamp when you log it and mark
+   their time `~HH:MM (operator-reported)`. (And `date '+…'`, not
+   `date | sed`.) The `start-deployment` skill provides a `dlog` helper that
+   bakes `date` into each entry so this is the easy path.
 7. **Sterile cockpit.** During live on-water ops, do *only* operation-essential
    work — no doc polish, refactors, or "while we're here" cleanups. Write
    them down for wrap-up.

--- a/.claude/skills/start-deployment/SKILL.md
+++ b/.claude/skills/start-deployment/SKILL.md
@@ -66,7 +66,14 @@ explicitly invokes the wrap-up flow or activates a different mode).
 6. **Avoid permission prompts.** Use `git -C <path>`, absolute paths,
    `gh -R`, and the file tools over heredocs / find / cat. The
    allowlist defeats itself when commands are wrapped in `cd && …`.
-   Timestamps: `date '+%Y-%m-%d %H:%M %:z'`, never `date | sed`.
+   **Timestamps: invoke `date '+%Y-%m-%d %H:%M %:z'` for every
+   timestamped entry — never type a time that "looks right," even when
+   typing feels faster under pressure.** A typed time is a durable lie
+   the wrap-up integration and downstream analysis will trust. For an
+   event the operator reports after the fact, call `date` to record
+   *when you're logging it* and write the operator's time separately as
+   `~HH:MM (operator-reported)`. Use `date '+…'`, never `date | sed`;
+   reach for the `dlog` helper below so the timestamp is never optional.
 7. **Sterile cockpit.** During live on-water ops, do *only*
    operation-essential work — no doc polish, refactors, or "while we're
    here" cleanups. Write them down for wrap-up.
@@ -290,6 +297,23 @@ Started: <YYYY-MM-DD HH:MM ±HH:MM>
 Any title / body / log-stamp warnings emitted below append to this
 file. It is the canonical sink for field-side drift warnings; dev side
 also appends here for parity.
+
+**Append entries with a `date`-baked helper.** Define this once after
+creating the log file, then use it for every entry so a measured
+timestamp is the path of least resistance (rule 6 — never type times by
+hand):
+
+```bash
+LOGFILE="<project_repo>/<log_dir>/<YYYY>/<YYYY-MM-DD>_<label>_logs.md"
+dlog() { printf '\n**%s** — %s\n' "$(date '+%Y-%m-%d %H:%M %:z')" "$1" >> "$LOGFILE"; }
+dlog "charger disconnected; controls check good; going to launch"
+```
+
+For an event the operator reports after the fact — whose time you did
+**not** measure — let `dlog` stamp when you're recording it and put the
+operator's time in the text, marked approximate:
+`dlog "in water (operator-reported ~12:35)"`. Never back-fill the
+header timestamp to the operator's time; the header is when *you* logged.
 
 **Verify the issue title** (form: `Deployment <YYYY-MM-DD>: <scope>`):
 


### PR DESCRIPTION
Closes #504.

## Problem

The first production run of `/start-deployment` fabricated most of the per-host
log timestamps — typed plausible-looking times instead of calling `date`. The
operator caught it at wrap-up ("some time stamps don't make sense. Did you make
those up?"). The per-host log is the **durable artifact** that feeds wrap-up
integration, bag-correlation analysis, and next-deployment scope, so typed times
are durable lies downstream agents/humans trust.

Root cause: rule 6's terse `Timestamps: date '+…', never date | sed` reads as a
*sed-warning* ("if you call date, don't pipe it"), not "actually **call** date,
don't type a value that looks right."

## Changes

- **`SKILL.md` rule 6** — make the timestamp rule forceful and unambiguous:
  invoke `date` for *every* timestamped entry, never type a time even under
  pressure; for an operator-reported event, `date`-stamp when you log it and
  write the operator's time separately as `~HH:MM (operator-reported)`.
- **`SKILL.md`** — add a `dlog()` helper near the per-host log init so a measured
  timestamp is the path of least resistance, with the operator-reported pattern
  shown.
- **`.agent/knowledge/deployment_mode.md`** — mirror the strengthened wording so
  the urgency contract's two homes stay in sync.

## Out of scope

The issue's candidate #3 (a wrap-up timestamp sanity-check pass — flag
monotonic-by-5-min sequences, too-clean `:00`/`:05` gaps) belongs to the
not-yet-existing `/wrap-up-deployment` skill; it stays tracked under #504/#495.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
