### PR TITLE
dispatch_subagent.sh + per-skill handoff boilerplate (closes #490)

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -85,6 +85,13 @@ conserve the Premium quota); when opted in and the `copilot` CLI is
 installed and authenticated, it provides a cross-model read that
 non-Claude runtimes can use to partly compensate.
 
+**Lifecycle handoff is Claude-specific** — the workflow skills' `### Next
+step` blocks dispatch the next phase via
+`.agent/scripts/dispatch_subagent.sh` / Claude Code's `Agent` tool. On a
+non-Claude runtime there's no auto-dispatch: read the handoff block and
+drive the next skill yourself; the issue's `progress.md` entry is the
+cross-phase handoff vessel.
+
 ## Workflow Skills
 
 Reusable workflow procedures are documented at the repo root in `.claude/skills/*/SKILL.md`.

--- a/.agent/AI_IDENTITY_STRATEGY.md
+++ b/.agent/AI_IDENTITY_STRATEGY.md
@@ -96,9 +96,16 @@ so pre-commit hooks see the agent identity even when the bash subshell
 running the commit didn't inherit the sourced exports. See AGENTS.md
 "Agent Commit Identity" for the full pattern + rationale.
 
-#### When to Use Persistent Identity (Containerized Agents)
+#### When to Use Persistent Identity (Dedicated Agent-Only Checkouts)
 
-**Use for**: Antigravity, containerized agents, or dedicated agent-only checkouts.
+**Use for**: Antigravity host clones or other dedicated agent-only checkouts.
+
+> **Not the sandboxed agent container.** The workspace's `docker_run_agent.sh`
+> container no longer runs `configure_git_identity.sh --detect` at entry. In the
+> container, commit identity comes from (a) the dispatch handoff prompt's
+> per-invocation `git -c user.name=… -c user.email=…` literals and (b) the
+> `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env that `agent-entrypoint.sh` exports from the
+> forwarded `AGENT_NAME`/`AGENT_EMAIL` before sourcing `setup.bash`.
 
 **Method**: Run the configuration script:
 ```bash
@@ -117,17 +124,18 @@ running the commit didn't inherit the sourced exports. See AGENTS.md
 ### Decision Tree
 
 ```
-Are you running in a container or isolated environment?
+Are you in the sandboxed agent container (docker_run_agent.sh)?
 │
-├─ YES → Use Persistent Identity
-│         (./.agent/scripts/configure_git_identity.sh)
+├─ YES → Don't configure identity here. It comes from the dispatch
+│         handoff's `git -c` literals + the entrypoint's
+│         GIT_AUTHOR_*/GIT_COMMITTER_* env (from forwarded AGENT_NAME/EMAIL).
 │
 └─ NO → Do you share this working copy with a human user?
          │
          ├─ YES → Use Ephemeral Identity
          │         (source .agent/scripts/set_git_identity_env.sh)
          │
-         └─ NO → Use Persistent Identity
+         └─ NO → Use Persistent Identity — dedicated checkout
                   (./.agent/scripts/configure_git_identity.sh)
 ```
 
@@ -143,7 +151,7 @@ We configure each agent to use a distinct name and email for git commits.
     *   Determine appropriate identity for your agent (ask user if needed)
     *   Choose appropriate configuration method (ephemeral vs. persistent - see "Agent Identity Configuration" section above)
     *   **Ephemeral**: `source .agent/scripts/set_git_identity_env.sh` (for host-based agents in shared workspaces)
-    *   **Persistent**: `./.agent/scripts/configure_git_identity.sh` (for containerized agents or dedicated checkouts)
+    *   **Persistent**: `./.agent/scripts/configure_git_identity.sh` (for dedicated agent-only checkouts; **not** the sandboxed container — see "When to Use Persistent Identity" above)
 *   **Benefits**:
     *   Git history clearly distinguishes agent commits from human commits.
     *   Blame view shows the agent name instead of the user.
@@ -232,7 +240,8 @@ We distinguish the **content** author from the **setup** author.
     - **Ask the user** if self-reporting and auto-detection both fail
 2.  **Choose the appropriate configuration method**:
     - **Host-based agents (Copilot CLI, Gemini CLI)**: Use ephemeral identity (environment variables)
-    - **Containerized agents (Antigravity)**: Use persistent identity (.git/config)
+    - **Sandboxed agent container (`docker_run_agent.sh`)**: Don't configure here — identity comes from the dispatch handoff's `git -c` literals + the entrypoint's `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env (forwarded `AGENT_NAME`/`AGENT_EMAIL`)
+    - **Dedicated agent-only checkouts (Antigravity host clones)**: Use persistent identity (.git/config)
     - See "Configuration Methods: Ephemeral vs. Persistent" section above for details
 3.  **Configure git identity** before making any commits:
     - **Ephemeral (preferred)**: `source .agent/scripts/set_git_identity_env.sh "<Name>" "<email>" "<your model>"` (self-report)

--- a/.agent/instructions/gemini-cli.instructions.md
+++ b/.agent/instructions/gemini-cli.instructions.md
@@ -56,6 +56,13 @@ Adversarial is **opt-in** via `--copilot` (off by default to conserve
 the Premium quota); when opted in with the `copilot` CLI installed and
 authenticated, it gives a cross-model read that partly compensates.
 
