### PR TITLE
sandbox: container identity fix + startup-cost/noise hardening (#489)

### DIFF
--- a/.agent/scripts/configure_git_identity.sh
+++ b/.agent/scripts/configure_git_identity.sh
@@ -97,17 +97,28 @@ if [ "$1" == "--agent" ]; then
     fi
 
 elif [ "$1" == "--detect" ]; then
-    DETECTED=$(detect_framework)
+    # Prefer an identity already present in the environment. This is the
+    # robust path for sandboxed/container runs: docker_run_agent.sh
+    # forwards AGENT_NAME/AGENT_EMAIL (exported on the host by
+    # set_git_identity_env.sh) into the container, where in-container
+    # framework auto-detection can't see the host runtime and would
+    # otherwise return "unknown" and hard-fail. Fall back to
+    # framework-table lookup only when the env vars are absent.
+    if [ -n "${AGENT_NAME:-}" ] && [ -n "${AGENT_EMAIL:-}" ]; then
+        echo "Using identity from environment: $AGENT_NAME <$AGENT_EMAIL>"
+    else
+        DETECTED=$(detect_framework)
 
-    if [ "$DETECTED" == "unknown" ]; then
-        echo "Error: Could not auto-detect framework"
-        echo "Please use --agent <framework> or provide name/email manually"
-        exit 1
+        if [ "$DETECTED" == "unknown" ]; then
+            echo "Error: Could not auto-detect framework, and AGENT_NAME/AGENT_EMAIL are not set in the environment."
+            echo "Use --agent <framework>, export AGENT_NAME + AGENT_EMAIL (e.g. via set_git_identity_env.sh), or provide name/email manually."
+            exit 1
+        fi
+
+        AGENT_NAME="${FRAMEWORK_NAMES[$DETECTED]}"
+        AGENT_EMAIL="${FRAMEWORK_EMAILS[$DETECTED]}"
+        echo "Detected framework: $DETECTED"
     fi
-
-    AGENT_NAME="${FRAMEWORK_NAMES[$DETECTED]}"
-    AGENT_EMAIL="${FRAMEWORK_EMAILS[$DETECTED]}"
-    echo "Detected framework: $DETECTED"
 
 elif [ $# -eq 2 ]; then
     # Manual name and email

--- a/.agent/scripts/configure_git_identity.sh
+++ b/.agent/scripts/configure_git_identity.sh
@@ -100,13 +100,24 @@ elif [ "$1" == "--detect" ]; then
     # Prefer an identity already present in the environment. This is the
     # robust path for sandboxed/container runs: docker_run_agent.sh
     # forwards AGENT_NAME/AGENT_EMAIL (exported on the host by
-    # set_git_identity_env.sh) into the container, where in-container
-    # framework auto-detection can't see the host runtime and would
-    # otherwise return "unknown" and hard-fail. Fall back to
-    # framework-table lookup only when the env vars are absent.
+    # set_git_identity_env.sh) into the container. In-container framework
+    # auto-detection may still resolve (CLAUDE_CODE_ENTRYPOINT is
+    # forwarded, so detect_cli_env.sh reports `claude-code`), but it would
+    # only yield the *generic* framework-table identity — not the actual
+    # launching agent's self-reported name/email. Honoring the forwarded
+    # env vars keeps attribution accurate; fall back to framework-table
+    # lookup only when they are absent.
     if [ -n "${AGENT_NAME:-}" ] && [ -n "${AGENT_EMAIL:-}" ]; then
         echo "Using identity from environment: $AGENT_NAME <$AGENT_EMAIL>"
     else
+        # Guard against a half-set environment: if exactly one of the two
+        # is provided, we cannot trust a guessed counterpart for the
+        # other, so warn that the partial value is being discarded rather
+        # than silently mixing it with a framework-table default.
+        if [ -n "${AGENT_NAME:-}" ] || [ -n "${AGENT_EMAIL:-}" ]; then
+            echo "⚠️  Only one of AGENT_NAME / AGENT_EMAIL is set; ignoring the partial value and falling back to framework detection." >&2
+        fi
+
         DETECTED=$(detect_framework)
 
         if [ "$DETECTED" == "unknown" ]; then

--- a/.agent/scripts/docker_run_agent.sh
+++ b/.agent/scripts/docker_run_agent.sh
@@ -189,6 +189,21 @@ if [ -f "$CLAUDE_CREDS" ]; then
     MOUNT_ARGS+=(-v "$CLAUDE_CREDS:/tmp/claude-credentials.json:ro")
 fi
 
+# 7. Pre-commit hook-env cache — amortize the ~30s hook-environment
+#    install across short container sessions. Ownership is correct
+#    because the container's `ros` user shares the host UID/GID (the
+#    Dockerfile USER_UID/USER_GID build args are set from `id -u`/`id -g`).
+if [ -d "$HOME/.cache/pre-commit" ]; then
+    MOUNT_ARGS+=(-v "$HOME/.cache/pre-commit:/home/ros/.cache/pre-commit")
+fi
+
+# 8. Persist the Claude Code plugin marketplace across runs via a named
+#    volume, so each container start doesn't re-clone claude-plugins-official.
+#    A named volume (not a host bind) keeps it isolated from the host's own
+#    ~/.claude/plugins. The entrypoint's recursive chown of ~/.claude fixes
+#    the root-owned mountpoint docker creates on first use.
+MOUNT_ARGS+=(-v "ros2-agent-claude-plugins:/home/ros/.claude/plugins")
+
 # ---------- Read-only GitHub token (optional) ----------
 # Provides container agents with read-only gh CLI access (view issues, PRs, code search).
 # Token sources (first match wins):
@@ -239,7 +254,13 @@ CONTAINER_CMD=()
 if [ "$SHELL_MODE" = true ]; then
     CONTAINER_CMD=(/bin/bash)
 else
-    CONTAINER_CMD=(claude --dangerously-skip-permissions)
+    # --strict-mcp-config: use only MCP servers from --mcp-config (none
+    # passed) → all MCP servers disabled. Silences the claude.ai
+    # Gmail/Drive/Calendar servers that fail-fast with auth errors on
+    # every start in the credential-less sandbox (they're host-only by
+    # design — see #481 non-goals), removing the startup-log noise and a
+    # round-trip per server. Local skills still resolve via /skill-name.
+    CONTAINER_CMD=(claude --dangerously-skip-permissions --strict-mcp-config)
 fi
 
 # ---------- Launch container ----------

--- a/.agent/scripts/docker_run_agent.sh
+++ b/.agent/scripts/docker_run_agent.sh
@@ -205,9 +205,26 @@ fi
 
 # ---------- Container environment ----------
 
+# Forward the agent git identity into the container. The entrypoint runs
+# `configure_git_identity.sh --detect`, which now prefers these env vars
+# over in-container framework auto-detection (which can't see the host
+# runtime and would otherwise return "unknown" and fail). These are
+# normally exported on the host by set_git_identity_env.sh; warn if they
+# are missing so commits inside the container don't land under a wrong or
+# unset identity.
+if [ "$SHELL_MODE" = false ] && { [ -z "${AGENT_NAME:-}" ] || [ -z "${AGENT_EMAIL:-}" ]; }; then
+    echo "⚠️  AGENT_NAME / AGENT_EMAIL not set — the container will fall back to" >&2
+    echo "    in-container framework detection, which may fail. Source" >&2
+    echo "    .agent/scripts/set_git_identity_env.sh before launching to set them." >&2
+fi
+
 ENV_ARGS=(
     ${ANTHROPIC_API_KEY:+-e "ANTHROPIC_API_KEY"}
     ${AGENT_GH_TOKEN:+-e "GH_TOKEN=$AGENT_GH_TOKEN"}
+    ${AGENT_NAME:+-e "AGENT_NAME=$AGENT_NAME"}
+    ${AGENT_EMAIL:+-e "AGENT_EMAIL=$AGENT_EMAIL"}
+    ${AGENT_MODEL:+-e "AGENT_MODEL=$AGENT_MODEL"}
+    ${AGENT_FRAMEWORK:+-e "AGENT_FRAMEWORK=$AGENT_FRAMEWORK"}
     -e "CLAUDE_CODE_ENTRYPOINT=1"
     -e "ROS2_AGENT_WORKSPACE_ROOT=$ROOT_DIR"
     -e "WORKTREE_ROOT=$WORKTREE_PATH"

--- a/.agent/scripts/docker_run_agent.sh
+++ b/.agent/scripts/docker_run_agent.sh
@@ -190,12 +190,17 @@ if [ -f "$CLAUDE_CREDS" ]; then
 fi
 
 # 7. Pre-commit hook-env cache — amortize the ~30s hook-environment
-#    install across short container sessions. Ownership is correct
-#    because the container's `ros` user shares the host UID/GID (the
-#    Dockerfile USER_UID/USER_GID build args are set from `id -u`/`id -g`).
-if [ -d "$HOME/.cache/pre-commit" ]; then
-    MOUNT_ARGS+=(-v "$HOME/.cache/pre-commit:/home/ros/.cache/pre-commit")
-fi
+#    install across container sessions via a NAMED VOLUME, deliberately
+#    NOT a bind of the host's ~/.cache/pre-commit. A read-write host bind
+#    would let a --dangerously-skip-permissions agent overwrite the
+#    host's hook-environment binaries (interpreters, console-script
+#    shims), which the human then executes at the next host-side commit —
+#    a sandbox-escape / persistence vector outside the PR review path.
+#    A named volume stays writable (pre-commit can install missing envs)
+#    and amortizes across container runs, with no route back to the
+#    host's own cache. First run pays the one-time install; the entrypoint
+#    chowns the root-owned mountpoint to the ros user.
+MOUNT_ARGS+=(-v "ros2-agent-precommit-cache:/home/ros/.cache/pre-commit")
 
 # 8. Persist the Claude Code plugin marketplace across runs via a named
 #    volume, so each container start doesn't re-clone claude-plugins-official.
@@ -222,8 +227,9 @@ fi
 
 # Forward the agent git identity into the container. The entrypoint runs
 # `configure_git_identity.sh --detect`, which now prefers these env vars
-# over in-container framework auto-detection (which can't see the host
-# runtime and would otherwise return "unknown" and fail). These are
+# over in-container framework auto-detection (detection still resolves to
+# the generic `claude-code` table entry via CLAUDE_CODE_ENTRYPOINT, but
+# that loses the launching agent's self-reported identity). These are
 # normally exported on the host by set_git_identity_env.sh; warn if they
 # are missing so commits inside the container don't land under a wrong or
 # unset identity.
@@ -256,10 +262,13 @@ if [ "$SHELL_MODE" = true ]; then
 else
     # --strict-mcp-config: use only MCP servers from --mcp-config (none
     # passed) → all MCP servers disabled. Silences the claude.ai
-    # Gmail/Drive/Calendar servers that fail-fast with auth errors on
-    # every start in the credential-less sandbox (they're host-only by
-    # design — see #481 non-goals), removing the startup-log noise and a
-    # round-trip per server. Local skills still resolve via /skill-name.
+    # Gmail/Drive/Calendar servers (and any other user-scoped MCP servers
+    # inherited via the mounted ~/.claude.json) that fail-fast with auth
+    # errors on every start in the credential-less sandbox — they're
+    # host-only by design (see #481 non-goals). The workspace defines no
+    # project/.mcp.json servers, so nothing the sandbox legitimately needs
+    # is lost; local skills still resolve via /skill-name. Removes the
+    # startup-log noise and a round-trip per server.
     CONTAINER_CMD=(claude --dangerously-skip-permissions --strict-mcp-config)
 fi
 

--- a/.devcontainer/agent/README.md
+++ b/.devcontainer/agent/README.md
@@ -79,17 +79,27 @@ required because git worktree `.git` files contain absolute paths to the parent 
 object store — mounting at a different path would break git operations.
 
 ```
-Host Path                           Container Mount     Access
-────────────────────────────────    ──────────────────  ──────
-<workspace>/                        same path           rw (base)
-<workspace>/.agent/                 same path           ro (overlay)
-<workspace>/.agent/scratchpad/      same path           rw (override)
-<workspace>/layers/main/*_ws/build  anonymous volume    rw (isolated)
-<workspace>/layers/main/*_ws/install anonymous volume   rw (isolated)
-<workspace>/layers/main/*_ws/log   anonymous volume     rw (isolated)
-<workspace>/layers/worktrees/       same path           rw
-<workspace>/.workspace-worktrees/   same path           rw
+Host Path / Source                  Container Mount          Access
+────────────────────────────────    ───────────────────────  ──────
+<workspace>/                        same path                rw (base)
+<workspace>/.agent/                 same path                ro (overlay)
+<workspace>/.agent/scratchpad/      same path                rw (override)
+<workspace>/layers/main/*_ws/build  anonymous volume         rw (isolated)
+<workspace>/layers/main/*_ws/install anonymous volume        rw (isolated)
+<workspace>/layers/main/*_ws/log   anonymous volume          rw (isolated)
+<workspace>/layers/worktrees/       same path                rw
+<workspace>/.workspace-worktrees/   same path                rw
+~/.claude.json, settings, creds     /tmp staging (copied)    ro
+named: ros2-agent-precommit-cache   /home/ros/.cache/pre-commit  rw (isolated)
+named: ros2-agent-claude-plugins    /home/ros/.claude/plugins    rw (isolated)
 ```
+
+The last two are **named Docker volumes**, not host binds. They amortize
+the pre-commit hook-environment install and the Claude plugin-marketplace
+clone across container runs without touching the host's own
+`~/.cache/pre-commit` or `~/.claude/plugins` — see Security Model. Reset
+either with `docker volume rm ros2-agent-precommit-cache` /
+`docker volume rm ros2-agent-claude-plugins` to force a fresh rebuild.
 
 **Mount ordering matters**: Docker processes mounts in order. Later mounts overlay
 earlier ones at the same path. So `.agent/` (ro) overlays the base (rw), and
@@ -111,6 +121,22 @@ has full visibility and control.
 The `.agent/` directory is mounted read-only to prevent the agent from modifying
 workspace infrastructure scripts. The exception is `.agent/scratchpad/`, which is
 read-write for push request signal files and temporary work.
+
+**The host's `~/.cache/pre-commit` and `~/.claude/plugins` are deliberately
+NOT bind-mounted.** Both hold *executable* content (hook-environment
+interpreters/shims; plugin code). A read-write host bind would let a
+`--dangerously-skip-permissions` agent overwrite binaries the **host**
+later executes (pre-commit runs hook envs at every host-side commit) —
+a sandbox-escape path that bypasses PR review. Instead, named volumes
+(`ros2-agent-precommit-cache`, `ros2-agent-claude-plugins`) give the
+same cross-run amortization while staying isolated from the host.
+
+MCP servers are disabled in-container via `--strict-mcp-config`: the
+claude.ai Gmail/Drive/Calendar servers (and any user-scoped servers
+inherited from the mounted `~/.claude.json`) are host-only and
+credential-less here, so they would only fail-fast on startup. The
+workspace defines no project `.mcp.json` servers, so nothing the sandbox
+needs is lost; local skills still resolve via `/skill-name`.
 
 ## Push Gateway Workflow
 

--- a/.devcontainer/agent/agent-entrypoint.sh
+++ b/.devcontainer/agent/agent-entrypoint.sh
@@ -6,8 +6,9 @@
 #   1. Fix ownership of anonymous volumes (build/install/log dirs)
 #   2. Configure persistent git identity
 #   3. Source ROS 2 environment
-#   4. Install rosdep dependencies (best-effort)
-#   5. Hand off to CMD (claude --dangerously-skip-permissions)
+#   4. Check/install rosdep dependencies (skip when already satisfied)
+#   5. Initialize Claude Code config; chown the pre-commit cache volume
+#   6. Hand off to CMD (claude --dangerously-skip-permissions ...)
 
 set -euo pipefail
 
@@ -105,6 +106,13 @@ if [ -f /tmp/claude-credentials.json ]; then
     chmod 600 "$TARGET_HOME/.claude/.credentials.json"
 fi
 chown -R "$TARGET_UID:$TARGET_GID" "$TARGET_HOME/.claude" "$TARGET_HOME/.claude.json" 2>/dev/null || true
+
+# Pre-commit cache named volume (docker_run_agent.sh mount #7): docker
+# creates the mountpoint root-owned, so chown it to the target user — the
+# pre-commit hooks run as that user and must read/write hook environments.
+if [ -d "$TARGET_HOME/.cache" ]; then
+    chown -R "$TARGET_UID:$TARGET_GID" "$TARGET_HOME/.cache" 2>/dev/null || true
+fi
 
 # ---------- 6. Hand off to CMD ----------
 # Restore working directory to the worktree (entrypoint cd'd to WORKSPACE_ROOT above)

--- a/.devcontainer/agent/agent-entrypoint.sh
+++ b/.devcontainer/agent/agent-entrypoint.sh
@@ -57,13 +57,29 @@ cd "$WORKSPACE_ROOT"
 source "$WORKSPACE_ROOT/.agent/scripts/setup.bash"
 set -u
 
-# ---------- 4. Install rosdep dependencies (best-effort) ----------
-# Refresh apt index — the Dockerfile's apt-get update is stale by container start
-apt-get update -qq
-echo "Installing rosdep dependencies..."
+# ---------- 4. Install rosdep dependencies (best-effort, skip when satisfied) ----------
+# `rosdep check` is fast and offline. Only pay the apt-get update +
+# rosdep install cost for layers that actually report missing deps —
+# on a workspace whose deps are already in the base image this skips
+# the 30–60s+ refresh entirely. Set FORCE_DEPS_REFRESH=1 to always
+# refresh (e.g. after editing a package.xml that adds a dependency).
+echo "Checking rosdep dependencies..."
+APT_REFRESHED=0
 for ws_dir in "$WORKSPACE_ROOT"/layers/main/*_ws; do
     [ -d "$ws_dir/src" ] || continue
     ws_name="$(basename "$ws_dir")"
+    if [ "${FORCE_DEPS_REFRESH:-0}" != "1" ] && \
+       rosdep check --from-paths "$ws_dir/src" --ignore-src --rosdistro jazzy >/dev/null 2>&1; then
+        echo "  $ws_name: dependencies satisfied — skipping install"
+        continue
+    fi
+    # Missing deps (or forced refresh, or rosdep db not yet usable):
+    # refresh the apt index once, then install for this layer.
+    if [ "$APT_REFRESHED" = "0" ]; then
+        echo "  refreshing apt index (deps missing or refresh forced)..."
+        apt-get update -qq || echo "  (apt-get update failed — continuing)"
+        APT_REFRESHED=1
+    fi
     echo "  rosdep install for $ws_name..."
     rosdep install --from-paths "$ws_dir/src" --ignore-src -y --rosdistro jazzy 2>/dev/null || {
         echo "  (some dependencies unavailable for $ws_name — continuing)"


### PR DESCRIPTION
## Summary

Hardens the sandboxed-agent Docker infrastructure — part of [#481](https://github.com/rolker/ros2_agent_workspace/issues/481) phase C (container sub-agent dispatch), addressing the bulk of [#489](https://github.com/rolker/ros2_agent_workspace/issues/489) sub (F).

### Changes (4 commits)

1. **Container git identity** (`e087910`) — the headline #489 bug. `docker_run_agent.sh` never forwarded `AGENT_NAME`/`AGENT_EMAIL`, and `configure_git_identity.sh --detect` ignored them anyway (it mapped a *detected framework* to a table). Fix: forward `AGENT_*` env into the container **and** teach `--detect` to honor pre-set `AGENT_NAME`/`AGENT_EMAIL` first. Warns on the host if identity is unset.
2. **rosdep dep-skip** (`770c8c4`) — entrypoint runs `rosdep check` per layer and skips `apt-get update` + `rosdep install` when satisfied (saves 30–60s+/start); `FORCE_DEPS_REFRESH=1` forces refresh; failures fall through to install (safe).
3. **Cache amortization + MCP-noise silence** (`310d5a0`) — named volume for `~/.claude/plugins` (no per-start marketplace re-clone); pre-commit cache; `--strict-mcp-config` to silence the credential-less claude.ai MCP servers.
4. **Dual-lens self-review fixes** (`2efa02b`) — see below.

### Self-review (dogfooding the new dual-lens review from #467/PR #517)

Ran the two-pass Claude Adversarial review on this branch. It caught a **HIGH-severity isolation bug**: change (3) originally **bind-mounted the host's `~/.cache/pre-commit` read-write**, letting a `--dangerously-skip-permissions` agent poison hook-environment binaries the human then executes at the next host-side commit — a sandbox escape outside PR review. **Fixed**: pre-commit cache is now a **named volume** (isolated, still writable + amortized; entrypoint chowns it to the `ros` user — verified writable as uid 1000). Also addressed: partial-identity warning, inaccurate comment rationale, and stale README/entrypoint docs.

### Validation (Docker, image rebuilt from this branch)

- ✅ `AGENT_*` env vars arrive in-container; `--detect` honors them (host unit-test)
- ✅ `rosdep check` SATISFIED → skip fires (e.g. `site_ws`); else safe fallback to install
- ✅ pre-commit named volume + plugin named volume mount correctly; cache writable by `ros` after entrypoint chown
- ✅ `claude --strict-mcp-config` accepted by the in-image CLI

### Not in this PR (remaining #489 scope)

- **F.5** (stop container writes to the worktree `.agent/scratchpad/`) — coupled to the `push_gateway` removal in [#493](https://github.com/rolker/ros2_agent_workspace/issues/493); cleaner there.
- **F.8** (remote-fallback audit — confirm every skill degrades gracefully with no SSH/gh) — read-only audit, follow-up.
- **F.9** (cosmetic `/root/.bashrc` permission warnings) — minor, follow-up.

So this **Refs**, not Closes, #489 — suggest leaving it open for the three tail items (or splitting them out).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
