### PR TITLE
Make the rosdep bake actually work (#522)

### DIFF
--- a/.agent/scripts/stage_rosdep_manifests.sh
+++ b/.agent/scripts/stage_rosdep_manifests.sh
@@ -51,9 +51,31 @@ rm -rf "$STAGE_DIR"
 mkdir -p "$STAGE_DIR"
 
 manifest_count=0
+skipped_count=0
 for src_dir in "$ROOT_DIR"/layers/main/*_ws/src; do
     [ -d "$src_dir" ] || continue
     while IFS= read -r -d '' pkgxml; do
+        # Skip packages that colcon/ament/catkin ignore. rosdep does NOT honor
+        # COLCON_IGNORE, so a non-built package (e.g. a leftover ROS1 package
+        # with deps that aren't rosdep keys) would otherwise be staged and
+        # abort the whole bake — `rosdep install --from-paths` fails if ANY
+        # key across the set is unresolvable. Walk from the package dir up to
+        # src_dir looking for an ignore marker.
+        pkgdir="$(dirname "$pkgxml")"
+        ignored=0
+        d="$pkgdir"
+        while :; do
+            if [ -e "$d/COLCON_IGNORE" ] || [ -e "$d/AMENT_IGNORE" ] || [ -e "$d/CATKIN_IGNORE" ]; then
+                ignored=1
+                break
+            fi
+            [ "$d" = "$src_dir" ] && break
+            d="$(dirname "$d")"
+        done
+        if [ "$ignored" = 1 ]; then
+            skipped_count=$((skipped_count + 1))
+            continue
+        fi
         rel="${pkgxml#"$ROOT_DIR"/}"
         dest="$STAGE_DIR/$rel"
         mkdir -p "$(dirname "$dest")"
@@ -62,4 +84,5 @@ for src_dir in "$ROOT_DIR"/layers/main/*_ws/src; do
     done < <(find "$src_dir" -name package.xml -type f -print0)
 done
 
-echo "Staged $manifest_count layer package.xml manifest(s) into $STAGE_DIR"
+echo "Staged $manifest_count layer package.xml manifest(s) into $STAGE_DIR" \
+     "(skipped $skipped_count ignored package(s))"

--- a/.agent/work-plans/issue-522/plan.md
+++ b/.agent/work-plans/issue-522/plan.md
@@ -1,0 +1,49 @@
+# Plan: Rosdep bake follow-up (#520 gaps + resilience)
+
+## Issue
+https://github.com/rolker/ros2_agent_workspace/issues/522
+
+## Context
+The #520 bake had two gaps found during a real `make agent-build`:
+(1) the `make agent-build` staging step was edited in the main tree by mistake
+and never committed, so `main`'s target is the bare `docker build` that fails on
+`COPY .rosdep-manifests/`; (2) staging gathered `COLCON_IGNORE`'d packages, and
+since rosdep ignores that marker, one dead ROS1 package (`image_warper`,
+dep `project11`) aborted the all-or-nothing `rosdep install` — baking nothing.
+
+## Approach
+1. **Fix A — `make agent-build`**: stage via `stage_rosdep_manifests.sh` (trap-cleaned) before `docker build`. The commit that was lost in #520.
+2. **Fix B — skip ignored packages**: `stage_rosdep_manifests.sh` skips any package under a `COLCON_IGNORE`/`AMENT_IGNORE`/`CATKIN_IGNORE` marker.
+3. **Fix C — resilient bake**: install all layers in one rosdep pass (so `--ignore-src` ignores cross-layer local packages — a per-layer pass would wrongly treat e.g. `ui_ws`'s use of `sensors_ws`'s `marine_radar_control_msgs` as an unresolvable key), but pre-compute genuinely-unresolvable external keys via `rosdep check` and pass them as `--skip-keys` so one bad key only skips itself.
+
+## Files to Change
+| File | Change |
+|------|--------|
+| `Makefile` | `agent-build` stages manifests (trap-cleaned) before the bare `docker build` |
+| `.agent/scripts/stage_rosdep_manifests.sh` | Skip `COLCON_IGNORE`/`AMENT_IGNORE`/`CATKIN_IGNORE` packages |
+| `.devcontainer/agent/Dockerfile` | All-at-once bake with dynamic `--skip-keys` |
+| `.devcontainer/agent/README.md` | Document ignore-skip + skip-keys resilience |
+
+## Principles Self-Check
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | Found via real build; fixes every build path (Makefile + script) and the docs |
+| Test what breaks | Staging verified to skip ignored pkgs (108→107); real `make agent-build` confirms apt installs happen |
+| Only what's needed | Dynamic skip-keys is the minimal robust mechanism; avoids per-layer's cross-layer breakage |
+
+## ADR Compliance
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0009 — Python pkg mgmt | Yes | rosdep/apt only |
+| 0007 — Retain Make | Yes | `agent-build` recipe stays a Make target; no new runner |
+
+## Consequences
+| If we change... | Also update... | In plan? |
+|---|---|---|
+| Bake/build paths | README + every build entry point (Makefile + docker_run_agent.sh) | Yes |
+
+## Open Questions
+- [ ] None — bake strategy settled with user (all-at-once + dynamic skip-keys).
+
+## Estimated Scope
+Single PR. Depends conceptually on rqt_operator_tools#62 (fixes one real bad key), but skip-keys makes the bake resilient regardless.

--- a/.agent/work-plans/issue-522/progress.md
+++ b/.agent/work-plans/issue-522/progress.md
@@ -1,0 +1,24 @@
+---
+issue: 522
+---
+
+# Issue #522 — Rosdep bake follow-up (commit make agent-build staging, skip ignored packages, resilient bake)
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-14 13:05 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+### Changes
+- **Fix A** `Makefile`: `agent-build` stages via `stage_rosdep_manifests.sh` (trap-cleaned) before `docker build` — the staging step lost in #520 (edited in main tree by mistake, never committed).
+- **Fix B** `stage_rosdep_manifests.sh`: skip packages under `COLCON_IGNORE`/`AMENT_IGNORE`/`CATKIN_IGNORE`. Verified: 108→107 staged, `image_warper` (ROS1, COLCON_IGNORE'd, bad `project11` key) excluded.
+- **Fix C** `Dockerfile`: all-at-once bake with dynamic `--skip-keys` (compute unresolvable external keys via `rosdep check`, skip only those) — keeps cross-layer `--ignore-src` correct while making one bad key non-fatal. Chosen over literal per-layer, which breaks cross-layer local deps (ui_ws→sensors_ws).
+- `README.md`: documented ignore-skip + skip-keys resilience.
+
+### Verification
+- `bash -n` clean (helper); Makefile recipe parses (`make -n agent-build`).
+- Staging skips image_warper (107 staged, 0 image_warper).
+- Pending: real `make agent-build` to confirm apt installs now happen (the #520 build baked zero).
+
+### Related
+- Completes #520. rqt_operator_tools#62 fixes the one real bad key (libqt5opengl5-dev→libqt5-opengl-dev); skip-keys makes the bake resilient regardless.

--- a/.agent/work-plans/issue-522/progress.md
+++ b/.agent/work-plans/issue-522/progress.md
@@ -35,9 +35,12 @@ issue: 522
 **Must-fix**: 0 | **Suggestions**: 4
 
 ### Findings
-- [ ] (suggestion) Makefile trap armed after staging — partial `.rosdep-manifests/` leak window if staging fails; arm before, for parity with docker_run_agent.sh — `Makefile:277-279`
-- [ ] (suggestion) `tr '\n' ' '` leaves trailing space → one inert empty `--skip-keys` entry; trim it — `.devcontainer/agent/Dockerfile:103`
-- [ ] (suggestion) sed only catches "Cannot locate rosdep definition"; other unresolvable forms fall through to launch-time (graceful via `|| echo WARNING`) — `.devcontainer/agent/Dockerfile:101-102`
-- [ ] (suggestion) `$(CURDIR)` absolute staging path vs relative build-context/trap; works via make cwd, pass explicit STAGE_DIR for consistency — `Makefile:278`
+- [x] (suggestion) Makefile trap armed after staging — partial `.rosdep-manifests/` leak window if staging fails; arm before, for parity with docker_run_agent.sh — `Makefile:277-279`. FIXED: trap now armed before the stage call.
+- [x] (suggestion) `tr '\n' ' '` leaves trailing space → one inert empty `--skip-keys` entry; trim it — `.devcontainer/agent/Dockerfile:103`. FIXED: appended `sed 's/  *$//'`.
+- [ ] (suggestion, declined) sed only catches "Cannot locate rosdep definition"; other unresolvable forms fall through to launch-time (graceful via `|| echo WARNING`) — `.devcontainer/agent/Dockerfile:101-102`. LEFT AS-IS: standard unresolvable-key form; other forms degrade gracefully to launch-time install; broadening risks over-matching.
+- [x] (suggestion) `$(CURDIR)` absolute staging path vs relative build-context/trap; works via make cwd, pass explicit STAGE_DIR for consistency — `Makefile:278`. FIXED: Makefile passes an explicit `STAGE_DIR` to the helper and trap.
 
 Static analysis clean (shellcheck, bash -n, make -n). Core ignore-walk + dynamic skip-keys verified correct by two disjoint-lens adversarial passes (one read rosdep source) and a recorded real `make agent-build`. No must-fix.
+
+### Findings resolution
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) — 2026-06-14. Sandboxed (container) review = approved, 0 must-fix. 3 of 4 suggestions applied; 1 left graceful-by-design. Trim is cosmetic (the empty `--skip-keys` was inert), so no rebuild needed — the prior real `make agent-build` already validated the bake mechanism.

--- a/.agent/work-plans/issue-522/progress.md
+++ b/.agent/work-plans/issue-522/progress.md
@@ -22,3 +22,22 @@ issue: 522
 
 ### Related
 - Completes #520. rqt_operator_tools#62 fixes the one real bad key (libqt5opengl5-dev→libqt5-opengl-dev); skip-keys makes the bake resilient regardless.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-15 03:24 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: approved
+
+**Branch**: feature/issue-522 at `01b24a4`
+**Mode**: pre-push
+**Depth**: Standard (reason: Makefile override-trigger + 137/14 lines, 6 files; no Deep trigger)
+**Must-fix**: 0 | **Suggestions**: 4
+
+### Findings
+- [ ] (suggestion) Makefile trap armed after staging — partial `.rosdep-manifests/` leak window if staging fails; arm before, for parity with docker_run_agent.sh — `Makefile:277-279`
+- [ ] (suggestion) `tr '\n' ' '` leaves trailing space → one inert empty `--skip-keys` entry; trim it — `.devcontainer/agent/Dockerfile:103`
+- [ ] (suggestion) sed only catches "Cannot locate rosdep definition"; other unresolvable forms fall through to launch-time (graceful via `|| echo WARNING`) — `.devcontainer/agent/Dockerfile:101-102`
+- [ ] (suggestion) `$(CURDIR)` absolute staging path vs relative build-context/trap; works via make cwd, pass explicit STAGE_DIR for consistency — `Makefile:278`
+
+Static analysis clean (shellcheck, bash -n, make -n). Core ignore-walk + dynamic skip-keys verified correct by two disjoint-lens adversarial passes (one read rosdep source) and a recorded real `make agent-build`. No must-fix.

--- a/.agent/work-plans/issue-522/progress.md
+++ b/.agent/work-plans/issue-522/progress.md
@@ -18,7 +18,7 @@ issue: 522
 ### Verification
 - `bash -n` clean (helper); Makefile recipe parses (`make -n agent-build`).
 - Staging skips image_warper (107 staged, 0 image_warper).
-- Pending: real `make agent-build` to confirm apt installs now happen (the #520 build baked zero).
+- **Confirmed**: real `make agent-build` (exit 0) staged 107 (skipped image_warper), computed `--skip-keys libqt5opengl5-dev`, and **installed real deps** (ros-jazzy-grid-map-rviz-plugin, zenoh, rqt-*, …) — vs. the #520 build which baked zero. Staging dir trap-cleaned.
 
 ### Related
 - Completes #520. rqt_operator_tools#62 fixes the one real bad key (libqt5opengl5-dev→libqt5-opengl-dev); skip-keys makes the bake resilient regardless.

--- a/.devcontainer/agent/Dockerfile
+++ b/.devcontainer/agent/Dockerfile
@@ -100,7 +100,7 @@ RUN apt-get update || echo "WARNING: apt-get update failed — skipping dep bake
     rosdep update || echo "WARNING: rosdep update failed — skipping dep bake"; \
     skip_keys="$(rosdep check --from-paths /tmp/rosdep-manifests --ignore-src --rosdistro jazzy 2>&1 \
         | sed -n 's/.*Cannot locate rosdep definition for \[\([^]]*\)\].*/\1/p' \
-        | sort -u | tr '\n' ' ')"; \
+        | sort -u | tr '\n' ' ' | sed 's/  *$//')"; \
     if [ -n "$skip_keys" ]; then \
         echo "rosdep bake: skipping unresolvable keys: $skip_keys"; \
     fi; \

--- a/.devcontainer/agent/Dockerfile
+++ b/.devcontainer/agent/Dockerfile
@@ -74,8 +74,8 @@ RUN npm install -g @anthropic-ai/claude-code
 # Initialize rosdep (as root, then update as user)
 RUN rosdep init 2>/dev/null || true
 
-# Bake workspace layer dependencies into the image (#520).
-# docker_run_agent.sh stages the layer package.xml manifests into
+# Bake workspace layer dependencies into the image (#520, #522).
+# stage_rosdep_manifests.sh stages the layer package.xml manifests into
 # .rosdep-manifests/ (build context); rosdep install them here so the system
 # deps live in a read-only image layer. Each container FS is ephemeral (--rm),
 # so this is what lets the launch-time `rosdep check` in agent-entrypoint.sh
@@ -83,14 +83,29 @@ RUN rosdep init 2>/dev/null || true
 # Runs as root (apt needs root; the image has no sudo) and needs its own rosdep
 # cache, hence the root-side `rosdep update`. The dev-tools blocks above each
 # end with `rm -rf /var/lib/apt/lists/*`, so refresh the apt index first.
-# Best-effort: a dep that won't resolve at bake time is logged and falls through
-# to the launch-time install path rather than breaking the build (matches the
-# entrypoint posture). The image must be built via docker_run_agent.sh --build,
-# which creates .rosdep-manifests/; a bare `docker build` won't have it.
+#
+# All layers are installed in a SINGLE rosdep pass so --ignore-src ignores
+# local packages across layers (an overlay package may depend on a local
+# package in a lower layer — a per-layer pass would treat it as an
+# unresolvable system key). But `rosdep install` is all-or-nothing on key
+# resolution: a single unresolvable EXTERNAL key aborts the whole install.
+# So first compute the genuinely-unresolvable keys via `rosdep check` and
+# pass them as --skip-keys — one bad key then only skips itself instead of
+# nuking the entire bake (#522). Still best-effort overall: anything skipped
+# or failed falls through to the launch-time install path.
+# The image must be built via docker_run_agent.sh --build or `make agent-build`,
+# which create .rosdep-manifests/; a bare `docker build` won't have it.
 COPY .rosdep-manifests/ /tmp/rosdep-manifests/
 RUN apt-get update || echo "WARNING: apt-get update failed — skipping dep bake"; \
     rosdep update || echo "WARNING: rosdep update failed — skipping dep bake"; \
+    skip_keys="$(rosdep check --from-paths /tmp/rosdep-manifests --ignore-src --rosdistro jazzy 2>&1 \
+        | sed -n 's/.*Cannot locate rosdep definition for \[\([^]]*\)\].*/\1/p' \
+        | sort -u | tr '\n' ' ')"; \
+    if [ -n "$skip_keys" ]; then \
+        echo "rosdep bake: skipping unresolvable keys: $skip_keys"; \
+    fi; \
     rosdep install --from-paths /tmp/rosdep-manifests --ignore-src -y --rosdistro jazzy \
+        ${skip_keys:+--skip-keys "$skip_keys"} \
         || echo "WARNING: some layer deps did not resolve at bake time — they will install at launch"; \
     rm -rf /tmp/rosdep-manifests /var/lib/apt/lists/*
 

--- a/.devcontainer/agent/README.md
+++ b/.devcontainer/agent/README.md
@@ -49,12 +49,21 @@ The build passes your host UID/GID to match file ownership.
 ### Dependency Baking
 
 The build **bakes the workspace's layer system-dependencies into the image**
-(#520). Before `docker build`, `docker_run_agent.sh` gathers every layer
-`package.xml` (recursively — multi-package repos nest manifests in subdirs)
-into a staging dir (`.rosdep-manifests/`, gitignored) under the build context;
-the Dockerfile `COPY`s those manifests and runs `rosdep install` so the deps
-land in a read-only image layer. The source itself stays mounted at runtime,
-never copied into the image.
+(#520, #522). Before `docker build`, `stage_rosdep_manifests.sh` gathers every
+layer `package.xml` (recursively — multi-package repos nest manifests in
+subdirs; `COLCON_IGNORE`/`AMENT_IGNORE`/`CATKIN_IGNORE` packages are skipped so
+non-built packages can't poison the bake) into a staging dir
+(`.rosdep-manifests/`, gitignored) under the build context; the Dockerfile
+`COPY`s those manifests and runs `rosdep install` so the deps land in a
+read-only image layer. The source itself stays mounted at runtime, never copied
+into the image.
+
+All layers are installed in a single rosdep pass so `--ignore-src` correctly
+ignores local packages across layers (an overlay package may depend on a local
+package in a lower layer). Because `rosdep install` aborts entirely if *any*
+key is unresolvable, the bake first computes the genuinely-unresolvable external
+keys (`rosdep check`) and passes them as `--skip-keys` — so one bad key skips
+only itself rather than nuking the whole bake (#522).
 
 This is what makes the launch-time `rosdep check` in `agent-entrypoint.sh`
 actually skip: with deps already baked, each launch installs only the *delta*

--- a/Makefile
+++ b/Makefile
@@ -275,8 +275,9 @@ generate-skills:
 
 agent-build:
 	@set -e; \
-	./.agent/scripts/stage_rosdep_manifests.sh "$(CURDIR)"; \
-	trap 'rm -rf .devcontainer/agent/.rosdep-manifests' EXIT; \
+	STAGE_DIR="$(CURDIR)/.devcontainer/agent/.rosdep-manifests"; \
+	trap 'rm -rf "$$STAGE_DIR"' EXIT; \
+	./.agent/scripts/stage_rosdep_manifests.sh "$(CURDIR)" "$$STAGE_DIR"; \
 	docker build \
 		--build-arg USER_UID=$$(id -u) \
 		--build-arg USER_GID=$$(id -g) \

--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,10 @@ generate-skills:
 # --- Agent container targets ---
 
 agent-build:
-	@docker build \
+	@set -e; \
+	./.agent/scripts/stage_rosdep_manifests.sh "$(CURDIR)"; \
+	trap 'rm -rf .devcontainer/agent/.rosdep-manifests' EXIT; \
+	docker build \
 		--build-arg USER_UID=$$(id -u) \
 		--build-arg USER_GID=$$(id -g) \
 		-t ros2-agent-workspace-agent:latest \


### PR DESCRIPTION
Closes #522

# Plan: Rosdep bake follow-up (#520 gaps + resilience)

## Issue
https://github.com/rolker/ros2_agent_workspace/issues/522

## Context
The #520 bake had two gaps found during a real `make agent-build`:
(1) the `make agent-build` staging step was edited in the main tree by mistake
and never committed, so `main`'s target is the bare `docker build` that fails on
`COPY .rosdep-manifests/`; (2) staging gathered `COLCON_IGNORE`'d packages, and
since rosdep ignores that marker, one dead ROS1 package (`image_warper`,
dep `project11`) aborted the all-or-nothing `rosdep install` — baking nothing.

## Approach
1. **Fix A — `make agent-build`**: stage via `stage_rosdep_manifests.sh` (trap-cleaned) before `docker build`. The commit that was lost in #520.
2. **Fix B — skip ignored packages**: `stage_rosdep_manifests.sh` skips any package under a `COLCON_IGNORE`/`AMENT_IGNORE`/`CATKIN_IGNORE` marker.
3. **Fix C — resilient bake**: install all layers in one rosdep pass (so `--ignore-src` ignores cross-layer local packages — a per-layer pass would wrongly treat e.g. `ui_ws`'s use of `sensors_ws`'s `marine_radar_control_msgs` as an unresolvable key), but pre-compute genuinely-unresolvable external keys via `rosdep check` and pass them as `--skip-keys` so one bad key only skips itself.

## Files to Change
| File | Change |
|------|--------|
| `Makefile` | `agent-build` stages manifests (trap-cleaned) before the bare `docker build` |
| `.agent/scripts/stage_rosdep_manifests.sh` | Skip `COLCON_IGNORE`/`AMENT_IGNORE`/`CATKIN_IGNORE` packages |
| `.devcontainer/agent/Dockerfile` | All-at-once bake with dynamic `--skip-keys` |
| `.devcontainer/agent/README.md` | Document ignore-skip + skip-keys resilience |

## Principles Self-Check
| Principle | Consideration |
|---|---|
| A change includes its consequences | Found via real build; fixes every build path (Makefile + script) and the docs |
| Test what breaks | Staging verified to skip ignored pkgs (108→107); real `make agent-build` confirms apt installs happen |
| Only what's needed | Dynamic skip-keys is the minimal robust mechanism; avoids per-layer's cross-layer breakage |

## ADR Compliance
| ADR | Triggered | How addressed |
|---|---|---|
| 0009 — Python pkg mgmt | Yes | rosdep/apt only |
| 0007 — Retain Make | Yes | `agent-build` recipe stays a Make target; no new runner |

## Consequences
| If we change... | Also update... | In plan? |
|---|---|---|
| Bake/build paths | README + every build entry point (Makefile + docker_run_agent.sh) | Yes |

## Open Questions
- [ ] None — bake strategy settled with user (all-at-once + dynamic skip-keys).

## Estimated Scope
Single PR. Depends conceptually on rqt_operator_tools#62 (fixes one real bad key), but skip-keys makes the bake resilient regardless.