+**Lifecycle handoff is Claude-specific** — the workflow skills' `### Next
+step` blocks dispatch the next phase via
+`.agent/scripts/dispatch_subagent.sh` / Claude Code's `Agent` tool. On a
+Gemini runtime there's no auto-dispatch: read the handoff block and drive
+the next skill yourself; the issue's `progress.md` entry is the cross-phase
+handoff vessel.
+
 
 ## Workflow Skills
 

--- a/.agent/knowledge/skill_workflows.md
+++ b/.agent/knowledge/skill_workflows.md
@@ -63,3 +63,46 @@ accepts a PR number / URL for post-PR review of someone else's work.
 `make_*` skills are auto-generated wrappers around Makefile targets (e.g.,
 `/make_build`, `/make_test`). Run `make generate-skills` after adding or
 removing `.PHONY` targets to keep them current.
+
+## Lifecycle Handoff Convention (#490)
+
+Each lifecycle skill's final step includes a `### Next step` block that
+describes how to hand off to the subsequent phase. The full lifecycle map:
+
+| Skill | Entry type written | Next skill | Next entry type |
+|-------|--------------------|------------|-----------------|
+| `review-issue` | `## Issue Review` | `plan-task` | `## Plan Authored` |
+| `plan-task` | `## Plan Authored` | `review-plan` | `## Plan Review` |
+| `review-plan` | `## Plan Review` | implement (no skill yet) → `review-code` | `## Local Review` |
+| `review-code` | `## Local Review` | `triage-reviews` | `## Integrated Review` |
+| `triage-reviews` | `## Integrated Review` | address findings / done | — |
+
+### How to hand off
+
+Use `dispatch_subagent.sh` to build a kickoff prompt that embeds the identity
+contract and `progress.md` exit contract, then pass it to a fresh sub-agent:
+
+```bash
+# In-process (fast; no filesystem isolation):
+.agent/scripts/dispatch_subagent.sh --mode in-process --issue <N> --skill <next-skill>
+# → emits a handoff block; paste into a fresh Agent tool call
+
+# Container (isolation; use for implementation-heavy phases):
+.agent/scripts/dispatch_subagent.sh --mode container --issue <N> --prompt-file <task.md>
+```
+
+The sub-agent reads the last `## <prev-entry-type>` entry in
+`.agent/work-plans/issue-<N>/progress.md` for context, and appends its own
+typed entry when done. The host reads the last entry (filtered by expected
+entry type) to determine the outcome and whether a new entry was written at all
+(a missing new entry = the sub-agent died before reporting).
+
+### Scope-E no-auto-chaining rule
+
+**Skills never dispatch the next phase themselves.** The host orchestrator
+(`/run-issue`, [#492](https://github.com/rolker/ros2_agent_workspace/issues/492))
+drives the lifecycle, invoking each phase in sequence and pausing at user
+checkpoints between them. A skill's `### Next step` block is a prompt for
+the operator or orchestrator to act on — not an instruction for the skill to
+execute autonomously. This keeps each step's entry independently attributed and
+prevents a single runaway sub-agent from racing through the whole lifecycle.

--- a/.agent/scripts/README.md
+++ b/.agent/scripts/README.md
@@ -213,9 +213,18 @@ source .agent/scripts/set_git_identity_env.sh "Gemini CLI Agent" "roland+gemini-
 
 ---
 
-### `configure_git_identity.sh` (Persistent - For Containerized Agents)
+### `configure_git_identity.sh` (Persistent - For Dedicated Agent-Only Checkouts)
 
 Configure git identity persistently across all repositories by modifying `.git/config`.
+
+> **Note:** This is **not** how the workspace's sandboxed agent container
+> (`docker_run_agent.sh`) sets its commit identity. The container entrypoint no
+> longer runs `configure_git_identity.sh --detect`; container commit identity now
+> comes from (a) the dispatch handoff prompt's per-invocation
+> `git -c user.name=… -c user.email=…` literals and (b) the
+> `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env that `agent-entrypoint.sh` exports from the
+> forwarded `AGENT_NAME`/`AGENT_EMAIL` before sourcing `setup.bash`. Use this
+> script for **non-container** dedicated agent-only checkouts (e.g. Antigravity).
 
 **Usage:**
 ```bash
@@ -234,7 +243,7 @@ Configure git identity persistently across all repositories by modifying `.git/c
 
 **Why use this:**
 - ✅ Persists across all shell sessions
-- ✅ Ideal for containerized agents (Antigravity) or dedicated agent-only checkouts
+- ✅ Ideal for dedicated agent-only checkouts (e.g. Antigravity host clones)
 - ✅ Automatically configures all repositories in one command
 
 **Trade-offs:**
@@ -247,11 +256,12 @@ Configure git identity persistently across all repositories by modifying `.git/c
 
 **Decision Tree:**
 ```
-Are you in a container or isolated environment?
-├─ YES → Use this script (configure_git_identity.sh)
+Are you in the sandboxed agent container (docker_run_agent.sh)?
+├─ YES → Don't use this script. Identity comes from the dispatch handoff's
+│        `git -c` literals + the entrypoint's GIT_AUTHOR_*/GIT_COMMITTER_* env.
 └─ NO → Do you share this checkout with the user?
          ├─ YES → Use set_git_identity_env.sh instead
-         └─ NO → Use this script (configure_git_identity.sh)
+         └─ NO → Use this script (configure_git_identity.sh) — dedicated checkout
 ```
 
 **Dependencies:**

--- a/.agent/scripts/dispatch_subagent.sh
+++ b/.agent/scripts/dispatch_subagent.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+# .agent/scripts/dispatch_subagent.sh
+# Dispatch a workflow skill (or a raw kickoff prompt) into a fresh-context
+# sub-agent — either in-process (Agent tool, via a stdout handoff block the
+# host pastes) or in a container (headless docker via docker_run_agent.sh).
+#
+# Part of #481 phase C / #490. The sub-agent's exit contract is convention-only
+# (no enforcement, per ADR-0004/0005): it writes a final progress.md entry; the
+# host reads the last entry for the outcome + next action.
+#
+# Usage:
+#   dispatch_subagent.sh --mode in-process|container --issue <N> \
+#       (--skill <name> | --prompt-file <path>) \
+#       [--entry-type <type>] [--output-format <fmt>]
+#
+# Examples:
+#   dispatch_subagent.sh --mode in-process --issue 490 --skill review-code
+#   dispatch_subagent.sh --mode container  --issue 490 --prompt-file /tmp/task.md --entry-type 'Local Review'
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+# Resolve to the main workspace root if invoked from inside a worktree.
+if [[ "$ROOT_DIR" == *"/.workspace-worktrees/"* ]]; then
+    ROOT_DIR="${ROOT_DIR%%/.workspace-worktrees/*}"
+elif [[ "$ROOT_DIR" == *"/layers/worktrees/"* ]]; then
+    ROOT_DIR="${ROOT_DIR%%/layers/worktrees/*}"
+fi
+
+# ---------- Defaults ----------
+
+MODE=""
+ISSUE=""
+SKILL=""
+PROMPT_FILE=""
+ENTRY_TYPE=""
+OUTPUT_FORMAT="stream-json"
+
+# Identity literals embedded in the handoff (AGENTS.md § Agent Commit Identity).
+# Prefer the session's exported identity; fall back to the Claude default.
+DISPATCH_AGENT_NAME="${AGENT_NAME:-Claude Code Agent}"
+DISPATCH_AGENT_EMAIL="${AGENT_EMAIL:-roland+claude-code@ccom.unh.edu}"
+
+# Skill -> expected progress.md entry type (ADR-0013 vocabulary). Used for the
+# exit-contract "a newer entry of the expected type" check when --entry-type is
+# not given explicitly.
+skill_entry_type() {
+    case "$1" in
+        review-issue)    echo "Issue Review" ;;
+        plan-task)       echo "Plan Authored" ;;
+        review-plan)     echo "Plan Review" ;;
+        review-code)     echo "Local Review" ;;
+        triage-reviews)  echo "Integrated Review" ;;
+        *)               echo "" ;;
+    esac
+}
+
+usage() {
+    sed -n '2,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# ---------- Argument parsing ----------
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --mode)          MODE="${2:-}"; shift 2 ;;
+        --issue)         ISSUE="${2:-}"; shift 2 ;;
+        --skill)         SKILL="${2:-}"; shift 2 ;;
+        --prompt-file)   PROMPT_FILE="${2:-}"; shift 2 ;;
+        --entry-type)    ENTRY_TYPE="${2:-}"; shift 2 ;;
+        --output-format) OUTPUT_FORMAT="${2:-}"; shift 2 ;;
+        -h|--help)       usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+# ---------- Validation ----------
+
+case "$MODE" in
+    in-process|container) : ;;
+    *) echo "ERROR: --mode must be 'in-process' or 'container'." >&2; usage >&2; exit 1 ;;
+esac
+if [ -z "$ISSUE" ]; then
+    echo "ERROR: --issue <N> is required." >&2; exit 1
+fi
+if [ -n "$SKILL" ] && [ -n "$PROMPT_FILE" ]; then
+    echo "ERROR: pass exactly one of --skill or --prompt-file, not both." >&2; exit 1
+fi
+if [ -z "$SKILL" ] && [ -z "$PROMPT_FILE" ]; then
+    echo "ERROR: pass one of --skill <name> or --prompt-file <path>." >&2; exit 1
+fi
+if [ -n "$PROMPT_FILE" ] && [ ! -f "$PROMPT_FILE" ]; then
+    echo "ERROR: --prompt-file not found: $PROMPT_FILE" >&2; exit 1
+fi
+
+# Resolve the expected entry type: explicit --entry-type wins, else derive from
+# the skill. May be empty for a raw prompt with no declared type.
+if [ -z "$ENTRY_TYPE" ] && [ -n "$SKILL" ]; then
+    ENTRY_TYPE="$(skill_entry_type "$SKILL")"
+fi
+
+# ---------- Resolve the worktree + its progress.md ----------
+
+WORKTREE_PATH=""
+for candidate in \
+    "$ROOT_DIR/.workspace-worktrees/issue-workspace-$ISSUE" \
+    "$ROOT_DIR/layers/worktrees/issue-"*"-$ISSUE"; do
+    if [ -d "$candidate" ]; then WORKTREE_PATH="$candidate"; break; fi
+done
+if [ -z "$WORKTREE_PATH" ]; then
+    echo "ERROR: no worktree found for issue #$ISSUE (create it first)." >&2; exit 1
+fi
+PROGRESS_FILE="$WORKTREE_PATH/.agent/work-plans/issue-$ISSUE/progress.md"
+
+# ---------- Build the handoff prompt ----------
+
+if [ -n "$PROMPT_FILE" ]; then
+    TASK_BODY="$(cat "$PROMPT_FILE")"
+else
+    TASK_BODY="Run the \`/$SKILL\` workflow skill for issue #$ISSUE: read \`.claude/skills/$SKILL/SKILL.md\` and follow its procedure to completion."
+fi
+
+if [ -n "$ENTRY_TYPE" ]; then
+    ENTRY_CLAUSE="append your final \`## $ENTRY_TYPE\` entry to"
+else
+    ENTRY_CLAUSE="append your final typed entry (per ADR-0013) to"
+fi
+
+HANDOFF="$(cat <<EOF
+$TASK_BODY
+
+---
+## Sub-agent handoff contract (#490)
+
+You are a fresh-context sub-agent dispatched for **issue #$ISSUE**. Work only
+within this issue's worktree; do not touch other issues.
+
+**Commit identity** — every \`git commit\` MUST carry per-invocation identity
+literals (AGENTS.md § Agent Commit Identity):
+
+    git -c user.name="$DISPATCH_AGENT_NAME" -c user.email="$DISPATCH_AGENT_EMAIL" commit -m "..."
+
+Never use \`--no-verify\`. Do **not** \`git push\` — the host performs pushes
+with its own credentials.
+
+**Exit contract** — before you finish, $ENTRY_CLAUSE:
+
+    .agent/work-plans/issue-$ISSUE/progress.md
+
+The host reads the **last** entry to learn the outcome and the next step. If you
+cannot finish, still write an entry with \`**Status**: partial\` (or \`failed\`)
+recording what was done and what remains — a missing entry reads as "died
+before reporting".
+EOF
+)"
+
+# ---------- in-process mode: emit the handoff for a fresh Agent call ----------
+
+if [ "$MODE" = "in-process" ]; then
+    echo "=== DISPATCH (in-process) — issue #$ISSUE${SKILL:+, skill /$SKILL} ==="
+    echo "Paste the block between the markers into a fresh Agent tool call (no"
+    echo "inherited context). Expected entry type: ${ENTRY_TYPE:-<any>}."
+    echo "---------------8<--------------- BEGIN HANDOFF ---------------8<---------------"
+    printf '%s\n' "$HANDOFF"
+    echo "---------------8<---------------- END HANDOFF ----------------8<---------------"
+    exit 0
+fi
+
+# ---------- container mode: launch headless docker, then read the contract ----------
+
+# Count progress.md entries (optionally of a given type) — used to require a
+# *newer* entry after dispatch. Missing file => 0.
+entry_count() {
+    [ -f "$PROGRESS_FILE" ] || { echo 0; return 0; }
+    local out
+    if [ -n "$ENTRY_TYPE" ]; then
+        out="$(python3 "$SCRIPT_DIR/progress_read.py" --type "$ENTRY_TYPE" "$PROGRESS_FILE" 2>/dev/null || true)"
+    else
+        out="$(python3 "$SCRIPT_DIR/progress_read.py" "$PROGRESS_FILE" 2>/dev/null || true)"
+    fi
+    printf '%s' "$out" | python3 -c 'import sys,json
+try: print(len(json.load(sys.stdin).get("entries", [])))
+except Exception: print(0)' 2>/dev/null || echo 0
+}
+
+PRE_COUNT="$(entry_count)"
+
+PROMPT_TMP="$(mktemp /tmp/dispatch_handoff.XXXXXX.md)"
+trap 'rm -f "$PROMPT_TMP"' EXIT
+printf '%s\n' "$HANDOFF" > "$PROMPT_TMP"
+
+echo "Dispatching issue #$ISSUE into a container (headless)…" >&2
+RC=0
+"$SCRIPT_DIR/docker_run_agent.sh" \
+    --issue "$ISSUE" \
+    --output-format "$OUTPUT_FORMAT" \
+    --prompt-file "$PROMPT_TMP" || RC=$?
+
+# --- Exit-contract read ---
+echo ""
+echo "===== Dispatch outcome (issue #$ISSUE) ====="
+if [ "$RC" -ne 0 ]; then
+    echo "  Result: FAILED — container exited $RC (claude error / killed)."
+    echo "  Any partial work is in the worktree: $WORKTREE_PATH"
+    exit "$RC"
+fi
+
+POST_COUNT="$(entry_count)"
+if [ "$POST_COUNT" -le "$PRE_COUNT" ]; then
+    echo "  Result: FAILED — no new \`## ${ENTRY_TYPE:-<typed>}\` progress.md entry"
+    echo "          (count ${PRE_COUNT} -> ${POST_COUNT}); sub-agent likely died before reporting."
+    echo "  Inspect the worktree: $WORKTREE_PATH"
+    exit 1
+fi
+
+echo "  Result: OK — sub-agent wrote a new entry. Last entry:"
+python3 "$SCRIPT_DIR/progress_read.py" "$PROGRESS_FILE" 2>/dev/null | python3 -c 'import sys,json
+d=json.load(sys.stdin); e=d.get("entries", [])
+if e:
+    x=e[-1]
+    print(f"    type:   {x.get(\"type\")}")
+    print(f"    status: {x.get(\"status\")}")
+    print(f"    by:     {x.get(\"by\")}")
+    print(f"    when:   {x.get(\"when\")}")
+' || echo "    (could not parse progress.md)"
+echo "  Next: the host reviews the entry and runs the next phase / does the push."

--- a/.agent/scripts/dispatch_subagent.sh
+++ b/.agent/scripts/dispatch_subagent.sh
@@ -11,7 +11,11 @@
 # Usage:
 #   dispatch_subagent.sh --mode in-process|container --issue <N> \
 #       (--skill <name> | --prompt-file <path>) \
-#       [--entry-type <type>] [--output-format <fmt>]
+#       [--entry-type <type>] [--output-format <fmt>] [--model <id>]
+#
+#   --model defaults per-skill (Opus for review/implement, Sonnet otherwise);
+#   pass an alias ('opus'/'sonnet') to override. Container mode forwards it;
+#   in-process mode only recommends it (the host picks the Agent's model).
 #
 # Examples:
 #   dispatch_subagent.sh --mode in-process --issue 490 --skill review-code
@@ -36,6 +40,7 @@ SKILL=""
 PROMPT_FILE=""
 ENTRY_TYPE=""
 OUTPUT_FORMAT="stream-json"
+MODEL=""   # --model override; empty => derive from the skill (see skill_model)
 
 # Identity literals embedded in the handoff (AGENTS.md § Agent Commit Identity).
 # Prefer the session's exported identity; fall back to the Claude default.
@@ -56,6 +61,20 @@ skill_entry_type() {
     esac
 }
 
+# Skill -> model (per-phase, #490). Reasoning-heavy phases get Opus; lighter
+# ones (and the default) get Sonnet for quota headroom. Aliases, not pinned
+# ids, so they survive model version bumps; an unavailable model hard-fails
+# loudly (claude exits non-zero -> exit-contract reports FAILED). `--model`
+# overrides any cell. Adjust the mapping here as needs change.
+skill_model() {
+    case "$1" in
+        review-code|review-plan|triage-reviews)  echo "opus" ;;
+        implement|address-findings)              echo "opus" ;;
+        review-issue|plan-task)                  echo "sonnet" ;;
+        *)                                       echo "sonnet" ;;
+    esac
+}
+
 usage() {
     sed -n '2,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
@@ -69,6 +88,7 @@ while [[ $# -gt 0 ]]; do
         --skill)         SKILL="${2:-}"; shift 2 ;;
         --prompt-file)   PROMPT_FILE="${2:-}"; shift 2 ;;
         --entry-type)    ENTRY_TYPE="${2:-}"; shift 2 ;;
+        --model)         MODEL="${2:-}"; shift 2 ;;
         --output-format) OUTPUT_FORMAT="${2:-}"; shift 2 ;;
         -h|--help)       usage; exit 0 ;;
         *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
@@ -98,6 +118,12 @@ fi
 # the skill. May be empty for a raw prompt with no declared type.
 if [ -z "$ENTRY_TYPE" ] && [ -n "$SKILL" ]; then
     ENTRY_TYPE="$(skill_entry_type "$SKILL")"
+fi
+
+# Resolve the model: explicit --model wins, else derive from the skill, else the
+# default ('sonnet'). For a raw prompt with no --model, the default applies.
+if [ -z "$MODEL" ]; then
+    if [ -n "$SKILL" ]; then MODEL="$(skill_model "$SKILL")"; else MODEL="sonnet"; fi
 fi
 
 # ---------- Resolve the worktree + its progress.md ----------
@@ -161,6 +187,8 @@ if [ "$MODE" = "in-process" ]; then
     echo "=== DISPATCH (in-process) — issue #$ISSUE${SKILL:+, skill /$SKILL} ==="
     echo "Paste the block between the markers into a fresh Agent tool call (no"
     echo "inherited context). Expected entry type: ${ENTRY_TYPE:-<any>}."
+    echo "Recommended model: $MODEL (in-process can't set it — pick it when you"
+    echo "spawn the Agent; container mode passes it automatically)."
     echo "---------------8<--------------- BEGIN HANDOFF ---------------8<---------------"
     printf '%s\n' "$HANDOFF"
     echo "---------------8<---------------- END HANDOFF ----------------8<---------------"
@@ -190,11 +218,12 @@ PROMPT_TMP="$(mktemp /tmp/dispatch_handoff.XXXXXX.md)"
 trap 'rm -f "$PROMPT_TMP"' EXIT
 printf '%s\n' "$HANDOFF" > "$PROMPT_TMP"
 
-echo "Dispatching issue #$ISSUE into a container (headless)…" >&2
+echo "Dispatching issue #$ISSUE into a container (headless, model=$MODEL)…" >&2
 RC=0
 "$SCRIPT_DIR/docker_run_agent.sh" \
     --issue "$ISSUE" \
     --output-format "$OUTPUT_FORMAT" \
+    --model "$MODEL" \
     --prompt-file "$PROMPT_TMP" || RC=$?
 
 # --- Exit-contract read ---

--- a/.agent/scripts/dispatch_subagent.sh
+++ b/.agent/scripts/dispatch_subagent.sh
@@ -215,13 +215,13 @@ if [ "$POST_COUNT" -le "$PRE_COUNT" ]; then
 fi
 
 echo "  Result: OK — sub-agent wrote a new entry. Last entry:"
-python3 "$SCRIPT_DIR/progress_read.py" "$PROGRESS_FILE" 2>/dev/null | python3 -c 'import sys,json
-d=json.load(sys.stdin); e=d.get("entries", [])
+python3 "$SCRIPT_DIR/progress_read.py" "$PROGRESS_FILE" 2>/dev/null | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+e = d.get("entries", [])
 if e:
-    x=e[-1]
-    print(f"    type:   {x.get(\"type\")}")
-    print(f"    status: {x.get(\"status\")}")
-    print(f"    by:     {x.get(\"by\")}")
-    print(f"    when:   {x.get(\"when\")}")
+    x = e[-1]
+    for k in ("type", "status", "by", "when"):
+        print("    %-7s %s" % (k + ":", x.get(k)))
 ' || echo "    (could not parse progress.md)"
 echo "  Next: the host reviews the entry and runs the next phase / does the push."

--- a/.agent/scripts/dispatch_subagent.sh
+++ b/.agent/scripts/dispatch_subagent.sh
@@ -113,6 +113,10 @@ fi
 if [ -n "$PROMPT_FILE" ] && [ ! -f "$PROMPT_FILE" ]; then
     echo "ERROR: --prompt-file not found: $PROMPT_FILE" >&2; exit 1
 fi
+case "$OUTPUT_FORMAT" in
+    stream-json|json|text) : ;;
+    *) echo "ERROR: --output-format must be one of stream-json|json|text (got '$OUTPUT_FORMAT')." >&2; exit 1 ;;
+esac
 
 # Resolve the expected entry type: explicit --entry-type wins, else derive from
 # the skill. May be empty for a raw prompt with no declared type.
@@ -129,13 +133,20 @@ fi
 # ---------- Resolve the worktree + its progress.md ----------
 
 WORKTREE_PATH=""
+WORKTREE_MATCHES=0
 for candidate in \
     "$ROOT_DIR/.workspace-worktrees/issue-workspace-$ISSUE" \
     "$ROOT_DIR/layers/worktrees/issue-"*"-$ISSUE"; do
-    if [ -d "$candidate" ]; then WORKTREE_PATH="$candidate"; break; fi
+    if [ -d "$candidate" ]; then
+        WORKTREE_MATCHES=$((WORKTREE_MATCHES + 1))
+        [ -z "$WORKTREE_PATH" ] && WORKTREE_PATH="$candidate"
+    fi
 done
 if [ -z "$WORKTREE_PATH" ]; then
     echo "ERROR: no worktree found for issue #$ISSUE (create it first)." >&2; exit 1
+fi
+if [ "$WORKTREE_MATCHES" -gt 1 ]; then
+    echo "⚠️  $WORKTREE_MATCHES worktrees matched issue #$ISSUE; using: $WORKTREE_PATH" >&2
 fi
 PROGRESS_FILE="$WORKTREE_PATH/.agent/work-plans/issue-$ISSUE/progress.md"
 
@@ -168,7 +179,8 @@ literals (AGENTS.md § Agent Commit Identity):
     git -c user.name="$DISPATCH_AGENT_NAME" -c user.email="$DISPATCH_AGENT_EMAIL" commit -m "..."
 
 Never use \`--no-verify\`. Do **not** \`git push\` — the host performs pushes
-with its own credentials.
+with its own credentials. Never write credentials/tokens (e.g.
+\`\$CLAUDE_CODE_OAUTH_TOKEN\`) into files, commits, or output.
 
 **Exit contract** — before you finish, $ENTRY_CLAUSE:
 
@@ -213,6 +225,9 @@ except Exception: print(0)' 2>/dev/null || echo 0
 }
 
 PRE_COUNT="$(entry_count)"
+# Fail closed: a non-numeric PRE_COUNT becomes -1 so any valid POST_COUNT
+# (>= 0) still requires a real new entry rather than spuriously passing.
+[[ "$PRE_COUNT" =~ ^[0-9]+$ ]] || PRE_COUNT=-1
 
 PROMPT_TMP="$(mktemp /tmp/dispatch_handoff.XXXXXX.md)"
 trap 'rm -f "$PROMPT_TMP"' EXIT
@@ -236,6 +251,10 @@ if [ "$RC" -ne 0 ]; then
 fi
 
 POST_COUNT="$(entry_count)"
+# Fail closed: a non-numeric POST_COUNT becomes 0 so the `-le "$PRE_COUNT"`
+# comparison below can't error (status 2) into the success branch and print a
+# false "Result: OK".
+[[ "$POST_COUNT" =~ ^[0-9]+$ ]] || POST_COUNT=0
 if [ "$POST_COUNT" -le "$PRE_COUNT" ]; then
     echo "  Result: FAILED — no new \`## ${ENTRY_TYPE:-<typed>}\` progress.md entry"
     echo "          (count ${PRE_COUNT} -> ${POST_COUNT}); sub-agent likely died before reporting."
@@ -243,14 +262,48 @@ if [ "$POST_COUNT" -le "$PRE_COUNT" ]; then
     exit 1
 fi
 
-echo "  Result: OK — sub-agent wrote a new entry. Last entry:"
-python3 "$SCRIPT_DIR/progress_read.py" "$PROGRESS_FILE" 2>/dev/null | python3 -c '
+# A new entry exists. Read its status (last entry of the gated --type, to match
+# the count check) and make the headline track it — #492 greps "Result: …".
+# Read the last entry (filtered by --type when set, matching the gate) once,
+# emitting STATUS on the first line and the display fields after.
+LAST_ENTRY="$(
+    if [ -n "$ENTRY_TYPE" ]; then
+        python3 "$SCRIPT_DIR/progress_read.py" --type "$ENTRY_TYPE" "$PROGRESS_FILE" 2>/dev/null
+    else
+        python3 "$SCRIPT_DIR/progress_read.py" "$PROGRESS_FILE" 2>/dev/null
+    fi | python3 -c '
 import sys, json
-d = json.load(sys.stdin)
-e = d.get("entries", [])
+try:
+    e = json.load(sys.stdin).get("entries", [])
+except Exception:
+    e = []
 if e:
     x = e[-1]
+    print((x.get("status") or "").strip().lower())
     for k in ("type", "status", "by", "when"):
         print("    %-7s %s" % (k + ":", x.get(k)))
-' || echo "    (could not parse progress.md)"
-echo "  Next: the host reviews the entry and runs the next phase / does the push."
+'
+)"
+LAST_STATUS="$(printf '%s\n' "$LAST_ENTRY" | head -n1)"
+ENTRY_DISPLAY="$(printf '%s\n' "$LAST_ENTRY" | tail -n +2)"
+
+case "$LAST_STATUS" in
+    failed)
+        echo "  Result: FAILED — sub-agent reported \`**Status**: failed\`. Last entry:" ;;
+    partial)
+        echo "  Result: PARTIAL — sub-agent reported \`**Status**: partial\`. Last entry:" ;;
+    complete)
+        echo "  Result: OK — sub-agent wrote a \`complete\` entry. Last entry:" ;;
+    *)
+        echo "  Result: OK — sub-agent wrote a new entry (status '${LAST_STATUS:-unknown}'). Last entry:" ;;
+esac
+if [ -n "$ENTRY_DISPLAY" ]; then
+    printf '%s\n' "$ENTRY_DISPLAY"
+else
+    echo "    (could not parse progress.md)"
+fi
+case "$LAST_STATUS" in
+    failed)  echo "  Next: the host inspects the failure in $WORKTREE_PATH."; exit 1 ;;
+    partial) echo "  Next: the host inspects the partial work in $WORKTREE_PATH."; exit 1 ;;
+    *)       echo "  Next: the host reviews the entry and runs the next phase / does the push." ;;
+esac

--- a/.agent/scripts/dispatch_subagent.sh
+++ b/.agent/scripts/dispatch_subagent.sh
@@ -211,17 +211,27 @@ fi
 
 # Count progress.md entries (optionally of a given type) — used to require a
 # *newer* entry after dispatch. Missing file => 0.
+#
+# Type matching is done here, NOT via progress_read.py's `--type` filter,
+# because that filter matches `type`/`base_type` exactly and `Local Review
+# (Pre-Push)` is itself a canonical type (its `base_type` is the full
+# `Local Review (Pre-Push)`, not the stripped `Local Review`). review-code in
+# pre-push mode resolves ENTRY_TYPE="Local Review" but writes a
+# `## Local Review (Pre-Push)` heading, so an exact filter misses it and the
+# count stays flat → a false "died before reporting". We therefore count an
+# entry when its full type equals ENTRY_TYPE, its base_type equals ENTRY_TYPE,
+# OR its type begins with ENTRY_TYPE (catching the parenthetical variant).
 entry_count() {
     [ -f "$PROGRESS_FILE" ] || { echo 0; return 0; }
-    local out
-    if [ -n "$ENTRY_TYPE" ]; then
-        out="$(python3 "$SCRIPT_DIR/progress_read.py" --type "$ENTRY_TYPE" "$PROGRESS_FILE" 2>/dev/null || true)"
-    else
-        out="$(python3 "$SCRIPT_DIR/progress_read.py" "$PROGRESS_FILE" 2>/dev/null || true)"
-    fi
-    printf '%s' "$out" | python3 -c 'import sys,json
-try: print(len(json.load(sys.stdin).get("entries", [])))
-except Exception: print(0)' 2>/dev/null || echo 0
+    python3 "$SCRIPT_DIR/progress_read.py" "$PROGRESS_FILE" 2>/dev/null \
+        | ENTRY_TYPE="$ENTRY_TYPE" python3 -c 'import os,sys,json
+want = os.environ.get("ENTRY_TYPE", "")
+try: entries = json.load(sys.stdin).get("entries", [])
+except Exception: print(0); sys.exit(0)
+def match(e):
+    t = e.get("type") or ""
+    return (not want) or t == want or e.get("base_type") == want or t.startswith(want)
+print(sum(1 for e in entries if match(e)))' 2>/dev/null || echo 0
 }
 
 PRE_COUNT="$(entry_count)"
@@ -256,27 +266,30 @@ POST_COUNT="$(entry_count)"
 # false "Result: OK".
 [[ "$POST_COUNT" =~ ^[0-9]+$ ]] || POST_COUNT=0
 if [ "$POST_COUNT" -le "$PRE_COUNT" ]; then
-    echo "  Result: FAILED — no new \`## ${ENTRY_TYPE:-<typed>}\` progress.md entry"
-    echo "          (count ${PRE_COUNT} -> ${POST_COUNT}); sub-agent likely died before reporting."
+    echo "  Result: FAILED — no new \`## ${ENTRY_TYPE:-<typed>}\` entry"
+    echo "          (count ${PRE_COUNT} -> ${POST_COUNT}); sub-agent died before"
+    echo "          reporting, or wrote an entry of an unexpected type."
     echo "  Inspect the worktree: $WORKTREE_PATH"
     exit 1
 fi
 
-# A new entry exists. Read its status (last entry of the gated --type, to match
-# the count check) and make the headline track it — #492 greps "Result: …".
-# Read the last entry (filtered by --type when set, matching the gate) once,
-# emitting STATUS on the first line and the display fields after.
+# A new entry exists. Read its status (last entry matching the gate, same
+# type/base_type/prefix predicate as entry_count, so the displayed entry is the
+# one the count gate keyed on) and make the headline track it — #492 greps
+# "Result: …". Emits STATUS on the first line and the display fields after.
 LAST_ENTRY="$(
-    if [ -n "$ENTRY_TYPE" ]; then
-        python3 "$SCRIPT_DIR/progress_read.py" --type "$ENTRY_TYPE" "$PROGRESS_FILE" 2>/dev/null
-    else
-        python3 "$SCRIPT_DIR/progress_read.py" "$PROGRESS_FILE" 2>/dev/null
-    fi | python3 -c '
-import sys, json
+    python3 "$SCRIPT_DIR/progress_read.py" "$PROGRESS_FILE" 2>/dev/null \
+    | ENTRY_TYPE="$ENTRY_TYPE" python3 -c '
+import os, sys, json
+want = os.environ.get("ENTRY_TYPE", "")
 try:
-    e = json.load(sys.stdin).get("entries", [])
+    entries = json.load(sys.stdin).get("entries", [])
 except Exception:
-    e = []
+    entries = []
+def match(e):
+    t = e.get("type") or ""
+    return (not want) or t == want or e.get("base_type") == want or t.startswith(want)
+e = [x for x in entries if match(x)]
 if e:
     x = e[-1]
     print((x.get("status") or "").strip().lower())

--- a/.agent/scripts/docker_run_agent.sh
+++ b/.agent/scripts/docker_run_agent.sh
@@ -34,6 +34,8 @@ CONTAINER_PREFIX="ros2-agent"
 ISSUE=""
 BUILD_IMAGE=false
 SHELL_MODE=false
+PROMPT=""              # kickoff prompt text (dispatch mode); empty → interactive
+OUTPUT_FORMAT="stream-json"  # claude -p --output-format in dispatch mode
 
 show_usage() {
     cat <<'EOF'
@@ -45,20 +47,29 @@ Required:
   --issue <N>       Issue number (worktree must exist on host)
 
 Options:
-  --build           Build/rebuild the Docker image before launch
-  --shell           Drop into bash instead of Claude Code (debugging)
-  -h, --help        Show this help
+  --build               Build/rebuild the Docker image before launch
+  --shell               Drop into bash instead of Claude Code (debugging)
+  --prompt <text>       Dispatch mode: run a headless `claude -p` with this
+                        kickoff prompt and exit (non-interactive). Mutually
+                        exclusive with --shell.
+  --prompt-file <path>  Dispatch mode: read the kickoff prompt from a file
+                        (preferred for multi-line prompts). Mutually exclusive
+                        with --prompt and --shell.
+  --output-format <fmt> Dispatch-mode claude output format: stream-json
+                        (default), json, or text. Ignored without a prompt.
+  -h, --help            Show this help
 
 Prerequisites:
   - Worktree must be created on host first:
       .agent/scripts/worktree_create.sh --issue <N> --type workspace
-  - ANTHROPIC_API_KEY must be set
+  - ANTHROPIC_API_KEY or subscription credentials must be available
 
-Workflow:
-  1. Create worktree on host
-  2. Run this script to launch container
-  3. Interact with Claude Code inside container
-  4. On exit, script checks for push requests and prompts to push
+Modes:
+  - Interactive (default): a TTY Claude Code session you drive.
+  - Dispatch (--prompt / --prompt-file): a headless `claude -p` run that
+    executes the kickoff and exits. The push-gateway post-exit step is
+    skipped; the caller (e.g. dispatch_subagent.sh) reads the worktree's
+    progress.md for the outcome.
 EOF
 }
 
@@ -75,6 +86,31 @@ while [[ $# -gt 0 ]]; do
             BUILD_IMAGE=true; shift ;;
         --shell)
             SHELL_MODE=true; shift ;;
+        --prompt)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --prompt requires a value." >&2
+                show_usage >&2
+                exit 1
+            fi
+            PROMPT="$2"; shift 2 ;;
+        --prompt-file)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --prompt-file requires a path." >&2
+                show_usage >&2
+                exit 1
+            fi
+            if [ ! -f "$2" ]; then
+                echo "ERROR: --prompt-file not found: $2" >&2
+                exit 1
+            fi
+            PROMPT="$(cat "$2")"; shift 2 ;;
+        --output-format)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --output-format requires a value." >&2
+                show_usage >&2
+                exit 1
+            fi
+            OUTPUT_FORMAT="$2"; shift 2 ;;
         -h|--help)
             show_usage; exit 0 ;;
         *)
@@ -90,15 +126,50 @@ if [ -z "$ISSUE" ]; then
     exit 1
 fi
 
+# Dispatch mode is active when a kickoff prompt was provided.
+DISPATCH_MODE=false
+[ -n "$PROMPT" ] && DISPATCH_MODE=true
+
+# --shell and dispatch mode are mutually exclusive (one wants a TTY, the
+# other is headless).
+if [ "$SHELL_MODE" = true ] && [ "$DISPATCH_MODE" = true ]; then
+    echo "ERROR: --shell and --prompt/--prompt-file are mutually exclusive." >&2
+    exit 1
+fi
+
 # ---------- Validation ----------
 
-# Check for authentication (API key or subscription credentials)
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ ! -f "$HOME/.claude/.credentials.json" ] && [ "$SHELL_MODE" = false ]; then
+# Check for authentication. Three sources, in order of robustness for a
+# headless/sandboxed run:
+#   1. CLAUDE_CODE_OAUTH_TOKEN — long-lived (1yr) subscription token from
+#      `claude setup-token`. Subscription-native (counts against Max/Pro
+#      limits, not API billing), purpose-built for CI/headless. Best for
+#      dispatch mode.
+#   2. ANTHROPIC_API_KEY — pay-as-you-go API billing.
+#   3. ~/.claude/.credentials.json — interactive subscription OAuth. The
+#      access token is short-lived and a transplanted stale token can't
+#      reliably refresh inside the sandbox, so it's unreliable for headless
+#      dispatch (works for interactive sessions where a fresh login is at
+#      hand).
+if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ] \
+   && [ ! -f "$HOME/.claude/.credentials.json" ] && [ "$SHELL_MODE" = false ]; then
     echo "ERROR: No authentication found." >&2
-    echo "Either:" >&2
-    echo "  - Export ANTHROPIC_API_KEY for API key auth" >&2
-    echo "  - Run 'claude' on the host and /login for subscription auth" >&2
+    echo "Pick one:" >&2
+    echo "  - CLAUDE_CODE_OAUTH_TOKEN  (recommended; run 'claude setup-token' on a dev host)" >&2
+    echo "  - ANTHROPIC_API_KEY        (API billing, not subscription)" >&2
+    echo "  - 'claude' + /login on the host for interactive subscription auth" >&2
     exit 1
+fi
+
+# Dispatch mode is headless, so transplanted OAuth credentials.json can't
+# refresh — steer the user to the long-lived token unless they've set one
+# (or an API key).
+if [ "$DISPATCH_MODE" = true ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+    echo "⚠️  Dispatch (headless) mode with no CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY." >&2
+    echo "    Mounted ~/.claude/.credentials.json OAuth tokens expire and cannot refresh in" >&2
+    echo "    the sandbox — the run will likely fail with 'Not logged in'. Generate a" >&2
+    echo "    long-lived subscription token on a dev host with 'claude setup-token' and" >&2
+    echo "    export CLAUDE_CODE_OAUTH_TOKEN before dispatching." >&2
 fi
 
 # Find worktree for this issue
@@ -240,6 +311,7 @@ if [ "$SHELL_MODE" = false ] && { [ -z "${AGENT_NAME:-}" ] || [ -z "${AGENT_EMAI
 fi
 
 ENV_ARGS=(
+    ${CLAUDE_CODE_OAUTH_TOKEN:+-e "CLAUDE_CODE_OAUTH_TOKEN"}
     ${ANTHROPIC_API_KEY:+-e "ANTHROPIC_API_KEY"}
     ${AGENT_GH_TOKEN:+-e "GH_TOKEN=$AGENT_GH_TOKEN"}
     ${AGENT_NAME:+-e "AGENT_NAME=$AGENT_NAME"}
@@ -256,21 +328,35 @@ ENV_ARGS=(
 
 # ---------- Determine CMD ----------
 
+# --strict-mcp-config: use only MCP servers from --mcp-config (none
+# passed) → all MCP servers disabled. Silences the claude.ai
+# Gmail/Drive/Calendar servers (and any other user-scoped MCP servers
+# inherited via the mounted ~/.claude.json) that fail-fast with auth
+# errors on every start in the credential-less sandbox — they're
+# host-only by design (see #481 non-goals). The workspace defines no
+# project/.mcp.json servers, so nothing the sandbox legitimately needs
+# is lost; local skills still resolve via /skill-name. Removes the
+# startup-log noise and a round-trip per server.
 CONTAINER_CMD=()
 if [ "$SHELL_MODE" = true ]; then
     CONTAINER_CMD=(/bin/bash)
+elif [ "$DISPATCH_MODE" = true ]; then
+    # Headless kickoff. `-p` takes the prompt as a single argv element
+    # (passed through the entrypoint's `exec ... -- "$@"` unchanged, so no
+    # shell re-splitting/quoting issue). stream-json output requires
+    # --verbose; for other formats --verbose is harmless.
+    CONTAINER_CMD=(claude -p "$PROMPT"
+        --output-format "$OUTPUT_FORMAT" --verbose
+        --dangerously-skip-permissions --strict-mcp-config)
 else
-    # --strict-mcp-config: use only MCP servers from --mcp-config (none
-    # passed) → all MCP servers disabled. Silences the claude.ai
-    # Gmail/Drive/Calendar servers (and any other user-scoped MCP servers
-    # inherited via the mounted ~/.claude.json) that fail-fast with auth
-    # errors on every start in the credential-less sandbox — they're
-    # host-only by design (see #481 non-goals). The workspace defines no
-    # project/.mcp.json servers, so nothing the sandbox legitimately needs
-    # is lost; local skills still resolve via /skill-name. Removes the
-    # startup-log noise and a round-trip per server.
     CONTAINER_CMD=(claude --dangerously-skip-permissions --strict-mcp-config)
 fi
+
+# TTY allocation: interactive/shell modes want a TTY; headless dispatch
+# must NOT allocate one (no stdin TTY in an orchestrated/CI context, and
+# stream-json is meant to be piped).
+TTY_FLAGS=(-it)
+[ "$DISPATCH_MODE" = true ] && TTY_FLAGS=()
 
 # ---------- Launch container ----------
 
@@ -283,14 +369,21 @@ echo "========================================="
 echo "  Issue:     #$ISSUE"
 echo "  Worktree:  $WORKTREE_PATH"
 echo "  Container: $CONTAINER_NAME"
-echo "  Mode:      $([ "$SHELL_MODE" = true ] && echo 'shell (debug)' || echo 'Claude Code (YOLO)')"
+if [ "$SHELL_MODE" = true ]; then
+    RUN_MODE="shell (debug)"
+elif [ "$DISPATCH_MODE" = true ]; then
+    RUN_MODE="dispatch (headless claude -p, $OUTPUT_FORMAT)"
+else
+    RUN_MODE="Claude Code (YOLO)"
+fi
+echo "  Mode:      $RUN_MODE"
 echo "  GitHub:    $([ -n "$AGENT_GH_TOKEN" ] && echo 'read-only token' || echo 'no token')"
 echo "========================================="
 echo ""
 
 # Allow non-zero exit (user Ctrl+C, Claude exit, etc.) — we still check push requests
 EXIT_CODE=0
-docker run -it --rm \
+docker run "${TTY_FLAGS[@]}" --rm \
     --name "$CONTAINER_NAME" \
     --hostname "agent-$ISSUE" \
     --security-opt no-new-privileges:true \
@@ -301,7 +394,18 @@ docker run -it --rm \
     "${CONTAINER_CMD[@]}" \
     || EXIT_CODE=$?
 
-# ---------- Post-exit: check for outbox items ----------
+# ---------- Post-exit ----------
+# Dispatch mode uses progress.md as the outcome channel (the caller reads
+# the worktree's last entry), so skip the interactive push-gateway flow
+# entirely and just surface the container exit code.
+if [ "$DISPATCH_MODE" = true ]; then
+    echo ""
+    echo "Dispatch run exited with code $EXIT_CODE."
+    echo "Outcome is in the worktree's progress.md (read the last entry)."
+    exit "$EXIT_CODE"
+fi
+
+# ---------- Post-exit: check for outbox items (interactive mode) ----------
 
 echo ""
 HAS_PENDING=false

--- a/.agent/scripts/docker_run_agent.sh
+++ b/.agent/scripts/docker_run_agent.sh
@@ -137,6 +137,26 @@ if [ "$SHELL_MODE" = true ] && [ "$DISPATCH_MODE" = true ]; then
     exit 1
 fi
 
+# ---------- Subscription token (file fallback) ----------
+# CLAUDE_CODE_OAUTH_TOKEN is the long-lived subscription token from
+# `claude setup-token`. Prefer an already-exported env var; otherwise read it
+# from a 600-perm file. The file path mirrors the gh-readonly-token pattern
+# and keeps the secret out of the launching agent's environment dumps. We
+# export it (rather than passing -e VAR=value) so it forwards via the bare
+# `-e CLAUDE_CODE_OAUTH_TOKEN` below without ever appearing in `ps`/argv.
+CLAUDE_OAUTH_TOKEN_FILE="$HOME/.config/ros2-agent/claude-oauth-token"
+if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -f "$CLAUDE_OAUTH_TOKEN_FILE" ]; then
+    # Warn (don't fail) if the secret file is group/world-readable.
+    PERM=$(stat -c '%a' "$CLAUDE_OAUTH_TOKEN_FILE" 2>/dev/null || echo "")
+    case "$PERM" in
+        600|400) : ;;
+        "") : ;;  # stat unavailable; skip the check
+        *) echo "⚠️  $CLAUDE_OAUTH_TOKEN_FILE is mode $PERM — recommend 'chmod 600'." >&2 ;;
+    esac
+    read -r CLAUDE_CODE_OAUTH_TOKEN < "$CLAUDE_OAUTH_TOKEN_FILE" || true
+    export CLAUDE_CODE_OAUTH_TOKEN
+fi
+
 # ---------- Validation ----------
 
 # Check for authentication. Three sources, in order of robustness for a
@@ -155,7 +175,9 @@ if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ] \
    && [ ! -f "$HOME/.claude/.credentials.json" ] && [ "$SHELL_MODE" = false ]; then
     echo "ERROR: No authentication found." >&2
     echo "Pick one:" >&2
-    echo "  - CLAUDE_CODE_OAUTH_TOKEN  (recommended; run 'claude setup-token' on a dev host)" >&2
+    echo "  - CLAUDE_CODE_OAUTH_TOKEN  (recommended; 'claude setup-token' in a real" >&2
+    echo "                              terminal, then save to $CLAUDE_OAUTH_TOKEN_FILE" >&2
+    echo "                              [chmod 600], or export the env var)" >&2
     echo "  - ANTHROPIC_API_KEY        (API billing, not subscription)" >&2
     echo "  - 'claude' + /login on the host for interactive subscription auth" >&2
     exit 1
@@ -168,8 +190,8 @@ if [ "$DISPATCH_MODE" = true ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z 
     echo "⚠️  Dispatch (headless) mode with no CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY." >&2
     echo "    Mounted ~/.claude/.credentials.json OAuth tokens expire and cannot refresh in" >&2
     echo "    the sandbox — the run will likely fail with 'Not logged in'. Generate a" >&2
-    echo "    long-lived subscription token on a dev host with 'claude setup-token' and" >&2
-    echo "    export CLAUDE_CODE_OAUTH_TOKEN before dispatching." >&2
+    echo "    long-lived subscription token with 'claude setup-token' and save it to" >&2
+    echo "    $CLAUDE_OAUTH_TOKEN_FILE (chmod 600) before dispatching." >&2
 fi
 
 # Find worktree for this issue

--- a/.agent/scripts/docker_run_agent.sh
+++ b/.agent/scripts/docker_run_agent.sh
@@ -36,6 +36,7 @@ BUILD_IMAGE=false
 SHELL_MODE=false
 PROMPT=""              # kickoff prompt text (dispatch mode); empty → interactive
 OUTPUT_FORMAT="stream-json"  # claude -p --output-format in dispatch mode
+MODEL=""               # claude --model (alias like 'opus'/'sonnet', or full id); empty → claude default
 
 show_usage() {
     cat <<'EOF'
@@ -57,6 +58,9 @@ Options:
                         with --prompt and --shell.
   --output-format <fmt> Dispatch-mode claude output format: stream-json
                         (default), json, or text. Ignored without a prompt.
+  --model <id>          claude --model (prefer an alias like 'opus'/'sonnet'
+                        over a pinned id). Empty => claude's default. An
+                        unavailable model makes claude exit non-zero.
   -h, --help            Show this help
 
 Prerequisites:
@@ -111,6 +115,13 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             OUTPUT_FORMAT="$2"; shift 2 ;;
+        --model)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --model requires a value." >&2
+                show_usage >&2
+                exit 1
+            fi
+            MODEL="$2"; shift 2 ;;
         -h|--help)
             show_usage; exit 0 ;;
         *)
@@ -359,6 +370,13 @@ ENV_ARGS=(
 # project/.mcp.json servers, so nothing the sandbox legitimately needs
 # is lost; local skills still resolve via /skill-name. Removes the
 # startup-log noise and a round-trip per server.
+# --model is optional. Prefer an alias ('opus'/'sonnet') over a pinned id so
+# it survives model version bumps; an unavailable model makes claude exit
+# non-zero (hard-fail, surfaced by the caller's exit-contract — no silent
+# downgrade). Empty MODEL => claude's built-in default.
+MODEL_FLAGS=()
+[ -n "$MODEL" ] && MODEL_FLAGS=(--model "$MODEL")
+
 CONTAINER_CMD=()
 if [ "$SHELL_MODE" = true ]; then
     CONTAINER_CMD=(/bin/bash)
@@ -369,9 +387,10 @@ elif [ "$DISPATCH_MODE" = true ]; then
     # --verbose; for other formats --verbose is harmless.
     CONTAINER_CMD=(claude -p "$PROMPT"
         --output-format "$OUTPUT_FORMAT" --verbose
+        "${MODEL_FLAGS[@]}"
         --dangerously-skip-permissions --strict-mcp-config)
 else
-    CONTAINER_CMD=(claude --dangerously-skip-permissions --strict-mcp-config)
+    CONTAINER_CMD=(claude "${MODEL_FLAGS[@]}" --dangerously-skip-permissions --strict-mcp-config)
 fi
 
 # TTY allocation: interactive/shell modes want a TTY; headless dispatch
@@ -399,6 +418,7 @@ else
     RUN_MODE="Claude Code (YOLO)"
 fi
 echo "  Mode:      $RUN_MODE"
+echo "  Model:     ${MODEL:-(claude default)}"
 echo "  GitHub:    $([ -n "$AGENT_GH_TOKEN" ] && echo 'read-only token' || echo 'no token')"
 echo "========================================="
 echo ""

--- a/.agent/scripts/docker_run_agent.sh
+++ b/.agent/scripts/docker_run_agent.sh
@@ -101,6 +101,7 @@ while [[ $# -gt 0 ]]; do
                 echo "ERROR: --prompt and --prompt-file are mutually exclusive." >&2
                 exit 1
             fi
+            [ -n "$2" ] || { echo "ERROR: --prompt is empty." >&2; exit 1; }
             PROMPT="$2"; PROMPT_SET=true; shift 2 ;;
         --prompt-file)
             if [[ $# -lt 2 ]]; then
@@ -151,9 +152,12 @@ if [ -z "$ISSUE" ]; then
     exit 1
 fi
 
-# Dispatch mode is active when a kickoff prompt was provided.
+# Dispatch mode is active when a prompt source was explicitly provided. Gate on
+# PROMPT_SET (the intent), not [ -n "$PROMPT" ] (the value): an empty prompt is
+# already rejected at parse time, but keying on intent keeps a future empty
+# prompt from silently falling back to an interactive `-it` container.
 DISPATCH_MODE=false
-[ -n "$PROMPT" ] && DISPATCH_MODE=true
+[ "$PROMPT_SET" = true ] && DISPATCH_MODE=true
 
 # --shell and dispatch mode are mutually exclusive (one wants a TTY, the
 # other is headless).
@@ -178,7 +182,7 @@ if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -f "$CLAUDE_OAUTH_TOKEN_FILE" ]; t
         "") : ;;  # stat unavailable; skip the check
         *) echo "⚠️  $CLAUDE_OAUTH_TOKEN_FILE is mode $PERM — recommend 'chmod 600'." >&2 ;;
     esac
-    read -r CLAUDE_CODE_OAUTH_TOKEN < "$CLAUDE_OAUTH_TOKEN_FILE" || true
+    IFS= read -r CLAUDE_CODE_OAUTH_TOKEN < "$CLAUDE_OAUTH_TOKEN_FILE" || true
     export CLAUDE_CODE_OAUTH_TOKEN
 fi
 
@@ -342,8 +346,13 @@ AGENT_GH_TOKEN="${AGENT_GH_TOKEN:-}"
 GH_TOKEN_FILE="$HOME/.config/ros2-agent/gh-readonly-token"
 
 if [ -z "$AGENT_GH_TOKEN" ] && [ -f "$GH_TOKEN_FILE" ]; then
-    read -r AGENT_GH_TOKEN < "$GH_TOKEN_FILE" || true
+    IFS= read -r AGENT_GH_TOKEN < "$GH_TOKEN_FILE" || true
 fi
+
+# Export the read-only GH token so it forwards via the bare `-e GH_TOKEN` below
+# (value-in-env, not value-in-argv) — keeping it out of the host's `ps`/cmdline,
+# matching the CLAUDE_CODE_OAUTH_TOKEN handling above.
+[ -n "$AGENT_GH_TOKEN" ] && export GH_TOKEN="$AGENT_GH_TOKEN"
 
 # ---------- Container environment ----------
 
@@ -368,7 +377,7 @@ fi
 ENV_ARGS=(
     ${CLAUDE_CODE_OAUTH_TOKEN:+-e "CLAUDE_CODE_OAUTH_TOKEN"}
     ${ANTHROPIC_API_KEY:+-e "ANTHROPIC_API_KEY"}
-    ${AGENT_GH_TOKEN:+-e "GH_TOKEN=$AGENT_GH_TOKEN"}
+    ${AGENT_GH_TOKEN:+-e GH_TOKEN}
     ${AGENT_NAME:+-e "AGENT_NAME=$AGENT_NAME"}
     ${AGENT_EMAIL:+-e "AGENT_EMAIL=$AGENT_EMAIL"}
     ${AGENT_MODEL:+-e "AGENT_MODEL=$AGENT_MODEL"}

--- a/.agent/scripts/docker_run_agent.sh
+++ b/.agent/scripts/docker_run_agent.sh
@@ -35,6 +35,7 @@ ISSUE=""
 BUILD_IMAGE=false
 SHELL_MODE=false
 PROMPT=""              # kickoff prompt text (dispatch mode); empty → interactive
+PROMPT_SET=false       # tracks whether a prompt source (--prompt/--prompt-file) was given
 OUTPUT_FORMAT="stream-json"  # claude -p --output-format in dispatch mode
 MODEL=""               # claude --model (alias like 'opus'/'sonnet', or full id); empty → claude default
 
@@ -96,24 +97,37 @@ while [[ $# -gt 0 ]]; do
                 show_usage >&2
                 exit 1
             fi
-            PROMPT="$2"; shift 2 ;;
+            if [ "$PROMPT_SET" = true ]; then
+                echo "ERROR: --prompt and --prompt-file are mutually exclusive." >&2
+                exit 1
+            fi
+            PROMPT="$2"; PROMPT_SET=true; shift 2 ;;
         --prompt-file)
             if [[ $# -lt 2 ]]; then
                 echo "ERROR: --prompt-file requires a path." >&2
                 show_usage >&2
                 exit 1
             fi
+            if [ "$PROMPT_SET" = true ]; then
+                echo "ERROR: --prompt and --prompt-file are mutually exclusive." >&2
+                exit 1
+            fi
             if [ ! -f "$2" ]; then
                 echo "ERROR: --prompt-file not found: $2" >&2
                 exit 1
             fi
-            PROMPT="$(cat "$2")"; shift 2 ;;
+            [ -s "$2" ] || { echo "ERROR: --prompt-file is empty: $2" >&2; exit 1; }
+            PROMPT="$(cat "$2")"; PROMPT_SET=true; shift 2 ;;
         --output-format)
             if [[ $# -lt 2 ]]; then
                 echo "ERROR: --output-format requires a value." >&2
                 show_usage >&2
                 exit 1
             fi
+            case "$2" in
+                stream-json|json|text) : ;;
+                *) echo "ERROR: --output-format must be one of stream-json|json|text (got '$2')." >&2; exit 1 ;;
+            esac
             OUTPUT_FORMAT="$2"; shift 2 ;;
         --model)
             if [[ $# -lt 2 ]]; then
@@ -207,12 +221,13 @@ fi
 
 # Find worktree for this issue
 WORKTREE_PATH=""
+WORKTREE_MATCHES=0
 for candidate in \
     "$ROOT_DIR/.workspace-worktrees/issue-workspace-$ISSUE" \
     "$ROOT_DIR/layers/worktrees/issue-"*"-$ISSUE"; do
     if [ -d "$candidate" ]; then
-        WORKTREE_PATH="$candidate"
-        break
+        WORKTREE_MATCHES=$((WORKTREE_MATCHES + 1))
+        [ -z "$WORKTREE_PATH" ] && WORKTREE_PATH="$candidate"
     fi
 done
 
@@ -221,6 +236,9 @@ if [ -z "$WORKTREE_PATH" ]; then
     echo "Create one first:" >&2
     echo "  .agent/scripts/worktree_create.sh --issue $ISSUE --type workspace" >&2
     exit 1
+fi
+if [ "$WORKTREE_MATCHES" -gt 1 ]; then
+    echo "⚠️  $WORKTREE_MATCHES worktrees matched issue #$ISSUE; using: $WORKTREE_PATH" >&2
 fi
 
 WORKTREE_ID="$(basename "$WORKTREE_PATH")"
@@ -329,18 +347,22 @@ fi
 
 # ---------- Container environment ----------
 
-# Forward the agent git identity into the container. The entrypoint runs
-# `configure_git_identity.sh --detect`, which now prefers these env vars
-# over in-container framework auto-detection (detection still resolves to
-# the generic `claude-code` table entry via CLAUDE_CODE_ENTRYPOINT, but
-# that loses the launching agent's self-reported identity). These are
-# normally exported on the host by set_git_identity_env.sh; warn if they
-# are missing so commits inside the container don't land under a wrong or
-# unset identity.
+# Forward the agent git identity into the container. No
+# `configure_git_identity.sh --detect` runs in the container anymore (that
+# entrypoint step was removed). Container commit identity now flows two ways:
+#   (a) the dispatch handoff prompt's per-invocation `git -c user.name=… -c
+#       user.email=… commit` literals (the load-bearing path); and
+#   (b) agent-entrypoint.sh exports GIT_AUTHOR_*/GIT_COMMITTER_* from
+#       AGENT_NAME/AGENT_EMAIL before sourcing setup.bash, so setup.bash's
+#       detect-and-set fallback is skipped and any `git commit` that omits the
+#       `-c` literals still uses the *forwarded* identity, not a re-detected one.
+# AGENT_NAME/AGENT_EMAIL are forwarded so (b) and `gh` signatures have them.
+# Warn if they're missing so the env-fallback identity doesn't go unset.
 if [ "$SHELL_MODE" = false ] && { [ -z "${AGENT_NAME:-}" ] || [ -z "${AGENT_EMAIL:-}" ]; }; then
-    echo "⚠️  AGENT_NAME / AGENT_EMAIL not set — the container will fall back to" >&2
-    echo "    in-container framework detection, which may fail. Source" >&2
-    echo "    .agent/scripts/set_git_identity_env.sh before launching to set them." >&2
+    echo "⚠️  AGENT_NAME / AGENT_EMAIL not set — the container's env-fallback git" >&2
+    echo "    identity will be unset (commits then rely solely on the handoff's" >&2
+    echo "    'git -c' literals). Source .agent/scripts/set_git_identity_env.sh" >&2
+    echo "    before launching to set them." >&2
 fi
 
 ENV_ARGS=(

--- a/.agent/scripts/test_dispatch_subagent.sh
+++ b/.agent/scripts/test_dispatch_subagent.sh
@@ -20,8 +20,9 @@ fi
 # A throwaway worktree so the script's worktree-resolution succeeds.
 TEST_ISSUE=999999
 FAKE_WT="$ROOT_DIR/.workspace-worktrees/issue-workspace-$TEST_ISSUE"
+FAKE_WT2="$ROOT_DIR/layers/worktrees/issue-test-$TEST_ISSUE"
 mkdir -p "$FAKE_WT/.agent/work-plans/issue-$TEST_ISSUE"
-trap 'rm -rf "$FAKE_WT"' EXIT
+trap 'rm -rf "$FAKE_WT" "$FAKE_WT2"' EXIT
 
 PASS=0; FAIL=0
 ok()   { PASS=$((PASS+1)); printf '  ok   - %s\n' "$1"; }
@@ -60,6 +61,10 @@ assert_fails "rejects missing prompt-file" "--prompt-file not found" \
     --mode container --issue "$TEST_ISSUE" --prompt-file /nonexistent/path.md
 assert_fails "rejects unknown worktree" "no worktree found" \
     --mode in-process --issue 888888 --skill review-code
+assert_fails "rejects bad --output-format" "must be one of stream-json|json|text" \
+    --mode container --issue "$TEST_ISSUE" --skill review-code --output-format yaml
+assert_emits "accepts a valid --output-format (in-process)" "BEGIN HANDOFF" \
+    --mode in-process --issue "$TEST_ISSUE" --skill review-code --output-format json
 
 # --- in-process handoff content ---
 assert_emits "embeds git -c identity literals" 'git -c user.name="Claude Code Agent" -c user.email="roland+claude-code@ccom.unh.edu"' \
@@ -67,6 +72,8 @@ assert_emits "embeds git -c identity literals" 'git -c user.name="Claude Code Ag
 assert_emits "embeds the no-push / no--no-verify rule" 'Never use `--no-verify`' \
     --mode in-process --issue "$TEST_ISSUE" --skill review-code
 assert_emits "embeds the progress.md exit contract" ".agent/work-plans/issue-$TEST_ISSUE/progress.md" \
+    --mode in-process --issue "$TEST_ISSUE" --skill review-code
+assert_emits "embeds the no-credentials-in-output rule" "Never write credentials/tokens" \
     --mode in-process --issue "$TEST_ISSUE" --skill review-code
 assert_emits "has copy markers" "BEGIN HANDOFF" \
     --mode in-process --issue "$TEST_ISSUE" --skill review-code
@@ -117,6 +124,15 @@ case "$out" in
     *'git -c user.name="Tester Bot" -c user.email="roland+tester@ccom.unh.edu"'*) ok "honors AGENT_NAME/AGENT_EMAIL override" ;;
     *) bad "honors AGENT_NAME/AGENT_EMAIL override" "override not reflected in handoff" ;;
 esac
+
+# --- ambiguous worktree match warns on stderr ---
+mkdir -p "$FAKE_WT2/.agent/work-plans/issue-$TEST_ISSUE"
+err="$("$DISPATCH" --mode in-process --issue "$TEST_ISSUE" --skill review-code 2>&1 >/dev/null)"
+case "$err" in
+    *"worktrees matched issue #$TEST_ISSUE"*) ok "warns on ambiguous worktree match" ;;
+    *) bad "warns on ambiguous worktree match" "no warning emitted to stderr" ;;
+esac
+rm -rf "$FAKE_WT2"
 
 echo ""
 echo "Passed: $PASS  Failed: $FAIL"

--- a/.agent/scripts/test_dispatch_subagent.sh
+++ b/.agent/scripts/test_dispatch_subagent.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Regression tests for dispatch_subagent.sh — the no-docker surface
+# (arg validation, skill->entry-type mapping, handoff-prompt content,
+# in-process emission). Container mode requires docker + a real worktree
+# and is covered by the manual layer-worktree verification in #490.
+#
+# Run: .agent/scripts/test_dispatch_subagent.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISPATCH="$SCRIPT_DIR/dispatch_subagent.sh"
+ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+if [[ "$ROOT_DIR" == *"/.workspace-worktrees/"* ]]; then
+    ROOT_DIR="${ROOT_DIR%%/.workspace-worktrees/*}"
+elif [[ "$ROOT_DIR" == *"/layers/worktrees/"* ]]; then
+    ROOT_DIR="${ROOT_DIR%%/layers/worktrees/*}"
+fi
+
+# A throwaway worktree so the script's worktree-resolution succeeds.
+TEST_ISSUE=999999
+FAKE_WT="$ROOT_DIR/.workspace-worktrees/issue-workspace-$TEST_ISSUE"
+mkdir -p "$FAKE_WT/.agent/work-plans/issue-$TEST_ISSUE"
+trap 'rm -rf "$FAKE_WT"' EXIT
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  ok   - %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL - %s\n' "$1"; [ -n "${2:-}" ] && printf '         %s\n' "$2"; }
+
+# assert the command exits non-zero AND stderr contains a substring
+assert_fails() {
+    local desc="$1" needle="$2"; shift 2
+    local out rc
+    out="$("$DISPATCH" "$@" 2>&1)"; rc=$?
+    if [ "$rc" -eq 0 ]; then bad "$desc" "expected non-zero exit"; return; fi
+    case "$out" in *"$needle"*) ok "$desc" ;; *) bad "$desc" "stderr missing: $needle";; esac
+}
+
+# assert the command succeeds AND stdout contains a substring
+assert_emits() {
+    local desc="$1" needle="$2"; shift 2
+    local out rc
+    out="$("$DISPATCH" "$@" 2>/dev/null)"; rc=$?
+    if [ "$rc" -ne 0 ]; then bad "$desc" "expected zero exit, got $rc"; return; fi
+    case "$out" in *"$needle"*) ok "$desc" ;; *) bad "$desc" "stdout missing: $needle";; esac
+}
+
+echo "dispatch_subagent.sh tests"
+
+# --- validation ---
+assert_fails "rejects bad --mode" "must be 'in-process' or 'container'" \
+    --mode bogus --issue "$TEST_ISSUE" --skill review-code
+assert_fails "requires --issue" "--issue <N> is required" \
+    --mode in-process --skill review-code
+assert_fails "rejects skill+prompt-file together" "exactly one of --skill or --prompt-file" \
+    --mode in-process --issue "$TEST_ISSUE" --skill review-code --prompt-file /tmp/nope
+assert_fails "requires a task (skill or prompt-file)" "one of --skill" \
+    --mode in-process --issue "$TEST_ISSUE"
+assert_fails "rejects missing prompt-file" "--prompt-file not found" \
+    --mode container --issue "$TEST_ISSUE" --prompt-file /nonexistent/path.md
+assert_fails "rejects unknown worktree" "no worktree found" \
+    --mode in-process --issue 888888 --skill review-code
+
+# --- in-process handoff content ---
+assert_emits "embeds git -c identity literals" 'git -c user.name="Claude Code Agent" -c user.email="roland+claude-code@ccom.unh.edu"' \
+    --mode in-process --issue "$TEST_ISSUE" --skill review-code
+assert_emits "embeds the no-push / no--no-verify rule" 'Never use `--no-verify`' \
+    --mode in-process --issue "$TEST_ISSUE" --skill review-code
+assert_emits "embeds the progress.md exit contract" ".agent/work-plans/issue-$TEST_ISSUE/progress.md" \
+    --mode in-process --issue "$TEST_ISSUE" --skill review-code
+assert_emits "has copy markers" "BEGIN HANDOFF" \
+    --mode in-process --issue "$TEST_ISSUE" --skill review-code
+
+# --- skill -> entry-type mapping ---
+assert_emits "review-code -> Local Review" 'final `## Local Review` entry' \
+    --mode in-process --issue "$TEST_ISSUE" --skill review-code
+assert_emits "review-plan -> Plan Review" 'final `## Plan Review` entry' \
+    --mode in-process --issue "$TEST_ISSUE" --skill review-plan
+assert_emits "plan-task -> Plan Authored" 'final `## Plan Authored` entry' \
+    --mode in-process --issue "$TEST_ISSUE" --skill plan-task
+assert_emits "triage-reviews -> Integrated Review" 'final `## Integrated Review` entry' \
+    --mode in-process --issue "$TEST_ISSUE" --skill triage-reviews
+assert_emits "unknown skill -> generic typed-entry clause" "append your final typed entry" \
+    --mode in-process --issue "$TEST_ISSUE" --skill frobnicate
+
+# --- explicit --entry-type overrides the skill default ---
+assert_emits "--entry-type overrides skill mapping" 'final `## Custom Type` entry' \
+    --mode in-process --issue "$TEST_ISSUE" --skill review-code --entry-type "Custom Type"
+
+# --- prompt-file mode uses the file as the task body ---
+PF="$(mktemp /tmp/dispatch_test_prompt.XXXXXX.md)"
+echo "UNIQUE_TASK_MARKER_42" > "$PF"
+assert_emits "prompt-file content becomes the task body" "UNIQUE_TASK_MARKER_42" \
+    --mode in-process --issue "$TEST_ISSUE" --prompt-file "$PF"
+rm -f "$PF"
+
+# --- identity override via env ---
+out="$(AGENT_NAME="Tester Bot" AGENT_EMAIL="roland+tester@ccom.unh.edu" \
+    "$DISPATCH" --mode in-process --issue "$TEST_ISSUE" --skill review-code 2>/dev/null)"
+case "$out" in
+    *'git -c user.name="Tester Bot" -c user.email="roland+tester@ccom.unh.edu"'*) ok "honors AGENT_NAME/AGENT_EMAIL override" ;;
+    *) bad "honors AGENT_NAME/AGENT_EMAIL override" "override not reflected in handoff" ;;
+esac
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.agent/scripts/test_dispatch_subagent.sh
+++ b/.agent/scripts/test_dispatch_subagent.sh
@@ -94,6 +94,22 @@ assert_emits "prompt-file content becomes the task body" "UNIQUE_TASK_MARKER_42"
     --mode in-process --issue "$TEST_ISSUE" --prompt-file "$PF"
 rm -f "$PF"
 
+# --- per-phase model mapping (in-process reports the recommended model) ---
+assert_emits "review-code -> opus model" "Recommended model: opus" \
+    --mode in-process --issue "$TEST_ISSUE" --skill review-code
+assert_emits "triage-reviews -> opus model" "Recommended model: opus" \
+    --mode in-process --issue "$TEST_ISSUE" --skill triage-reviews
+assert_emits "review-issue -> sonnet model" "Recommended model: sonnet" \
+    --mode in-process --issue "$TEST_ISSUE" --skill review-issue
+assert_emits "plan-task -> sonnet model" "Recommended model: sonnet" \
+    --mode in-process --issue "$TEST_ISSUE" --skill plan-task
+assert_emits "unknown skill -> sonnet default" "Recommended model: sonnet" \
+    --mode in-process --issue "$TEST_ISSUE" --skill frobnicate
+assert_emits "raw prompt -> sonnet default" "Recommended model: sonnet" \
+    --mode in-process --issue "$TEST_ISSUE" --prompt-file /etc/hostname
+assert_emits "--model overrides skill mapping" "Recommended model: haiku" \
+    --mode in-process --issue "$TEST_ISSUE" --skill review-code --model haiku
+
 # --- identity override via env ---
 out="$(AGENT_NAME="Tester Bot" AGENT_EMAIL="roland+tester@ccom.unh.edu" \
     "$DISPATCH" --mode in-process --issue "$TEST_ISSUE" --skill review-code 2>/dev/null)"

--- a/.agent/work-plans/issue-490/plan.md
+++ b/.agent/work-plans/issue-490/plan.md
@@ -47,11 +47,12 @@ Two concrete gaps the dispatch must close:
      fresh `Agent` call (same context root; fast; no isolation).
    - **container**: emit the prompt + launch `docker_run_agent.sh` headless
      with it as kickoff; on exit, apply the exit-contract read (step 3) and
-     print outcome + next action. **Identity note**: container dispatch must
-     forward `AGENT_NAME`/`AGENT_EMAIL` — the entrypoint's
-     `configure_git_identity.sh --detect` reads them to set the container's git
-     config (distinct from the prompt's `git -c` literals, which only tell the
-     sub-agent what to use). Reuse #489's forwarding + missing-identity warning.
+     print outcome + next action. **Identity**: pure per-commit `git -c`
+     literals embedded in the handoff prompt — no persistent container git
+     config (see Implementation Notes for why and the dogfood that settled it).
+     **Auth**: the headless container needs a `CLAUDE_CODE_OAUTH_TOKEN`
+     (subscription `setup-token`), which `docker_run_agent.sh` reads from
+     `~/.config/ros2-agent/claude-oauth-token` (600).
 3. **Exit-contract read (robust).** The host determines outcome from, in order:
    (a) the container/claude **exit status** — non-zero → failure regardless of
    `progress.md`; (b) a **newer** `progress.md` entry than existed pre-dispatch
@@ -87,7 +88,8 @@ Two concrete gaps the dispatch must close:
 | File | Change |
 |------|--------|
 | `.agent/scripts/dispatch_subagent.sh` | NEW — dual-mode dispatch + handoff-prompt builder + exit-contract read |
-| `.agent/scripts/docker_run_agent.sh` | Headless `--prompt`/`--prompt-file` kickoff; guard the push_gateway post-exit block off in dispatch mode |
+| `.agent/scripts/docker_run_agent.sh` | Headless `--prompt`/`--prompt-file` kickoff (drops `-it`, skips push_gateway post-exit); `CLAUDE_CODE_OAUTH_TOKEN` accept/forward + 600-file read |
+| `.devcontainer/agent/agent-entrypoint.sh` | Drop the root-run git-identity step (pure `-c`); set `HOME`/`USER`/`LOGNAME` for the dropped `ros` user |
 | `.agent/scripts/test_dispatch_subagent.sh` | NEW — unit tests |
 | `.claude/skills/review-issue/SKILL.md` | "Next step" handoff block |
 | `.claude/skills/plan-task/SKILL.md` | "Next step" handoff block |
@@ -123,7 +125,8 @@ Two concrete gaps the dispatch must close:
 |---|---|---|
 | Add `.agent/scripts/dispatch_subagent.sh` | AGENTS.md Script Reference table | Yes (ask-first) — **no** Makefile target, so no `make generate-skills` run needed |
 | Edit the 5 skills' final step (handoff block) | The 3 framework adapters (copilot / gemini / AGENT_ONBOARDING) | Yes — now listed in Files-to-Change; each gets a one-line "handoff is Claude-`Agent`-specific" note |
-| Container-mode dispatch sets git identity | Forward `AGENT_NAME`/`AGENT_EMAIL` (entrypoint `--detect`) | Yes — reuse #489's forwarding + missing-identity warning (Approach step 2) |
+| Container commits need identity | Handoff prompt embeds `git -c` literals (pure `-c`); no entrypoint config | Yes — settled via dogfood (Implementation Notes); `agent-entrypoint.sh` drops the identity step |
+| Headless container needs auth | `CLAUDE_CODE_OAUTH_TOKEN` via `setup-token`, read from a 600 file | Yes — `docker_run_agent.sh` accept/forward/file-read |
 | `docker_run_agent.sh` exit flow | `push_gateway` lifecycle | Partial — guarded now; full removal is #493 (gated on #492) |
 
 ## Decisions (resolved with user, 2026-06-13)
@@ -153,3 +156,45 @@ Two concrete gaps the dispatch must close:
 Single PR for #490 (Scope A + B + E), closing the issue. #493 is a separate,
 later PR gated on #492 — recommend a dedicated `plan-task 493` after #492 lands
 rather than folding its deletions in here.
+
+## Implementation Notes
+
+The headless container path was **dogfooded end-to-end** (2026-06-13): a
+sandboxed `claude -p` run authenticated, executed, made a correctly-attributed
+`git -c` commit, and pre-commit hooks ran — all validated. Three blockers were
+found and fixed during that dogfood (each would have shipped broken from a
+host-only build):
+
+- **Auth — `CLAUDE_CODE_OAUTH_TOKEN`, not transplanted OAuth.** A mounted
+  `~/.claude/.credentials.json` subscription-OAuth access token is short-lived
+  and can't refresh in the credential-less sandbox (`Not logged in`). Anthropic's
+  sanctioned headless/subscription method is `claude setup-token` → a 1-year
+  token (subscription billing, not API). Because each agent Bash invocation is a
+  fresh subshell, an exported env var never reaches the launcher, so
+  `docker_run_agent.sh` reads the token from a **600-perm file**
+  (`~/.config/ros2-agent/claude-oauth-token`, mirroring the gh-token pattern) —
+  secret stays out of argv and the transcript. We do **not** use `--bare` (it
+  disables OAuth/token entirely).
+- **Identity — pure `git -c`, not entrypoint config.** A root-run
+  `configure_git_identity.sh --detect` tripped git's dubious-ownership guard over
+  host-uid-owned mounts (`fatal: not in a git directory`). Removed it: the agent
+  runs as the repo-owning `ros` user and commits with per-invocation `-c`
+  literals. (Bonus: `setup.bash` sources `set_git_identity_env.sh`, so
+  `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env identity is also present and — uniquely in
+  the container's single process tree — propagates to the agent's git ops, so a
+  forgotten `-c` still attributes correctly. Started with pure `-c` to watch the
+  failure rate; the env identity makes hard-fail unlikely.)
+- **`HOME` for the dropped user.** `setpriv` inherited `HOME=/root`, so the `ros`
+  agent hit `EACCES` writing `/root/.claude/...` and every Bash call failed. Set
+  `HOME`/`USER`/`LOGNAME` to the target user on the exec.
+
+Also confirmed: **pre-commit hooks run in-container via the mounted host
+`.venv`** (the hook's `INSTALL_PYTHON` absolute path is mounted at the same path),
+so the "hooks must run" rule is honored without baking pre-commit into the image.
+Build-time dep-baking (to cut the rosdep-install storm on every launch) is tracked
+separately as #520.
+
+**Deferred:** the sandbox-vs-host provenance marker (distinct identity vs. commit
+trailer) is settled when wiring the Scope-B handoff literals — start with no
+marker / same identity unless we want sandbox commits visibly distinct while
+building trust.

--- a/.agent/work-plans/issue-490/plan.md
+++ b/.agent/work-plans/issue-490/plan.md
@@ -1,0 +1,125 @@
+# Plan: dispatch_subagent.sh + per-skill handoff boilerplate (#490)
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/490 — part of #481
+(phase C of #470). Planned jointly with #493 (delete push_gateway) per
+request; see Open Questions for why #493 is sequenced *after* #492, not here.
+
+## Context
+
+The sandboxed agent container already runs tasks today — `docker_run_agent.sh
+--issue <N>` builds the image, mounts the worktree, forwards identity, and runs
+an **interactive** `claude --dangerously-skip-permissions --strict-mcp-config`
+with zero permission prompts (hardened by #489). What's missing is a
+*programmatic dispatch layer* so a host orchestrator (#492 `/run-issue`) can
+launch any workflow skill into a fresh-context sub-agent — in-process (`Agent`
+tool) or container (docker) — with a prepared kickoff prompt, identity literals,
+and a defined exit contract. #490 is that keystone; #491/#492 consume it.
+
+Two concrete gaps the dispatch must close:
+
+1. **`docker_run_agent.sh` is interactive-only** (`-it`, interactive claude).
+   Container dispatch needs a **headless kickoff** path. Confirmed the image's
+   `claude` supports `-p/--print` with `--output-format`.
+2. **The exit contract.** Today the container signals work via `push_gateway.sh`
+   + `.agent/scratchpad/push-requests/*.json`. #481's model replaces that: the
+   sub-agent writes a final `progress.md` entry (ADR-0013 vocabulary) and the
+   host reads the last entry for outcome + next action. #490 introduces this
+   contract **for the dispatch path only** — it does *not* delete the gateway
+   (that's #493, which depends on #492 — see Open Questions).
+
+## Approach
+
+1. **Headless kickoff in `docker_run_agent.sh`** — add `--prompt <text>` /
+   `--prompt-file <path>`. When given, launch non-interactively (drop `-it`):
+   `claude -p "<kickoff>" --output-format stream-json
+   --dangerously-skip-permissions --strict-mcp-config`, tee to a per-run log,
+   exit with claude's status. No prompt → existing interactive behavior
+   unchanged. **Guard** the post-exit `push_gateway` block so it is skipped in
+   dispatch mode (host reads `progress.md` instead) — guard, don't delete.
+2. **`dispatch_subagent.sh` (NEW)** — `--mode in-process|container`,
+   `--issue <N>`, and `--skill <name>` or `--prompt-file`. Builds the handoff
+   prompt: identity **literals** via `git -c` (AGENTS.md § Agent Commit
+   Identity), the "read the last `## <EntryType>` entry in
+   `progress.md`" vessel instruction, and a mode hint.
+   - **in-process**: emit the prompt to stdout for the host to paste into a
+     fresh `Agent` call (same context root; fast; no isolation).
+   - **container**: emit the prompt + launch `docker_run_agent.sh` headless
+     with it as kickoff; on exit, read the worktree-issue's last `progress.md`
+     entry and print outcome + next action.
+3. **Exit-contract read** — reuse `.agent/scripts/progress_read.py` to extract
+   the last typed entry. Document that the contract is **convention-only, no
+   enforcement** (per #490 / ADR-0004 honesty about enforcement tiers).
+4. **Per-skill handoff boilerplate (Scope B)** — add a "Next step" block to the
+   final step of `review-issue`, `plan-task`, `review-plan`, `review-code`,
+   `triage-reviews` (+ address-findings when #491 lands): identity literals,
+   the `progress.md` handoff vessel, and a mode hint (in-process for short
+   reviews; container for isolation-worthy phases). Document **Scope E**: no
+   skill-level auto-chaining — the host orchestrator (#492) drives next-phase
+   dispatch.
+5. **Tests** — `test_dispatch_subagent.sh` (mode selection, prompt emission,
+   exit-contract read), following the `test_check_commit_identity.sh` pattern.
+   **Layer-worktree container check**: verify container mode works for a
+   project-repo (layer) worktree — the 2026-05-20 experiment only exercised a
+   *workspace* worktree, and #492 will rely on layer dispatch.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/dispatch_subagent.sh` | NEW — dual-mode dispatch + handoff-prompt builder + exit-contract read |
+| `.agent/scripts/docker_run_agent.sh` | Headless `--prompt`/`--prompt-file` kickoff; guard the push_gateway post-exit block off in dispatch mode |
+| `.agent/scripts/test_dispatch_subagent.sh` | NEW — unit tests |
+| `.claude/skills/review-issue/SKILL.md` | "Next step" handoff block |
+| `.claude/skills/plan-task/SKILL.md` | "Next step" handoff block |
+| `.claude/skills/review-plan/SKILL.md` | "Next step" handoff block |
+| `.claude/skills/review-code/SKILL.md` | "Next step" handoff block |
+| `.claude/skills/triage-reviews/SKILL.md` | "Next step" handoff block |
+| `.agent/knowledge/skill_workflows.md` | Document handoff convention + Scope-E no-auto-chain |
+| `AGENTS.md` | Script Reference row for `dispatch_subagent.sh` (**ask-first** — instruction file) |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Worktree isolation (ADR-0002) | Dispatch operates on existing per-issue worktrees; container mounts them — no branch switching |
+| Project-agnostic infra (ADR-0003) | Dispatch + handoff are workspace-generic; no project-specific assumptions |
+| Honest enforcement (ADR-0004/0005) | Exit contract is convention-only and documented as such — no false enforcement signal |
+| Quality / robustness | Headless path must surface a non-zero claude exit; layer-worktree path tested, not assumed |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0013 (progress.md vocab) | Yes | Exit contract reads/writes existing typed entries; no new entry type added here (address-findings type is #491's call) |
+| ADR-0002 (worktree isolation) | Yes | Dispatch uses existing worktrees, not branch checkouts |
+| New orchestration ADR | Maybe | A dispatch/orchestration ADR may be warranted once #492 lands; flag — do not author in #490 |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Add `dispatch_subagent.sh` | AGENTS.md Script Reference table | Yes (ask-first) |
+| Edit 6 skills' final step | Skill list / framework adapters (consequences map) | Yes — handoff is Claude-`Agent`-specific; note non-Claude limitation in adapters |
+| `docker_run_agent.sh` exit flow | `push_gateway` lifecycle | Partial — guarded now; full removal is #493 (gated on #492) |
+
+## Open Questions
+
+- [ ] **#493 sequencing.** #493 (delete `push_gateway.sh` + scratchpad request
+  dirs + Makefile `push-gateway` target) declares it **depends on #492**, not
+  #490. Recommended approach: #490 introduces the `progress.md` exit contract
+  for the dispatch path but **leaves the gateway in place** for the legacy
+  interactive launch until #492 replaces it and #493 deletes it. Planning the
+  deletion in detail now is premature. Confirm this split.
+- [ ] **Kickoff output format** — `stream-json` (live progress), `json` (single
+  result), or `text` for the host to consume. Leaning `stream-json`.
+- [ ] **PR split** — A (dispatch + headless docker) and B (6 skill handoff
+  blocks) as one PR or two. Leaning one — B is needed to test A end-to-end and
+  both are small.
+
+## Estimated Scope
+
+Single PR for #490 (Scope A + B + E). #493 is a separate, later PR gated on
+#492 — recommend a dedicated `plan-task 493` after #492 lands rather than
+folding its deletions in here.

--- a/.agent/work-plans/issue-490/plan.md
+++ b/.agent/work-plans/issue-490/plan.md
@@ -104,22 +104,30 @@ Two concrete gaps the dispatch must close:
 | Edit 6 skills' final step | Skill list / framework adapters (consequences map) | Yes — handoff is Claude-`Agent`-specific; note non-Claude limitation in adapters |
 | `docker_run_agent.sh` exit flow | `push_gateway` lifecycle | Partial — guarded now; full removal is #493 (gated on #492) |
 
+## Decisions (resolved with user, 2026-06-13)
+
+- **#493 sequencing — leave the gateway intact.** #490 introduces the
+  `progress.md` exit contract for the *dispatch path only*; the legacy
+  interactive `docker_run_agent.sh --issue N` keeps `push_gateway.sh`
+  unchanged. #492 provides the host-side replacement; #493 (gated on #492)
+  deletes the gateway. No deprecation warning added in #490 — the gateway
+  stays as-is until its replacement exists. Plan #493's deletions separately
+  after #492.
+- **Kickoff output format — `stream-json`** (paired with `--verbose`, which
+  Claude Code requires for streaming `--print`). Gives #492 structured,
+  parseable live progress + a final result object. The authoritative outcome
+  still comes from the `progress.md` exit contract; `--output-format` remains a
+  per-call override.
+- **One PR, closes #490** — Scope A (dispatch + headless docker + tests) and B
+  (6 skill handoff blocks + docs) land together. A is independently testable
+  via `--prompt-file`, but bundling keeps the keystone cohesive in one review.
+
 ## Open Questions
 
-- [ ] **#493 sequencing.** #493 (delete `push_gateway.sh` + scratchpad request
-  dirs + Makefile `push-gateway` target) declares it **depends on #492**, not
-  #490. Recommended approach: #490 introduces the `progress.md` exit contract
-  for the dispatch path but **leaves the gateway in place** for the legacy
-  interactive launch until #492 replaces it and #493 deletes it. Planning the
-  deletion in detail now is premature. Confirm this split.
-- [ ] **Kickoff output format** — `stream-json` (live progress), `json` (single
-  result), or `text` for the host to consume. Leaning `stream-json`.
-- [ ] **PR split** — A (dispatch + headless docker) and B (6 skill handoff
-  blocks) as one PR or two. Leaning one — B is needed to test A end-to-end and
-  both are small.
+- [ ] None remaining — all three resolved above; plan is review-plan-ready.
 
 ## Estimated Scope
 
-Single PR for #490 (Scope A + B + E). #493 is a separate, later PR gated on
-#492 — recommend a dedicated `plan-task 493` after #492 lands rather than
-folding its deletions in here.
+Single PR for #490 (Scope A + B + E), closing the issue. #493 is a separate,
+later PR gated on #492 — recommend a dedicated `plan-task 493` after #492 lands
+rather than folding its deletions in here.

--- a/.agent/work-plans/issue-490/plan.md
+++ b/.agent/work-plans/issue-490/plan.md
@@ -88,7 +88,7 @@ Two concrete gaps the dispatch must close:
 | File | Change |
 |------|--------|
 | `.agent/scripts/dispatch_subagent.sh` | NEW — dual-mode dispatch + handoff-prompt builder + exit-contract read |
-| `.agent/scripts/docker_run_agent.sh` | Headless `--prompt`/`--prompt-file` kickoff (drops `-it`, skips push_gateway post-exit); `CLAUDE_CODE_OAUTH_TOKEN` accept/forward + 600-file read |
+| `.agent/scripts/docker_run_agent.sh` | Headless `--prompt`/`--prompt-file` kickoff (drops `-it`, skips push_gateway post-exit); `CLAUDE_CODE_OAUTH_TOKEN` accept/forward + 600-file read; `--model` pass-through |
 | `.devcontainer/agent/agent-entrypoint.sh` | Drop the root-run git-identity step (pure `-c`); set `HOME`/`USER`/`LOGNAME` for the dropped `ros` user |
 | `.agent/scripts/test_dispatch_subagent.sh` | NEW — unit tests |
 | `.claude/skills/review-issue/SKILL.md` | "Next step" handoff block |
@@ -193,6 +193,18 @@ Also confirmed: **pre-commit hooks run in-container via the mounted host
 so the "hooks must run" rule is honored without baking pre-commit into the image.
 Build-time dep-baking (to cut the rosdep-install storm on every launch) is tracked
 separately as #520.
+
+- **Per-phase model selection (dogfood finding).** The first container dispatch
+  ran on **Sonnet 4.6** (the headless `claude` default), not Opus —
+  `AGENT_MODEL` is cosmetic; the lever is `claude --model`. Added `--model` to
+  `docker_run_agent.sh` and a skill→model map to `dispatch_subagent.sh`: Opus
+  for review-code / review-plan / triage-reviews / implement / address-findings;
+  Sonnet for review-issue / plan-task and the default (quota headroom). Uses
+  **aliases** (`opus`/`sonnet`), not pinned ids, so it survives version bumps;
+  an unavailable model **hard-fails loudly** (verified `claude --model <bad>`
+  exits 1 → the exit-contract reports FAILED, no silent downgrade) — fix is one
+  mapping line. In-process mode only *recommends* the model (the host picks the
+  Agent's). `--model` overrides any cell.
 
 **Deferred:** the sandbox-vs-host provenance marker (distinct identity vs. commit
 trailer) is settled when wiring the Scope-B handoff literals — start with no

--- a/.agent/work-plans/issue-490/plan.md
+++ b/.agent/work-plans/issue-490/plan.md
@@ -46,11 +46,25 @@ Two concrete gaps the dispatch must close:
    - **in-process**: emit the prompt to stdout for the host to paste into a
      fresh `Agent` call (same context root; fast; no isolation).
    - **container**: emit the prompt + launch `docker_run_agent.sh` headless
-     with it as kickoff; on exit, read the worktree-issue's last `progress.md`
-     entry and print outcome + next action.
-3. **Exit-contract read** — reuse `.agent/scripts/progress_read.py` to extract
-   the last typed entry. Document that the contract is **convention-only, no
-   enforcement** (per #490 / ADR-0004 honesty about enforcement tiers).
+     with it as kickoff; on exit, apply the exit-contract read (step 3) and
+     print outcome + next action. **Identity note**: container dispatch must
+     forward `AGENT_NAME`/`AGENT_EMAIL` — the entrypoint's
+     `configure_git_identity.sh --detect` reads them to set the container's git
+     config (distinct from the prompt's `git -c` literals, which only tell the
+     sub-agent what to use). Reuse #489's forwarding + missing-identity warning.
+3. **Exit-contract read (robust).** The host determines outcome from, in order:
+   (a) the container/claude **exit status** — non-zero → failure regardless of
+   `progress.md`; (b) a **newer** `progress.md` entry than existed pre-dispatch
+   — capture the pre-dispatch last-entry sha/count and require the post-exit
+   read to show a newer one, else treat as "sub-agent died before writing" =
+   failure (never misread a stale prior entry as this run's result); (c) the
+   entry must match the **expected entry type** for the dispatched skill (e.g.
+   `## Plan Review` for review-plan) so an earlier skill's trailing entry in the
+   same worktree isn't mistaken for this run's. Note `progress_read.py` has **no
+   tail selector** — it emits all (or `--type`-filtered) entries as a JSON array
+   in document order, so the host type-filters then takes `.entries[-1]`. The
+   contract itself is **convention-only, no enforcement** (per ADR-0004/0005
+   honesty about enforcement tiers).
 4. **Per-skill handoff boilerplate (Scope B)** — add a "Next step" block to the
    final step of `review-issue`, `plan-task`, `review-plan`, `review-code`,
    `triage-reviews` (+ address-findings when #491 lands): identity literals,
@@ -62,7 +76,11 @@ Two concrete gaps the dispatch must close:
    exit-contract read), following the `test_check_commit_identity.sh` pattern.
    **Layer-worktree container check**: verify container mode works for a
    project-repo (layer) worktree — the 2026-05-20 experiment only exercised a
-   *workspace* worktree, and #492 will rely on layer dispatch.
+   *workspace* worktree, and #492 will rely on layer dispatch. This is a
+   **documented manual verification step** (a real container run against a real
+   layer worktree), not an automated CI test — the shell regression test can't
+   spin up a layer worktree + docker in CI. Record the run in the PR so it isn't
+   silently dropped.
 
 ## Files to Change
 
@@ -77,7 +95,10 @@ Two concrete gaps the dispatch must close:
 | `.claude/skills/review-code/SKILL.md` | "Next step" handoff block |
 | `.claude/skills/triage-reviews/SKILL.md` | "Next step" handoff block |
 | `.agent/knowledge/skill_workflows.md` | Document handoff convention + Scope-E no-auto-chain |
-| `AGENTS.md` | Script Reference row for `dispatch_subagent.sh` (**ask-first** — instruction file) |
+| `.github/copilot-instructions.md` | One-line note: handoff/dispatch is Claude-`Agent`-specific; non-Claude runtimes paste the handoff prompt manually (**ask-first** — adapter) |
+| `.agent/instructions/gemini-cli.instructions.md` | Same Claude-specific handoff note (**ask-first** — adapter) |
+| `.agent/AGENT_ONBOARDING.md` | Same Claude-specific handoff note (**ask-first** — adapter) |
+| `AGENTS.md` | Script Reference row for `dispatch_subagent.sh`; **no** Makefile target added (**ask-first** — instruction file) |
 
 ## Principles Self-Check
 
@@ -100,8 +121,9 @@ Two concrete gaps the dispatch must close:
 
 | If we change... | Also update... | Included in plan? |
 |---|---|---|
-| Add `dispatch_subagent.sh` | AGENTS.md Script Reference table | Yes (ask-first) |
-| Edit 6 skills' final step | Skill list / framework adapters (consequences map) | Yes — handoff is Claude-`Agent`-specific; note non-Claude limitation in adapters |
+| Add `.agent/scripts/dispatch_subagent.sh` | AGENTS.md Script Reference table | Yes (ask-first) — **no** Makefile target, so no `make generate-skills` run needed |
+| Edit the 5 skills' final step (handoff block) | The 3 framework adapters (copilot / gemini / AGENT_ONBOARDING) | Yes — now listed in Files-to-Change; each gets a one-line "handoff is Claude-`Agent`-specific" note |
+| Container-mode dispatch sets git identity | Forward `AGENT_NAME`/`AGENT_EMAIL` (entrypoint `--detect`) | Yes — reuse #489's forwarding + missing-identity warning (Approach step 2) |
 | `docker_run_agent.sh` exit flow | `push_gateway` lifecycle | Partial — guarded now; full removal is #493 (gated on #492) |
 
 ## Decisions (resolved with user, 2026-06-13)

--- a/.agent/work-plans/issue-490/progress.md
+++ b/.agent/work-plans/issue-490/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 490
+---
+
+# Issue #490 — dispatch_subagent.sh + per-skill handoff boilerplate
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-13 17:14 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-490/plan.md` at `24896d3`
+**PR**: https://github.com/rolker/ros2_agent_workspace/pull/519 (`[PLAN]` prefix)
+**Phases**: single (Scope A + B + E in one PR; #493 deferred, gated on #492)
+
+### Open questions
+- [ ] #493 sequencing: #490 adds the progress.md exit contract but leaves push_gateway in place; deletion is #493, gated on #492 — confirm the split.
+- [ ] Kickoff output format: stream-json vs json vs text for the host to consume (leaning stream-json).
+- [ ] PR split: dispatch+headless (A) and skill handoff blocks (B) as one PR or two (leaning one).

--- a/.agent/work-plans/issue-490/progress.md
+++ b/.agent/work-plans/issue-490/progress.md
@@ -33,3 +33,36 @@ issue: 490
 - [x] (suggestion) Container-mode must forward AGENT_NAME/EMAIL for entrypoint --detect identity — plan Approach step 2
 - [x] (suggestion) Layer-worktree container check is manual, not CI — clarified in plan Approach step 5
 - [x] (suggestion) State no Makefile target for dispatch_subagent.sh — added to Consequences
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-14 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+**Scope**: Scope B — per-skill handoff blocks and knowledge doc
+**Commits**: `e1d0efb` (5 skill SKILL.md files), `703e7ff` (skill_workflows.md)
+
+### What was added
+
+Five lifecycle skill files each received a `### Next step` block as
+the last section of their procedure (before `## Guidelines`):
+
+- `review-issue/SKILL.md` → hands off to `plan-task` (in-process); entry pair: `## Issue Review` → `## Plan Authored`
+- `plan-task/SKILL.md` → hands off to `review-plan` (in-process); entry pair: `## Plan Authored` → `## Plan Review`
+- `review-plan/SKILL.md` → describes two-phase hand-off: implement (container, no skill yet) then `review-code` (in-process); entry pair: `## Plan Review` → `## Local Review`
+- `review-code/SKILL.md` → hands off to `triage-reviews` (in-process, after push); entry pair: `## Local Review` → `## Integrated Review`
+- `triage-reviews/SKILL.md` → end-of-loop description (address findings / merge); no dispatch line needed
+
+`.agent/knowledge/skill_workflows.md` received a new
+`## Lifecycle Handoff Convention (#490)` section: entry-type table,
+dispatcher usage examples, and the Scope-E no-auto-chaining rule.
+
+### Ask-first files intentionally omitted
+
+`.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`,
+`.agent/AGENT_ONBOARDING.md`, and `AGENTS.md` are held for human approval per
+the plan's Files-to-Change "ask-first" annotation and the task prompt's Do-NOT-touch list.
+
+### Actions
+- [ ] Host: push branch and open/update PR for review
+- [ ] Ask-first: add one-line "handoff is Claude-Agent-specific" note to the 3 framework adapters + AGENTS.md Script Reference row (human approval needed)

--- a/.agent/work-plans/issue-490/progress.md
+++ b/.agent/work-plans/issue-490/progress.md
@@ -171,3 +171,71 @@ clean (shellcheck unavailable). Copilot: off.
 - [ ] (suggestion/ask-first) AGENTS.md Script Reference adds `dispatch_subagent.sh` row but omits `docker_run_agent.sh` (extended into the dispatch backend) — `AGENTS.md:466`
 - [ ] (suggestion/ask-first) `configure_git_identity.sh` still documented as "ideal for containerized agents" (README.md 216-255, AI_IDENTITY_STRATEGY.md) but the entrypoint no longer runs it (new model: `git -c` literals + env-fallback) — stale/contradictory
 - [ ] (governance) Confirm human approval for the 4 ask-first instruction-file edits now in the diff (AGENTS.md, copilot-instructions.md, gemini-cli.instructions.md, AGENT_ONBOARDING.md) before pushing
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-14 12:59 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8) — fresh-context sub-agent dispatch
+
+**Scope**: address the round-2 `Local Review (Pre-Push)` findings — 1 must-fix
++ 1 must-fix (exit-contract) + 2 in-scope suggestions + 2 human-approved
+ask-first doc edits. Do-NOT-touch list honored (`framework_config.sh`,
+`set_git_identity_env.sh`, and the 4 earlier framework-adapter/AGENTS handoff
+edits left untouched).
+
+**Branch**: feature/issue-490
+
+**Commits**:
+- `3d98375` — `docker_run_agent.sh` (#1, #3, #4)
+- `da0b52b` — `dispatch_subagent.sh` (#2)
+- `f702f4b` — `AGENTS.md` Script Reference row (#5)
+- `05a553c` — `README.md` + `AI_IDENTITY_STRATEGY.md` doc sync (#6)
+
+### Findings fixed
+- **#1 (must-fix)** `--prompt ""` dispatch gate — `--prompt` arm now rejects
+  an empty value at parse time, and `DISPATCH_MODE` is gated on `PROMPT_SET`
+  (intent) instead of `[ -n "$PROMPT" ]` (value), so an empty prompt can no
+  longer fall through to an interactive `-it` container —
+  `docker_run_agent.sh`.
+- **#2 (must-fix)** exit-contract missed review-code's pre-push variant.
+  **Note on the task's `base_type` premise:** verified via `progress_read.py`
+  JSON that `Local Review (Pre-Push)` is *itself* a canonical ADR-0013 type,
+  so its `base_type` is the full `Local Review (Pre-Push)` — it does **not**
+  strip to `Local Review`. The documented fallback was therefore required:
+  `entry_count` and the OK-branch last-entry display now match over the
+  unfiltered `progress_read.py` JSON with the predicate
+  `type == ENTRY_TYPE OR base_type == ENTRY_TYPE OR type.startswith(ENTRY_TYPE)`
+  (the `startswith` arm catches the parenthetical variant). `progress_read.py`
+  left unchanged (changing `_canonical_base` would broadly re-scope a distinct
+  canonical type and risk other consumers). Failure message softened to
+  acknowledge the unexpected-type case — `dispatch_subagent.sh`.
+- **#3 (suggestion)** `GH_TOKEN` now forwarded via bare `-e GH_TOKEN`
+  (value-in-env, exported when set) instead of `-e "GH_TOKEN=$AGENT_GH_TOKEN"`
+  (value-in-argv, visible in host `ps`) — matches the OAuth pattern —
+  `docker_run_agent.sh`.
+- **#4 (suggestion)** both secret-file reads use `IFS= read -r` to avoid
+  whitespace stripping — `docker_run_agent.sh`.
+- **#5 (ask-first, approved)** `docker_run_agent.sh` row added to the AGENTS.md
+  Script Reference (verbatim per the task) — `AGENTS.md`.
+- **#6 (ask-first, approved)** `configure_git_identity.sh` containerized-identity
+  docs synced to the current model (handoff `git -c` literals + entrypoint
+  `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env); the script is reframed as the
+  dedicated-checkout method, not the container method — `README.md`,
+  `AI_IDENTITY_STRATEGY.md`. Claims cross-checked against
+  `agent-entrypoint.sh` (lines 67–80).
+
+### Tests
+- `bash -n` clean on both edited scripts (`docker_run_agent.sh`,
+  `dispatch_subagent.sh`).
+- `test_dispatch_subagent.sh`: **29/29 pass**.
+- shellcheck (via pre-commit) passed on both scripts.
+- The #2 matching predicate runs only in the container-mode exit-contract path
+  (not reachable without docker, consistent with the existing test file's
+  documented scope), so no new unit test was added; it was verified manually
+  with the live `progress.md` — `ENTRY_TYPE="Local Review"` now matches both
+  `Local Review` and `Local Review (Pre-Push)` (count 1 → 2).
+
+### Out of scope (untouched)
+`framework_config.sh` stale-model follow-up, `set_git_identity_env.sh`, and the
+4 already-committed framework-adapter/AGENTS handoff edits — per the
+Do-NOT-touch list. No `git push` (host performs pushes).

--- a/.agent/work-plans/issue-490/progress.md
+++ b/.agent/work-plans/issue-490/progress.md
@@ -145,3 +145,29 @@ touched, per the Do-NOT-touch list.
 handoff rule, and the ambiguous-worktree warning). Container-mode behavior
 (fixes #1/#4/#6 runtime path) remains covered by the manual layer-worktree
 verification noted in the plan — not unit-testable without docker.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-14 12:25 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-490 at `65d3408`
+**Mode**: pre-push
+**Depth**: Deep (reason: security-relevant scripts — container dispatch, --dangerously-skip-permissions, OAuth-token handling, in-container git identity)
+**Must-fix**: 1 | **Suggestions**: 5
+
+Re-review of the current tree after the prior post-PR fixes (`e6770db`,
+`a2d898d`, `cc26ead`). All earlier must-fix items verify as applied;
+`test_dispatch_subagent.sh` 29/29; both adversarial lenses confirmed the
+exit-contract + privilege-drop logic correct. Static analysis: `bash -n`
+clean (shellcheck unavailable). Copilot: off.
+
+### Findings
+- [ ] (must-fix) `--prompt ""` sets `PROMPT_SET=true` but `DISPATCH_MODE` stays false (gated on `[ -n "$PROMPT" ]`) → silently launches interactive `-it` container; same class as prior must-fix #2 for `--prompt-file`. Gate on `PROMPT_SET` + reject empty `--prompt` — `docker_run_agent.sh:156`
+- [ ] (suggestion) GH read-only token forwarded inline `-e "GH_TOKEN=$AGENT_GH_TOKEN"` → visible in host `ps`/cmdline; PR's new adjacent OAuth forwarding (line 369) uses the safe bare-`-e` form. Pre-existing line, 1-line fix while here — `docker_run_agent.sh:371`
+- [ ] (suggestion) "died before reporting" headline is a false-negative when the sub-agent writes a real entry of a different type than the gated `--entry-type`; add a caveat to the message — `dispatch_subagent.sh:265`
+- [ ] (suggestion) secrets read via `read -r VAR < file`; use `IFS= read -r` to avoid whitespace stripping — `docker_run_agent.sh:181,345`
+- [ ] (suggestion/ask-first) AGENTS.md Script Reference adds `dispatch_subagent.sh` row but omits `docker_run_agent.sh` (extended into the dispatch backend) — `AGENTS.md:466`
+- [ ] (suggestion/ask-first) `configure_git_identity.sh` still documented as "ideal for containerized agents" (README.md 216-255, AI_IDENTITY_STRATEGY.md) but the entrypoint no longer runs it (new model: `git -c` literals + env-fallback) — stale/contradictory
+- [ ] (governance) Confirm human approval for the 4 ask-first instruction-file edits now in the diff (AGENTS.md, copilot-instructions.md, gemini-cli.instructions.md, AGENT_ONBOARDING.md) before pushing

--- a/.agent/work-plans/issue-490/progress.md
+++ b/.agent/work-plans/issue-490/progress.md
@@ -66,3 +66,29 @@ the plan's Files-to-Change "ask-first" annotation and the task prompt's Do-NOT-t
 ### Actions
 - [ ] Host: push branch and open/update PR for review
 - [ ] Ask-first: add one-line "handoff is Claude-Agent-specific" note to the 3 framework adapters + AGENTS.md Script Reference row (human approval needed)
+
+## Local Review
+**Status**: complete
+**When**: 2026-06-14 07:22 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: changes-requested
+
+**PR**: #519 at `0139dda`
+**Mode**: post-PR
+**Depth**: Deep (reason: +1032/-39, 16 files, container-isolation/auth/identity scripts)
+**Must-fix**: 4 | **Suggestions**: 6 | **Ask-first follow-ups**: 3
+
+### Findings
+- [ ] (must-fix) exit-contract fails OPEN: non-numeric `entry_count` makes `[ -le ]` error → success branch → false "OK" — `dispatch_subagent.sh` (PRE/POST_COUNT). Fix: validate numeric, fail closed.
+- [ ] (must-fix) empty `--prompt-file` → `DISPATCH_MODE` stays false → launches interactive `-it` container — `docker_run_agent.sh`. Fix: reject empty file (`[ -s ]`).
+- [ ] (must-fix) stale comment describes the now-deleted entrypoint `configure_git_identity.sh --detect` step — `docker_run_agent.sh` (forward-identity block). Fix: rewrite to the pure-`-c` + env-from-setup.bash reality.
+- [ ] (must-fix) exit-contract prints `Result: OK` even when the entry's `**Status**` is `failed`/`partial` — `dispatch_subagent.sh` OK branch. Fix: read `entries[-1].status`, headline FAILED/PARTIAL, exit non-zero. (High value: #492 greps this.)
+- [ ] (suggestion) env-fallback identity diverges from the `-c` literals: `setup.bash`→`set_git_identity_env.sh --detect` re-derives `claude-code` instead of honoring forwarded `AGENT_NAME/EMAIL` (only differs for a custom agent name; benign for human-misattribution). Fix: entrypoint export `GIT_AUTHOR_*/GIT_COMMITTER_*` from forwarded vars before sourcing setup.bash.
+- [ ] (suggestion) OK-branch last-entry printer is unfiltered; show the `--type`-filtered last entry to match the gate — `dispatch_subagent.sh`.
+- [ ] (suggestion) `--prompt`/`--prompt-file` "mutually exclusive" claimed in help but not enforced — `docker_run_agent.sh`. Enforce or soften.
+- [ ] (suggestion) add "never write credentials into files/commits/output" to the handoff contract — `dispatch_subagent.sh` (defense-in-depth).
+- [ ] (suggestion) warn when the layer-worktree glob matches >1 dir (silently picks first) — `dispatch_subagent.sh`/`docker_run_agent.sh`.
+- [ ] (suggestion) validate `--output-format` against stream-json|json|text up front — `dispatch_subagent.sh`.
+- [ ] (ask-first) add `docker_run_agent.sh` row to AGENTS.md Script Reference (sibling of the dispatch row; still missing).
+- [ ] (ask-first) sync `configure_git_identity.sh` containerized-identity docs (`.agent/scripts/README.md`, `.agent/AI_IDENTITY_STRATEGY.md`) — now stale after the entrypoint step was removed.
+- [ ] (follow-up) `framework_config.sh` model entry stale (`Claude Opus 4.6`) — pre-existing, cosmetic; separate from this PR.

--- a/.agent/work-plans/issue-490/progress.md
+++ b/.agent/work-plans/issue-490/progress.md
@@ -17,3 +17,19 @@ issue: 490
 - [ ] #493 sequencing: #490 adds the progress.md exit contract but leaves push_gateway in place; deletion is #493, gated on #492 — confirm the split.
 - [ ] Kickoff output format: stream-json vs json vs text for the host to consume (leaning stream-json).
 - [ ] PR split: dispatch+headless (A) and skill handoff blocks (B) as one PR or two (leaning one).
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-13 17:49 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) — fresh-context sub-agent dispatch (independent of plan-author context; same agent identity)
+
+**Plan**: `.agent/work-plans/issue-490/plan.md` at `4290908` (findings addressed)
+**PR**: https://github.com/rolker/ros2_agent_workspace/pull/519
+**Verdict**: changes-requested (2 must-fix + 3 suggestions; all folded into plan at `4290908`)
+
+### Findings
+- [x] (must-fix) Exit-contract under-specified: crash-before-write reads stale entry; progress_read.py has no tail selector; could match wrong skill's entry → gate on exit status + require newer entry + key on expected type — plan Approach step 3
+- [x] (must-fix) 3 framework adapters not in Files-to-Change (handoff is Claude-Agent-specific) — now listed
+- [x] (suggestion) Container-mode must forward AGENT_NAME/EMAIL for entrypoint --detect identity — plan Approach step 2
+- [x] (suggestion) Layer-worktree container check is manual, not CI — clarified in plan Approach step 5
+- [x] (suggestion) State no Makefile target for dispatch_subagent.sh — added to Consequences

--- a/.agent/work-plans/issue-490/progress.md
+++ b/.agent/work-plans/issue-490/progress.md
@@ -92,3 +92,56 @@ the plan's Files-to-Change "ask-first" annotation and the task prompt's Do-NOT-t
 - [ ] (ask-first) add `docker_run_agent.sh` row to AGENTS.md Script Reference (sibling of the dispatch row; still missing).
 - [ ] (ask-first) sync `configure_git_identity.sh` containerized-identity docs (`.agent/scripts/README.md`, `.agent/AI_IDENTITY_STRATEGY.md`) — now stale after the entrypoint step was removed.
 - [ ] (follow-up) `framework_config.sh` model entry stale (`Claude Opus 4.6`) — pre-existing, cosmetic; separate from this PR.
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-14 08:10 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8) — fresh-context sub-agent dispatch
+
+**Scope**: address the Local Review findings (4 must-fix + 6 in-scope
+suggestions); ask-first files left untouched.
+
+**Commits**:
+- `e6770db` — `dispatch_subagent.sh` + `test_dispatch_subagent.sh`
+- `a2d898d` — `docker_run_agent.sh`
+- `cc26ead` — `agent-entrypoint.sh`
+
+### Findings fixed
+- **#1 (must-fix)** exit-contract fail-closed: `PRE_COUNT`/`POST_COUNT`
+  coerced (`-1`/`0`) when non-numeric so `[ -le ]` can't error into the
+  success branch — `dispatch_subagent.sh`.
+- **#2 (must-fix)** empty `--prompt-file` rejected via `[ -s ]` —
+  `docker_run_agent.sh`.
+- **#3 (must-fix)** stale `configure_git_identity.sh --detect` comment
+  rewritten to the `git -c` literals + entrypoint env-export reality —
+  `docker_run_agent.sh`.
+- **#4 (must-fix)** status-aware exit contract: reads the gated entry's
+  `**Status**`, emits `Result: FAILED`/`PARTIAL` and exits non-zero for
+  failed/partial; `complete` → OK, unknown/missing → OK-but-says-so —
+  `dispatch_subagent.sh`.
+- **#5 (suggestion)** entrypoint pre-exports `GIT_AUTHOR_*`/`GIT_COMMITTER_*`
+  from forwarded `AGENT_NAME`/`AGENT_EMAIL` before sourcing `setup.bash`,
+  so the env-fallback matches the handoff literals — `agent-entrypoint.sh`.
+- **#6 (suggestion)** last-entry printer now `--type`-filtered to match the
+  gate (folded into #4) — `dispatch_subagent.sh`.
+- **#7 (suggestion)** `--prompt`/`--prompt-file` mutual exclusion enforced
+  via a `PROMPT_SET` tracker — `docker_run_agent.sh`.
+- **#8 (suggestion)** credential-handling line added to the handoff
+  contract — `dispatch_subagent.sh`.
+- **#9 (suggestion)** ambiguous worktree match warns on stderr (both
+  scripts).
+- **#10 (suggestion)** `--output-format` validated against
+  `stream-json|json|text` up front in both scripts.
+
+### Out of scope (left for human / follow-up)
+The 3 ask-first follow-ups (AGENTS.md Script Reference row,
+`configure_git_identity.sh` doc sync in `README.md`/`AI_IDENTITY_STRATEGY.md`)
+and the cosmetic `framework_config.sh` model-entry follow-up were **not**
+touched, per the Do-NOT-touch list.
+
+### Tests
+`bash -n` clean on all 4 edited scripts. `test_dispatch_subagent.sh`:
+**29/29 pass** (added: `--output-format` validation, the no-credentials
+handoff rule, and the ambiguous-worktree warning). Container-mode behavior
+(fixes #1/#4/#6 runtime path) remains covered by the manual layer-worktree
+verification noted in the plan — not unit-testable without docker.

--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -276,6 +276,26 @@ Summarize:
   static-analysis / governance / plan-drift / adversarial findings
   while they're still cheap to fix locally
 
+### Next step
+
+Lifecycle: **Plan Authored** → **review-plan**
+
+Hand off to the next phase in a **fresh-context sub-agent** — independence
+between lifecycle steps is what makes the timeline trustworthy (a reviewer who
+shares the author's context inherits their blind spots). Use the dispatcher:
+
+    .agent/scripts/dispatch_subagent.sh --mode in-process --issue <N> --skill review-plan
+
+The sub-agent reads the last `## Plan Authored` entry in
+`.agent/work-plans/issue-<N>/progress.md` for your output, and writes its own
+`## Plan Review` entry when done.
+
+**No auto-chaining (Scope E):** this skill never dispatches the next phase itself —
+the host orchestrator (`/run-issue`,
+[#492](https://github.com/rolker/ros2_agent_workspace/issues/492)) drives,
+pausing at user checkpoints. This step only emits this prompt and its
+`progress.md` entry.
+
 ## During implementation
 
 The `plan-task` skill's primary artifact is the committed plan file

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -913,6 +913,26 @@ Key points:
   this in the report Summary ("Progress persistence skipped (no linked
   issue)") — the same canonical wording used in the step-8 intro above.
 
+### Next step
+
+Lifecycle: **Local Review** → push / open PR → **triage-reviews**
+
+Once findings are addressed and the branch is pushed (or a PR opened), hand off
+to the next phase in a **fresh-context sub-agent** — independence between
+lifecycle steps is what makes the timeline trustworthy. Use the dispatcher:
+
+    .agent/scripts/dispatch_subagent.sh --mode in-process --issue <N> --skill triage-reviews
+
+The sub-agent reads the last `## Local Review` entry in
+`.agent/work-plans/issue-<N>/progress.md` for your output (plus live PR review
+comments), and writes its own `## Integrated Review` entry when done.
+
+**No auto-chaining (Scope E):** this skill never dispatches the next phase itself —
+the host orchestrator (`/run-issue`,
+[#492](https://github.com/rolker/ros2_agent_workspace/issues/492)) drives,
+pausing at user checkpoints. This step only emits this prompt and its
+`progress.md` entry.
+
 ## Guidelines
 
 - **Report first, then persist** — output the review in the conversation,

--- a/.claude/skills/review-issue/SKILL.md
+++ b/.claude/skills/review-issue/SKILL.md
@@ -338,6 +338,26 @@ user decides not to proceed (and so plan-task never runs), they can
 remove the worktree + branch via
 `.agent/scripts/worktree_remove.sh --issue <N>`.
 
+### Next step
+
+Lifecycle: **Issue Review** → **plan-task**
+
+Hand off to the next phase in a **fresh-context sub-agent** — independence
+between lifecycle steps is what makes the timeline trustworthy (a reviewer who
+shares the author's context inherits their blind spots). Use the dispatcher:
+
+    .agent/scripts/dispatch_subagent.sh --mode in-process --issue <N> --skill plan-task
+
+The sub-agent reads the last `## Issue Review` entry in
+`.agent/work-plans/issue-<N>/progress.md` for your output, and writes its own
+`## Plan Authored` entry when done.
+
+**No auto-chaining (Scope E):** this skill never dispatches the next phase itself —
+the host orchestrator (`/run-issue`,
+[#492](https://github.com/rolker/ros2_agent_workspace/issues/492)) drives,
+pausing at user checkpoints. This step only emits this prompt and its
+`progress.md` entry.
+
 ## Guidelines
 
 - **Comment, don't edit** — the issue body is the authoritative spec. Review

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -411,6 +411,32 @@ implementation step (or the plan author) should address them and amend
 the plan inline per `plan-task`'s "During implementation" rules before
 work continues. The `## Plan Review` entry stays as a historical record.
 
+### Next step
+
+Lifecycle: **Plan Review** → **implement** → **review-code**
+
+Two phases follow this review:
+
+1. **Implementation** (no skill yet) — the implementer reads the last `## Plan
+   Review` entry in `.agent/work-plans/issue-<N>/progress.md` and the linked
+   plan. If the verdict is `changes-requested`, address must-fix findings before
+   starting. Use `--mode container` for isolation-worthy implementation work:
+
+       .agent/scripts/dispatch_subagent.sh --mode container --issue <N> --prompt-file <task.md>
+
+2. **Pre-push code review** — once implementation is complete and before pushing,
+   hand off to `review-code` in a fresh-context sub-agent:
+
+       .agent/scripts/dispatch_subagent.sh --mode in-process --issue <N> --skill review-code
+
+   The sub-agent writes a `## Local Review` entry when done.
+
+**No auto-chaining (Scope E):** this skill never dispatches the next phase itself —
+the host orchestrator (`/run-issue`,
+[#492](https://github.com/rolker/ros2_agent_workspace/issues/492)) drives,
+pausing at user checkpoints. This step only emits this prompt and its
+`progress.md` entry.
+
 ## Guidelines
 
 - **Evaluate, don't rewrite** — flag gaps and concerns. Don't generate an

--- a/.claude/skills/triage-reviews/SKILL.md
+++ b/.claude/skills/triage-reviews/SKILL.md
@@ -356,6 +356,29 @@ name doesn't carry an issue number — the skill stops with an error
 rather than silently writing to the wrong path or skipping
 persistence.)
 
+### Next step
+
+Lifecycle: **Integrated Review** → address findings / done
+
+`triage-reviews` is the last automated skill in the per-issue lifecycle. After
+the `## Integrated Review` entry is committed, the next action is manual:
+
+- **If must-fix or cross-confirmed findings remain** — address each item from
+  the `### Findings` list, commit, push, and re-run `/triage-reviews` for
+  another round. Each round writes a new `## Integrated Review` entry.
+- **If no must-fix findings remain** — the PR is ready for merge. Use
+  `.agent/scripts/merge_pr.sh` (or `make merge-pr`) to merge, remove the
+  worktree, delete the branches, and sync.
+
+No `dispatch_subagent.sh` call is issued here — there is no next skill to hand
+off to. The host orchestrator (`/run-issue`,
+[#492](https://github.com/rolker/ros2_agent_workspace/issues/492)) reads the
+last `## Integrated Review` entry and surfaces the outcome and recommended
+actions to the operator.
+
+**No auto-chaining (Scope E):** no skill in the lifecycle dispatches the next
+phase autonomously — the host orchestrator drives, pausing at user checkpoints.
+
 ## Guidelines
 
 - **Triage, don't fix** — output the classified plan in the conversation. The user

--- a/.devcontainer/agent/agent-entrypoint.sh
+++ b/.devcontainer/agent/agent-entrypoint.sh
@@ -4,7 +4,7 @@
 #
 # Responsibilities:
 #   1. Fix ownership of anonymous volumes (build/install/log dirs)
-#   2. Configure persistent git identity
+#   2. (git identity is intentionally NOT configured here — see step 2)
 #   3. Source ROS 2 environment
 #   4. Check/install rosdep dependencies (skip when already satisfied)
 #   5. Initialize Claude Code config; chown the pre-commit cache volume
@@ -40,21 +40,20 @@ for ws_dir in "$WORKSPACE_ROOT"/layers/main/*_ws; do
     done
 done
 
-# ---------- 2. Configure persistent git identity ----------
-# In a container, we use persistent config (writes to .git/config) rather than
-# ephemeral env vars, since the container is an isolated environment.
+# ---------- 2. Git identity: intentionally NOT configured here ----------
+# Dispatched agents commit with per-invocation identity literals
+# (`git -c user.name=… -c user.email=… commit`, per AGENTS.md § Agent Commit
+# Identity), which the dispatch handoff prompt embeds. The agent runs as the
+# repo-owning `ros` user (UID matches the host owner), so there is no
+# dubious-ownership issue and no persistent `.git/config` identity is needed.
 #
-# This step runs as root (before the privilege drop), but the mounted repos
-# are owned by the host user (uid != 0). Git's dubious-ownership protection
-# would otherwise reject every repo with "fatal: not in a git directory",
-# leaving identity silently unset. The container is single-tenant and
-# ephemeral, so trust all repo paths for root's git invocations here.
-git config --global --add safe.directory '*'
-if [ -x "$WORKSPACE_ROOT/.agent/scripts/configure_git_identity.sh" ]; then
-    echo "Configuring git identity..."
-    cd "$WORKSPACE_ROOT"
-    "$WORKSPACE_ROOT/.agent/scripts/configure_git_identity.sh" --detect
-fi
+# Deliberately NOT setting a default identity: a `git commit` that omits the
+# `-c` literals then fails loudly (and leaves the work staged in the
+# bind-mounted worktree for the host to recover) rather than committing under
+# a silent/generic identity. That loud failure is the guard against
+# misattribution, not a bug. (This replaces an earlier root-run
+# `configure_git_identity.sh --detect` that tripped git's dubious-ownership
+# protection — running as root over host-uid-owned mounts.)
 
 # ---------- 3. Source ROS 2 environment ----------
 # Temporarily relax strict mode — ROS 2 setup scripts reference unbound variables
@@ -132,7 +131,7 @@ echo "========================================="
 echo "  Sandboxed Agent Container Ready"
 echo "========================================="
 echo "  Workspace: $WORKSPACE_ROOT"
-echo "  Identity:  $(git config user.name 2>/dev/null || echo 'not set') <$(git config user.email 2>/dev/null || echo 'not set')>"
+echo "  Identity:  per-commit via 'git -c' literals (no persistent config — by design)"
 echo "  ROS 2:     ${ROS_DISTRO:-not sourced}"
 echo "========================================="
 echo ""

--- a/.devcontainer/agent/agent-entrypoint.sh
+++ b/.devcontainer/agent/agent-entrypoint.sh
@@ -55,6 +55,22 @@ done
 # `configure_git_identity.sh --detect` that tripped git's dubious-ownership
 # protection — running as root over host-uid-owned mounts.)
 
+# ---------- 2b. Env-fallback git identity (matches the forwarded one) ----------
+# setup.bash (sourced below) runs `set_git_identity_env.sh --detect` when
+# GIT_AUTHOR_NAME is unset, which re-derives a generic `claude-code` identity
+# that can diverge from the launching agent's self-reported AGENT_NAME/EMAIL.
+# If the host forwarded both, pre-export the GIT_AUTHOR_*/GIT_COMMITTER_* vars
+# from them so that detect branch is skipped — the env-fallback identity then
+# matches the handoff prompt's `git -c` literals instead of a re-detected one.
+# (The `-c` literals remain the load-bearing path; this just keeps the fallback
+# consistent for any commit that omits them.)
+if [ -n "${AGENT_NAME:-}" ] && [ -n "${AGENT_EMAIL:-}" ]; then
+    export GIT_AUTHOR_NAME="$AGENT_NAME"
+    export GIT_AUTHOR_EMAIL="$AGENT_EMAIL"
+    export GIT_COMMITTER_NAME="$AGENT_NAME"
+    export GIT_COMMITTER_EMAIL="$AGENT_EMAIL"
+fi
+
 # ---------- 3. Source ROS 2 environment ----------
 # Temporarily relax strict mode — ROS 2 setup scripts reference unbound variables
 set +u

--- a/.devcontainer/agent/agent-entrypoint.sh
+++ b/.devcontainer/agent/agent-entrypoint.sh
@@ -43,6 +43,13 @@ done
 # ---------- 2. Configure persistent git identity ----------
 # In a container, we use persistent config (writes to .git/config) rather than
 # ephemeral env vars, since the container is an isolated environment.
+#
+# This step runs as root (before the privilege drop), but the mounted repos
+# are owned by the host user (uid != 0). Git's dubious-ownership protection
+# would otherwise reject every repo with "fatal: not in a git directory",
+# leaving identity silently unset. The container is single-tenant and
+# ephemeral, so trust all repo paths for root's git invocations here.
+git config --global --add safe.directory '*'
 if [ -x "$WORKSPACE_ROOT/.agent/scripts/configure_git_identity.sh" ]; then
     echo "Configuring git identity..."
     cd "$WORKSPACE_ROOT"

--- a/.devcontainer/agent/agent-entrypoint.sh
+++ b/.devcontainer/agent/agent-entrypoint.sh
@@ -139,4 +139,12 @@ echo ""
 # Drop privileges: run CMD as the non-root target user.
 # setpriv uses setuid(2) directly (no setuid bits) so it works with
 # --security-opt no-new-privileges:true.
-exec setpriv --reuid="$TARGET_UID" --regid="$TARGET_GID" --init-groups -- "$@"
+#
+# setpriv inherits the entrypoint's environment, where HOME is still /root
+# (the entrypoint runs as root). Without resetting it, the dropped `ros`
+# process would resolve HOME=/root and fail with EACCES trying to write
+# under /root/.claude (e.g. Claude Code's per-session env dir). Set HOME
+# (and USER/LOGNAME) to the target user so $HOME-relative paths land in
+# the user-owned /home/ros.
+exec setpriv --reuid="$TARGET_UID" --regid="$TARGET_GID" --init-groups -- \
+    env HOME="$TARGET_HOME" USER="$TARGET_USER" LOGNAME="$TARGET_USER" "$@"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,6 +53,13 @@ opt-in via `--copilot` and additionally requires `copilot` CLI
 authentication — opted-in but unauthenticated hosts route to the
 skipped-with-notice path automatically).
 
+**Lifecycle handoff is Claude-specific** — the workflow skills' `### Next
+step` blocks dispatch the next phase via
+`.agent/scripts/dispatch_subagent.sh` / Claude Code's `Agent` tool. On a
+Copilot runtime there's no auto-dispatch: read the handoff block and drive
+the next skill yourself; the issue's `progress.md` entry is the cross-phase
+handoff vessel.
+
 ## Environment Setup
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,6 +464,7 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/field_mode.sh` | Detect field mode (non-GitHub origin) vs. dev mode **(source or exec)** |
 | `.agent/scripts/agent start-task <N>` | High-level wrapper: create + enter worktree |
 | `.agent/scripts/dispatch_subagent.sh` | Dispatch a workflow skill into a fresh-context sub-agent (in-process or container); reads the progress.md exit contract |
+| `.agent/scripts/docker_run_agent.sh` | Launch the sandboxed agent container for a worktree; interactive or headless dispatch (`--prompt`/`--prompt-file`, `--model`), reads `CLAUDE_CODE_OAUTH_TOKEN` |
 | `.agent/scripts/dashboard.sh` | Unified workspace status (supports `--quick`) |
 | `.agent/scripts/build.sh` | Build all layers in order |
 | `.agent/scripts/check_branch_updates.sh` | Check if branch is behind default |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -463,6 +463,7 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/worktree_list.sh` | List active worktrees |
 | `.agent/scripts/field_mode.sh` | Detect field mode (non-GitHub origin) vs. dev mode **(source or exec)** |
 | `.agent/scripts/agent start-task <N>` | High-level wrapper: create + enter worktree |
+| `.agent/scripts/dispatch_subagent.sh` | Dispatch a workflow skill into a fresh-context sub-agent (in-process or container); reads the progress.md exit contract |
 | `.agent/scripts/dashboard.sh` | Unified workspace status (supports `--quick`) |
 | `.agent/scripts/build.sh` | Build all layers in order |
 | `.agent/scripts/check_branch_updates.sh` | Check if branch is behind default |


### PR DESCRIPTION
Closes #490.

Phase C keystone of the composable-timeline umbrella ([#470](https://github.com/rolker/ros2_agent_workspace/issues/470) → [#481](https://github.com/rolker/ros2_agent_workspace/issues/481)): the sub-agent dispatch mechanism + per-skill handoff boilerplate.

## What landed

**Scope A — dispatch mechanism**
- `.agent/scripts/dispatch_subagent.sh` (NEW): dual-mode (`in-process` | `container`) dispatch of a workflow skill or raw prompt into a fresh-context sub-agent. Builds the handoff prompt (per-invocation `git -c` identity literals, the progress.md exit-contract instruction, no-push/no-`--no-verify`/no-credential-leak rules); container mode launches the headless kickoff and reads the exit contract back (gate on exit code → require a *newer* entry, matched by type/base_type → report status-aware OK/PARTIAL/FAILED).
- `docker_run_agent.sh`: headless `--prompt`/`--prompt-file` kickoff (drops `-it`, skips the push-gateway post-exit), `--output-format`, `--model` pass-through, `CLAUDE_CODE_OAUTH_TOKEN` accept/forward from a 600-perm file.
- `agent-entrypoint.sh`: pure per-commit `-c` identity (root-run identity step removed) + env-fallback `GIT_AUTHOR_*` from forwarded vars; `HOME`/`USER`/`LOGNAME` set on the privilege-drop exec.
- Per-phase **model lever**: Opus for review/implement phases, Sonnet otherwise; aliases (not pinned ids) so they survive version bumps; an unavailable model hard-fails loudly. `--model` overrides.
- `test_dispatch_subagent.sh`: 29 no-docker tests.

**Scope B — per-skill handoff**
- `### Next step` handoff blocks in the 5 lifecycle skills + Scope-E no-auto-chaining; `skill_workflows.md` convention doc; framework-adapter notes (Copilot/Gemini/AGENT_ONBOARDING) + AGENTS.md Script Reference rows for `dispatch_subagent.sh` and `docker_run_agent.sh`.

## Dogfood validation (the whole point)

The container path was exercised end-to-end on this very PR: **host review → Opus container fix → zero-prompt Opus container review → Opus container fix-round-2.** Each leg validated identity attribution, the exit contract, pre-commit-via-mounted-venv, and the `--model` lever. Review convergence: 4 must-fix → 1 → 0. Three sandbox-blockers were found-and-fixed along the way (subscription `setup-token` auth, pure-`-c` identity, `HOME`-for-dropped-user).

## Deferred follow-ups (separate)
- Bake rosdep into the image to cut container-launch latency ([#520](https://github.com/rolker/ros2_agent_workspace/issues/520)).
- `framework_config.sh` stale model entry (pre-existing, cosmetic); #489 F.8 (remote-fallback audit) / F.9 (cosmetic warnings).
- Phase C remainder: #491 (address-findings skill), #492 (`/run-issue` orchestrator), #493 (delete push_gateway).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
