### PR TITLE
#481 sub (C): 'address findings' skill (consume ## Integrated Review)

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -102,7 +102,7 @@ corresponding SKILL.md and follow its steps.
 Available workflow skills: `review-issue`, `plan-task`, `review-plan`,
 `review-code`, `brainstorm`, `research`, `audit-workspace`, `audit-project`,
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
-`triage-reviews`, `skill-importer`, `document-package`, `issue-triage`,
+`triage-reviews`, `address-findings`, `skill-importer`, `document-package`, `issue-triage`,
 `test-engineering`, `inspiration-tracker`, `import-field-changes`,
 `start-deployment`.
 

--- a/.agent/instructions/gemini-cli.instructions.md
+++ b/.agent/instructions/gemini-cli.instructions.md
@@ -74,7 +74,7 @@ corresponding SKILL.md and follow its steps.
 Available workflow skills: `review-issue`, `plan-task`, `review-plan`,
 `review-code`, `brainstorm`, `research`, `audit-workspace`, `audit-project`,
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
-`triage-reviews`, `skill-importer`, `document-package`, `issue-triage`,
+`triage-reviews`, `address-findings`, `skill-importer`, `document-package`, `issue-triage`,
 `test-engineering`, `inspiration-tracker`, `import-field-changes`,
 `start-deployment`.
 

--- a/.agent/knowledge/skill_workflows.md
+++ b/.agent/knowledge/skill_workflows.md
@@ -77,7 +77,8 @@ describes how to hand off to the subsequent phase. The full lifecycle map:
 | `plan-task` | `## Plan Authored` | `review-plan` | `## Plan Review` |
 | `review-plan` | `## Plan Review` | implement (no skill yet) → `review-code` | `## Local Review` |
 | `review-code` | `## Local Review` | `triage-reviews` | `## Integrated Review` |
-| `triage-reviews` | `## Integrated Review` | address findings / done | — |
+| `triage-reviews` | `## Integrated Review` | `address-findings` (if open findings) / done | `## Implementation` |
+| `address-findings` | `## Implementation` | `review-code` (re-review) | `## Local Review` |
 
 ### How to hand off
 

--- a/.agent/knowledge/skill_workflows.md
+++ b/.agent/knowledge/skill_workflows.md
@@ -8,6 +8,7 @@ post-PR review triage:
 ```
 brainstorm → review-issue → plan-task → review-plan → implement
           → review-code → push / open PR → triage-reviews
+          → address-findings → review-code (re-review) → …
 ```
 
 Most steps are optional — simple issues can skip straight to
@@ -42,6 +43,7 @@ accepts a PR number / URL for post-PR review of someone else's work.
 | `review-plan` | After plan-task, before implementation | Independent evaluation of a committed work plan (accepts PR / file path / `--issue <N>`) |
 | `review-code` | Between implement and push / open PR (also post-PR for someone else's diff) | Lead reviewer orchestrating specialist sub-reviews (static analysis, governance, plan drift, adversarial). Pre-push mode is the default; depth tiers (Light / Standard / Deep) scale specialist count to change risk |
 | `triage-reviews` | After PR review comments arrive | Classifies each comment (human + bot) against current code, persists triage to `progress.md` |
+| `address-findings` | After triage-reviews, before a re-review | Works the open `- [ ]` actions from the latest `## Integrated Review`, commits each fix atomically, writes a `## Implementation` entry |
 
 ### Utility skills (on-demand / periodic)
 

--- a/.agent/scripts/dispatch_subagent.sh
+++ b/.agent/scripts/dispatch_subagent.sh
@@ -57,6 +57,7 @@ skill_entry_type() {
         review-plan)     echo "Plan Review" ;;
         review-code)     echo "Local Review" ;;
         triage-reviews)  echo "Integrated Review" ;;
+        address-findings) echo "Implementation" ;;
         *)               echo "" ;;
     esac
 }

--- a/.agent/work-plans/issue-491/plan.md
+++ b/.agent/work-plans/issue-491/plan.md
@@ -32,6 +32,8 @@ The integration points already exist:
 | File | Change |
 |------|--------|
 | `.claude/skills/address-findings/SKILL.md` | **New** — the thin skill |
+| `.agent/scripts/dispatch_subagent.sh` | **(must-fix, review-plan)** add `address-findings) echo "Implementation"` to `skill_entry_type()` — `skill_model()` already lists it, so the file is half-wired; without this the orchestrator's exit-contract check silently no-ops |
+| `.agent/knowledge/skill_workflows.md` | Add `address-findings` to the Skill Index + lifecycle diagram (triage-reviews → address-findings → re-review) |
 | `.github/copilot-instructions.md` | Add skill to list |
 | `.agent/instructions/gemini-cli.instructions.md` | Add skill to list |
 | `.agent/AGENT_ONBOARDING.md` | Add skill to list |
@@ -55,6 +57,8 @@ The integration points already exist:
 | If we change... | Also update... | In plan? |
 |---|---|---|
 | Add a workflow skill | Skill list in non-Claude adapters | Yes |
+| Add a workflow skill | `dispatch_subagent.sh` `skill_entry_type()` + `skill_model()` | Yes (entry_type was the gap — review-plan must-fix) |
+| Add a workflow skill | `.agent/knowledge/skill_workflows.md` Skill Index + diagram | Yes (review-plan suggestion) |
 | Add a skill that writes progress.md | Use an ADR-0013 type | Yes (`## Implementation`) |
 
 ## Open Questions

--- a/.agent/work-plans/issue-491/plan.md
+++ b/.agent/work-plans/issue-491/plan.md
@@ -58,8 +58,9 @@ The integration points already exist:
 | Add a skill that writes progress.md | Use an ADR-0013 type | Yes (`## Implementation`) |
 
 ## Open Questions
-- [ ] **Entry type (ADR-0013 gate)** — recommend reusing `## Implementation` (no new ADR). Confirm, or mint `## Findings Addressed` via a superseding ADR.
-- [ ] **De-dup scope** — remove the ad-hoc external-review handling from `triage-reviews`/`review-code` in *this* PR, or a focused follow-up? Recommend follow-up.
+_Both resolved with the user (2026-06-15):_
+- [x] **Entry type** → **reuse `## Implementation`** (no new ADR). Confirmed.
+- [x] **De-dup scope** → **follow-up PR** (this PR only adds the skill). Confirmed; file the de-dup follow-up after merge.
 
 ## Estimated Scope
 Single PR (skill + adapter lists). De-dup follow-up tracked separately.

--- a/.agent/work-plans/issue-491/plan.md
+++ b/.agent/work-plans/issue-491/plan.md
@@ -1,0 +1,65 @@
+# Plan: 'address-findings' skill (consume ## Integrated Review)
+
+## Issue
+https://github.com/rolker/ros2_agent_workspace/issues/491
+
+## Context
+Phase C of #481 needs a thin workflow skill that closes the review loop: after
+`triage-reviews` writes a `## Integrated Review` entry (a fix plan of `- [ ]`
+actions), `address-findings` works through those actions, commits the fixes
+atomically, checks the boxes, and writes a closing entry. It's the phase the
+`/run-issue` orchestrator (#492) dispatches between triage and re-review — the
+reason we build C before D.
+
+The integration points already exist:
+- `progress_read.py --type "Integrated Review"` returns each entry's `findings[]`
+  array (`{section, checked, source_hint, text}`) — the `- [ ]` actions, parsed.
+  No markdown re-parsing needed.
+- `## Integrated Review` entry type exists (#485 merged — the issue's stated
+  blocker is cleared).
+
+## Approach
+1. **New skill** `.claude/skills/address-findings/SKILL.md` (thin), steps:
+   1. Resolve the issue's `progress.md`; run `progress_read.py --type "Integrated Review"`; take the **last** entry's unchecked `findings[]` (`checked == false`). If none, report "nothing to address" and exit.
+   2. For each finding: make the code change, run pre-commit, commit atomically (`git -c` identity per AGENTS.md), then check its box (`- [ ]`→`- [x]`) in the `## Integrated Review` entry — same-commit so the timeline tracks resolution.
+   3. Skip/annotate findings that are dismissals (plain bullets) or already `- [x]`.
+   4. Write one closing `## Implementation` entry (see ADR gate) summarizing what was addressed + what was deferred, with a `### Actions` checklist for anything left.
+   5. Emit a "Next step" handoff to **review-code** (re-review the fixes) — no auto-chaining (Scope E).
+2. **Adapter skill lists** — add `address-findings` to `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md`.
+3. **De-dup note (scope decision)** — the issue says this "replaces ad-hoc external-review handling in `triage-reviews`+`review-code`." Propose: this PR only *adds* the skill; the removal of the old handling is a **follow-up** (keeps the PR focused and the removal independently reviewable). Open question 2.
+
+## Files to Change
+| File | Change |
+|------|--------|
+| `.claude/skills/address-findings/SKILL.md` | **New** — the thin skill |
+| `.github/copilot-instructions.md` | Add skill to list |
+| `.agent/instructions/gemini-cli.instructions.md` | Add skill to list |
+| `.agent/AGENT_ONBOARDING.md` | Add skill to list |
+
+## Principles Self-Check
+| Principle | Consideration |
+|---|---|
+| Only what's needed | Reuse `progress_read.py` + an existing entry type; no new parser, no new ADR (per recommendation) |
+| Capture decisions | Entry-type choice recorded; ADR-0013 honored |
+| A change includes its consequences | Skill-list adapter updates in the same PR |
+| Improve incrementally | De-dup of old handling deferred to a focused follow-up |
+
+## ADR Compliance
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0013 — progress.md vocabulary | **Yes** | Skill **writes `## Implementation`** (recommended) — an existing canonical type, no superseding ADR. Minting `## Findings Addressed` is rejected unless #492 needs to distinguish it (it doesn't: orchestrator reads the *last* entry; "Implementation → re-review" is the correct transition either way). |
+| 0004/0005 — enforcement layering | Yes (satisfied) | Convention-only skill, consistent with peers |
+| 0006 — shared AGENTS.md | Yes | Skill listed in all framework adapters |
+
+## Consequences
+| If we change... | Also update... | In plan? |
+|---|---|---|
+| Add a workflow skill | Skill list in non-Claude adapters | Yes |
+| Add a skill that writes progress.md | Use an ADR-0013 type | Yes (`## Implementation`) |
+
+## Open Questions
+- [ ] **Entry type (ADR-0013 gate)** — recommend reusing `## Implementation` (no new ADR). Confirm, or mint `## Findings Addressed` via a superseding ADR.
+- [ ] **De-dup scope** — remove the ad-hoc external-review handling from `triage-reviews`/`review-code` in *this* PR, or a focused follow-up? Recommend follow-up.
+
+## Estimated Scope
+Single PR (skill + adapter lists). De-dup follow-up tracked separately.

--- a/.agent/work-plans/issue-491/progress.md
+++ b/.agent/work-plans/issue-491/progress.md
@@ -74,6 +74,9 @@ issue: 491
 **Must-fix**: 2 | **Suggestions**: 1
 
 ### Findings
-- [ ] (must-fix) Lifecycle Handoff Convention table not updated for `address-findings`; same-file diagram + Skill Index were — internally inconsistent — `.agent/knowledge/skill_workflows.md:80`
-- [ ] (must-fix) `triage-reviews` "Next step" still claims it is the terminal automated skill with no handoff; now false — `.claude/skills/triage-reviews/SKILL.md:363-381`
-- [ ] (suggestion) Step 2 doesn't handle the "file exists, zero Integrated Review entries" case — `.claude/skills/address-findings/SKILL.md:45-62`
+- [x] (must-fix) Lifecycle Handoff Convention table not updated for `address-findings`; same-file diagram + Skill Index were — internally inconsistent — `.agent/knowledge/skill_workflows.md:80`. FIXED in `b53086e`: table now lists triage→address-findings→re-review rows.
+- [x] (must-fix) `triage-reviews` "Next step" still claims it is the terminal automated skill with no handoff; now false — `.claude/skills/triage-reviews/SKILL.md:363-381`. FIXED in `b53086e`: points to the address-findings handoff (Scope-E note retained).
+- [x] (suggestion) Step 2 doesn't handle the "file exists, zero Integrated Review entries" case — `.claude/skills/address-findings/SKILL.md:45-62`. FIXED in `b53086e`: explicit no-entry guard (don't fall back to other types).
+
+### Resolution
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) — 2026-06-15. Sandboxed review-code = changes-requested; all 3 findings addressed in `b53086e`. Lifecycle coherence verified (address-findings named consistently across diagram, both tables, and triage-reviews handoff).

--- a/.agent/work-plans/issue-491/progress.md
+++ b/.agent/work-plans/issue-491/progress.md
@@ -108,3 +108,24 @@ issue: 491
 ### Notes
 - Cross-confirmed clean: dispatcher exit-contract is **not** confused by the shared `## Implementation` type — both adversarial passes independently verified the count-delta (`entry_count` PRE vs POST) mechanism in `dispatch_subagent.sh`.
 - Scope-E (no auto-chaining) and commit-identity/no-`--no-verify` verified consistent across `triage-reviews`, `address-findings`, and `skill_workflows.md`. Adapters (3/3), lifecycle diagram + both tables, and the dispatcher mapping all updated correctly.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-15 12:53 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-491 at `3707c49`
+**Mode**: pre-push
+**Depth**: Standard (reason: governance/workflow files — new workflow skill, dispatcher, framework adapters, lifecycle docs, ADR addendum)
+**Must-fix**: 1 | **Suggestions**: 3
+
+### Findings
+- [ ] (must-fix) Guidelines bullet "Deferred/non-actionable items stay **unchecked**" contradicts the skill's own Steps (3.2 + Step 5), which write deferred items **checked** — breaks the documented re-run idempotency — `.claude/skills/address-findings/SKILL.md:175-176`. Cross-confirmed by both adversarial lenses.
+- [ ] (suggestion) The "re-attempted every run" deferral rationale overstates the mechanism (skill reads only the last Integrated Review; lifecycle never re-runs against the same entry) — `.claude/skills/address-findings/SKILL.md:91-95,142-145`. Reconcile when fixing the must-fix.
+- [ ] (suggestion) Cross-round dropout: a still-open `(deferred:)` finding is indistinguishable from a resolved checked one to `progress_read.py`; `triage-reviews` isn't told to re-raise it → may be silently dropped. Candidate for the de-dup follow-up — `.claude/skills/triage-reviews/SKILL.md`.
+- [ ] (suggestion) `review-code` Next-step doesn't acknowledge the new re-review entry path; existing wording mostly covers it (low priority, file not in diff) — `.claude/skills/review-code/SKILL.md:916-928`.
+
+### Notes
+- Round-3 cross-confirmed clean (unchanged, re-verified): all consequence categories (3/3 adapters, dispatcher `skill_entry_type`+`skill_model`, `skill_workflows.md` index/diagram/handoff table, ADR-0013 addendum), Scope-E, commit-identity/no-push, and the ADR-0012-addendum governance choice. shellcheck clean on `dispatch_subagent.sh`.
+- The single must-fix is a **new** finding (internal Guidelines↔Steps contradiction) not surfaced in rounds 1–2; the deferred-checkbox prose was added in round 2 (`25b0ecd`) and the Guidelines bullet was not reconciled with it.

--- a/.agent/work-plans/issue-491/progress.md
+++ b/.agent/work-plans/issue-491/progress.md
@@ -32,3 +32,17 @@ issue: 491
 ### Open questions
 - [x] Entry type → **reuse `## Implementation`** (no new ADR). Confirmed with user 2026-06-15.
 - [x] De-dup scope → **follow-up PR**; this PR only adds the skill. Confirmed with user 2026-06-15.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-15 10:20 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-491/plan.md` at `108a089`
+**PR**: https://github.com/rolker/ros2_agent_workspace/pull/524
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (must-fix) Missing consequence: `dispatch_subagent.sh` `skill_entry_type()` (lines 53-61) has no `address-findings` case → returns `""`, so the exit-contract "newer entry of the expected type" check is silently skipped when the orchestrator (#492) dispatches this skill. Since the plan commits to writing `## Implementation`, add `address-findings) echo "Implementation"` to that case. Note `skill_model()` (line 72) already lists `address-findings` → opus, so the file is half-wired and the asymmetry is a latent bug. — `plan.md:54` (Consequences table)
+- [ ] (suggestion) Missing consequence: `.agent/knowledge/skill_workflows.md` is the canonical lifecycle reference (diagram lines 8-11 + Skill Index table lines 35-44). `address-findings` is a new lifecycle step (triage-reviews → address-findings → re-review); the plan's consequences only list the three framework adapters, not this doc. Add a Skill Index row / lifecycle-diagram mention. — `plan.md:54`
+- [ ] (suggestion) Stale SHA: the `## Plan Authored` entry references plan SHA `52f523a`, but the open-questions resolution landed in `108a089`. Minor; consider refreshing per plan-task's "keep plan/progress in sync" rule. — `progress.md:28`

--- a/.agent/work-plans/issue-491/progress.md
+++ b/.agent/work-plans/issue-491/progress.md
@@ -80,3 +80,28 @@ issue: 491
 
 ### Resolution
 **By**: Claude Code Agent (Claude Opus 4.8 (1M context)) — 2026-06-15. Sandboxed review-code = changes-requested; all 3 findings addressed in `b53086e`. Lifecycle coherence verified (address-findings named consistently across diagram, both tables, and triage-reviews handoff).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-15 11:00 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-491 at `c21ff05`
+**Mode**: pre-push
+**Depth**: Standard (reason: governance/workflow files — dispatcher, framework adapters, lifecycle docs, new workflow skill)
+**Must-fix**: 3 | **Suggestions**: 5
+
+### Findings
+- [ ] (must-fix) `## Implementation` template omits ADR-0013's required correlation field (`**PR**:`/`**Branch**: <name> at <sha>`); `progress_read.py` lists Implementation in `_PR_BRANCH_TYPES` → entries parse to `correlation: null` — `.claude/skills/address-findings/SKILL.md:107-120`
+- [ ] (must-fix) ADR-0013 Writer column for `## Implementation` still says "future implement skill" only; `address-findings` is now a second writer and must be registered (light addendum, no new ADR) — `docs/decisions/0013-progress-md-entry-type-vocabulary.md:56`
+- [ ] (must-fix) Step-5 heading "Commit and push" but block only commits; contradicts the sub-agent no-push dispatch contract — `.claude/skills/address-findings/SKILL.md:122`
+- [ ] (suggestion) Deferred-finding dead-end: not-actionable items stay unchecked and are re-attempted every run; nothing consumes the deferred list — `.claude/skills/address-findings/SKILL.md:78-81,117-119`
+- [ ] (suggestion) `## Implementation` doubles as orchestrator routing key; ambiguous once a future `implement` skill also writes it — flag for #492 — `.claude/skills/address-findings/SKILL.md:32-36`
+- [ ] (suggestion) Internal tension: "stage only the files for this finding" vs box-check riding in same commit — `.claude/skills/address-findings/SKILL.md:83-94`
+- [ ] (suggestion) `progress_read.py --type "Integrated Review"` also matches legacy `## External Review`; take last entry whose base type is Integrated Review — `.claude/skills/address-findings/SKILL.md:50-61`
+- [ ] (suggestion) Step 3 bare `git commit` vs step 5 `git -C <worktree>` with undefined `<worktree>` placeholder — `.claude/skills/address-findings/SKILL.md:87,126`
+
+### Notes
+- Cross-confirmed clean: dispatcher exit-contract is **not** confused by the shared `## Implementation` type — both adversarial passes independently verified the count-delta (`entry_count` PRE vs POST) mechanism in `dispatch_subagent.sh`.
+- Scope-E (no auto-chaining) and commit-identity/no-`--no-verify` verified consistent across `triage-reviews`, `address-findings`, and `skill_workflows.md`. Adapters (3/3), lifecycle diagram + both tables, and the dispatcher mapping all updated correctly.

--- a/.agent/work-plans/issue-491/progress.md
+++ b/.agent/work-plans/issue-491/progress.md
@@ -30,5 +30,5 @@ issue: 491
 **Phases**: single
 
 ### Open questions
-- [ ] Entry type (ADR-0013): recommend reusing `## Implementation`; confirm vs mint `## Findings Addressed` via superseding ADR.
-- [ ] De-dup scope: remove old ad-hoc external-review handling in this PR or a follow-up (recommend follow-up).
+- [x] Entry type → **reuse `## Implementation`** (no new ADR). Confirmed with user 2026-06-15.
+- [x] De-dup scope → **follow-up PR**; this PR only adds the skill. Confirmed with user 2026-06-15.

--- a/.agent/work-plans/issue-491/progress.md
+++ b/.agent/work-plans/issue-491/progress.md
@@ -61,3 +61,19 @@ issue: 491
 - [x] `skill_workflows.md` diagram + Skill Index updated.
 - [x] `address-findings` added to all 3 framework adapter skill lists.
 - [ ] De-dup of old triage-reviews/review-code external-review handling — **deferred to a follow-up PR** (per settled open question).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-15 10:33 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-491 at `6d1f30e`
+**Mode**: pre-push
+**Depth**: Standard (reason: governance/workflow files — dispatcher, adapters, lifecycle docs)
+**Must-fix**: 2 | **Suggestions**: 1
+
+### Findings
+- [ ] (must-fix) Lifecycle Handoff Convention table not updated for `address-findings`; same-file diagram + Skill Index were — internally inconsistent — `.agent/knowledge/skill_workflows.md:80`
+- [ ] (must-fix) `triage-reviews` "Next step" still claims it is the terminal automated skill with no handoff; now false — `.claude/skills/triage-reviews/SKILL.md:363-381`
+- [ ] (suggestion) Step 2 doesn't handle the "file exists, zero Integrated Review entries" case — `.claude/skills/address-findings/SKILL.md:45-62`

--- a/.agent/work-plans/issue-491/progress.md
+++ b/.agent/work-plans/issue-491/progress.md
@@ -1,0 +1,21 @@
+---
+issue: 491
+---
+
+# Issue #491 — 'address findings' skill (consume ## Integrated Review)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-15 09:30 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Issue**: #491
+**Comment**: https://github.com/rolker/ros2_agent_workspace/issues/491#issuecomment-4704591505
+**Scope verdict**: well-scoped
+
+### Actions
+- [ ] (must resolve in plan-task) Entry-type gate (ADR-0013): default to reusing `## Implementation`; mint `## Findings Addressed` only via a superseding ADR if #492 needs to distinguish it. This is the plan's primary open question.
+- [ ] New workflow skill ⇒ update skill list in non-Claude adapters (`.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md`).
+- [ ] Persist a typed `progress.md` entry per ADR-0013 (follows from the entry-type decision).
+- [ ] Scope the triage-reviews/review-code de-duplication (in-PR vs follow-up) so findings aren't double-handled.
+- [ ] Update the #491 issue body to note #485 is merged (blocker cleared).

--- a/.agent/work-plans/issue-491/progress.md
+++ b/.agent/work-plans/issue-491/progress.md
@@ -121,10 +121,13 @@ issue: 491
 **Must-fix**: 1 | **Suggestions**: 3
 
 ### Findings
-- [ ] (must-fix) Guidelines bullet "Deferred/non-actionable items stay **unchecked**" contradicts the skill's own Steps (3.2 + Step 5), which write deferred items **checked** — breaks the documented re-run idempotency — `.claude/skills/address-findings/SKILL.md:175-176`. Cross-confirmed by both adversarial lenses.
-- [ ] (suggestion) The "re-attempted every run" deferral rationale overstates the mechanism (skill reads only the last Integrated Review; lifecycle never re-runs against the same entry) — `.claude/skills/address-findings/SKILL.md:91-95,142-145`. Reconcile when fixing the must-fix.
-- [ ] (suggestion) Cross-round dropout: a still-open `(deferred:)` finding is indistinguishable from a resolved checked one to `progress_read.py`; `triage-reviews` isn't told to re-raise it → may be silently dropped. Candidate for the de-dup follow-up — `.claude/skills/triage-reviews/SKILL.md`.
-- [ ] (suggestion) `review-code` Next-step doesn't acknowledge the new re-review entry path; existing wording mostly covers it (low priority, file not in diff) — `.claude/skills/review-code/SKILL.md:916-928`.
+- [x] (must-fix) Guidelines bullet "Deferred/non-actionable items stay **unchecked**" contradicted Steps 3.2/5 (which write deferred items checked) — FIXED `aa8c25d`: Guidelines bullet reconciled to the checked+annotated convention.
+- [x] (suggestion) "re-attempted every run" rationale overstated — FIXED `aa8c25d`: reworded as an idempotency guard for a re-run against the *same* entry, not "every run".
+- [ ] (suggestion, deferred → de-dup follow-up) Cross-round dropout: a still-open `(deferred:)` finding looks the same as a resolved checked one to `progress_read.py`; `triage-reviews` isn't told to re-raise it. Reviewer tagged this for the de-dup follow-up (touches `triage-reviews`, out of this PR's scope). Carry into the de-dup follow-up issue.
+- [ ] (suggestion, deferred → low priority) `review-code` "Next step" doesn't explicitly acknowledge the re-review entry path; existing wording mostly covers it and the file isn't in this diff. Optional polish.
+
+### Resolution (round 3)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) — 2026-06-15. Sandboxed re-review (round 3) = changes-requested (1 must-fix + 3 suggestions). The must-fix was a self-introduced round-2 contradiction (Guidelines vs Steps), now fixed in `aa8c25d` along with the related rationale suggestion. The 2 remaining suggestions are deferred by design — one to the de-dup follow-up (reviewer-tagged), one low-priority polish on a file not in this diff. Findings converged 3→8→1; round 3 cross-confirmed all mechanics clean (consequences 3/3 adapters + dispatcher + skill_workflows + ADR addendum, Scope-E, commit-identity/no-push, shellcheck).
 
 ### Notes
 - Round-3 cross-confirmed clean (unchanged, re-verified): all consequence categories (3/3 adapters, dispatcher `skill_entry_type`+`skill_model`, `skill_workflows.md` index/diagram/handoff table, ADR-0013 addendum), Scope-E, commit-identity/no-push, and the ADR-0012-addendum governance choice. shellcheck clean on `dispatch_subagent.sh`.

--- a/.agent/work-plans/issue-491/progress.md
+++ b/.agent/work-plans/issue-491/progress.md
@@ -25,7 +25,7 @@ issue: 491
 **When**: 2026-06-15 09:45 -04:00
 **By**: Claude Code Agent (Claude Opus 4.8 (1M context))
 
-**Plan**: `.agent/work-plans/issue-491/plan.md` at `52f523a`
+**Plan**: `.agent/work-plans/issue-491/plan.md` at `108a089` (refreshed from `52f523a` after open-questions resolution)
 **PR**: https://github.com/rolker/ros2_agent_workspace/pull/524 (`[PLAN]` prefix)
 **Phases**: single
 
@@ -43,6 +43,21 @@ issue: 491
 **Verdict**: approve-with-suggestions
 
 ### Findings
-- [ ] (must-fix) Missing consequence: `dispatch_subagent.sh` `skill_entry_type()` (lines 53-61) has no `address-findings` case → returns `""`, so the exit-contract "newer entry of the expected type" check is silently skipped when the orchestrator (#492) dispatches this skill. Since the plan commits to writing `## Implementation`, add `address-findings) echo "Implementation"` to that case. Note `skill_model()` (line 72) already lists `address-findings` → opus, so the file is half-wired and the asymmetry is a latent bug. — `plan.md:54` (Consequences table)
-- [ ] (suggestion) Missing consequence: `.agent/knowledge/skill_workflows.md` is the canonical lifecycle reference (diagram lines 8-11 + Skill Index table lines 35-44). `address-findings` is a new lifecycle step (triage-reviews → address-findings → re-review); the plan's consequences only list the three framework adapters, not this doc. Add a Skill Index row / lifecycle-diagram mention. — `plan.md:54`
-- [ ] (suggestion) Stale SHA: the `## Plan Authored` entry references plan SHA `52f523a`, but the open-questions resolution landed in `108a089`. Minor; consider refreshing per plan-task's "keep plan/progress in sync" rule. — `progress.md:28`
+- [x] (must-fix) Missing consequence: `dispatch_subagent.sh` `skill_entry_type()` had no `address-findings` case → returned `""`, silently skipping the exit-contract check. FIXED in `8a91aef`: added `address-findings) echo "Implementation"` (verified resolves). Plan consequences table updated.
+- [x] (suggestion) Missing consequence: `.agent/knowledge/skill_workflows.md`. FIXED in `8a91aef`: added `address-findings` to the lifecycle diagram + Skill Index row; plan consequences updated.
+- [x] (suggestion) Stale SHA in `## Plan Authored`. FIXED: refreshed `52f523a` → `108a089`.
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-15 10:45 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Addressed**: `## Plan Review` (approve-with-suggestions) — all 3 findings.
+**Commits**: `8a91aef` (skill + dispatcher wiring + lifecycle doc + 3 adapters + plan consequences)
+
+### Actions
+- [x] New `.claude/skills/address-findings/SKILL.md` (thin; reads last `## Integrated Review` via `progress_read.py`, commits each fix atomically, writes `## Implementation`).
+- [x] `dispatch_subagent.sh` `skill_entry_type()` → `address-findings) echo "Implementation"` (must-fix).
+- [x] `skill_workflows.md` diagram + Skill Index updated.
+- [x] `address-findings` added to all 3 framework adapter skill lists.
+- [ ] De-dup of old triage-reviews/review-code external-review handling — **deferred to a follow-up PR** (per settled open question).

--- a/.agent/work-plans/issue-491/progress.md
+++ b/.agent/work-plans/issue-491/progress.md
@@ -19,3 +19,16 @@ issue: 491
 - [ ] Persist a typed `progress.md` entry per ADR-0013 (follows from the entry-type decision).
 - [ ] Scope the triage-reviews/review-code de-duplication (in-PR vs follow-up) so findings aren't double-handled.
 - [ ] Update the #491 issue body to note #485 is merged (blocker cleared).
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-15 09:45 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-491/plan.md` at `52f523a`
+**PR**: https://github.com/rolker/ros2_agent_workspace/pull/524 (`[PLAN]` prefix)
+**Phases**: single
+
+### Open questions
+- [ ] Entry type (ADR-0013): recommend reusing `## Implementation`; confirm vs mint `## Findings Addressed` via superseding ADR.
+- [ ] De-dup scope: remove old ad-hoc external-review handling in this PR or a follow-up (recommend follow-up).

--- a/.agent/work-plans/issue-491/progress.md
+++ b/.agent/work-plans/issue-491/progress.md
@@ -93,14 +93,17 @@ issue: 491
 **Must-fix**: 3 | **Suggestions**: 5
 
 ### Findings
-- [ ] (must-fix) `## Implementation` template omits ADR-0013's required correlation field (`**PR**:`/`**Branch**: <name> at <sha>`); `progress_read.py` lists Implementation in `_PR_BRANCH_TYPES` → entries parse to `correlation: null` — `.claude/skills/address-findings/SKILL.md:107-120`
-- [ ] (must-fix) ADR-0013 Writer column for `## Implementation` still says "future implement skill" only; `address-findings` is now a second writer and must be registered (light addendum, no new ADR) — `docs/decisions/0013-progress-md-entry-type-vocabulary.md:56`
-- [ ] (must-fix) Step-5 heading "Commit and push" but block only commits; contradicts the sub-agent no-push dispatch contract — `.claude/skills/address-findings/SKILL.md:122`
-- [ ] (suggestion) Deferred-finding dead-end: not-actionable items stay unchecked and are re-attempted every run; nothing consumes the deferred list — `.claude/skills/address-findings/SKILL.md:78-81,117-119`
-- [ ] (suggestion) `## Implementation` doubles as orchestrator routing key; ambiguous once a future `implement` skill also writes it — flag for #492 — `.claude/skills/address-findings/SKILL.md:32-36`
-- [ ] (suggestion) Internal tension: "stage only the files for this finding" vs box-check riding in same commit — `.claude/skills/address-findings/SKILL.md:83-94`
-- [ ] (suggestion) `progress_read.py --type "Integrated Review"` also matches legacy `## External Review`; take last entry whose base type is Integrated Review — `.claude/skills/address-findings/SKILL.md:50-61`
-- [ ] (suggestion) Step 3 bare `git commit` vs step 5 `git -C <worktree>` with undefined `<worktree>` placeholder — `.claude/skills/address-findings/SKILL.md:87,126`
+- [x] (must-fix) `## Implementation` template omits ADR-0013's required correlation field — FIXED `25b0ecd`: template now carries `**Branch**:`/`**PR**: <name> at <sha>`.
+- [x] (must-fix) ADR-0013 Writer registration for `## Implementation` — FIXED `adab51c`: ADR-0012 cross-reference addendum registers `address-findings` as a second writer (Decision table unchanged; user-approved approach).
+- [x] (must-fix) Step-5 "Commit and push" contradicted the no-push dispatch contract — FIXED `25b0ecd`: commit only, host pushes.
+- [x] (suggestion) Deferred-finding dead-end — FIXED `25b0ecd`: deferred items written checked+`(deferred:)` so they're not re-attempted (`address-findings` acts only on `checked == false`).
+- [x] (suggestion) `## Implementation` shared routing key — FIXED `25b0ecd`: forward-flag note added for #492 (orchestrator disambiguates by preceding entry).
+- [x] (suggestion) Staging vs box-check tension — FIXED `25b0ecd`: box-check is the one permitted addition to a finding's commit.
+- [x] (suggestion) `## External Review` legacy match — FIXED `25b0ecd`: step 2 filters on `base_type == "Integrated Review"`.
+- [x] (suggestion) Worktree/commit-consistency — FIXED `25b0ecd`: commits run from the issue worktree; placeholder removed.
+
+### Resolution (round 2)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) — 2026-06-15. Sandboxed re-review = changes-requested (3 must-fix + 5 suggestions); all 8 addressed in `25b0ecd` (skill) + `adab51c` (ADR-0013 addendum). The ADR registration approach (ADR-0012 addendum vs superseding ADR) was confirmed with the user. Round-2 cross-confirmed-clean items (dispatcher exit-contract, Scope-E, adapters, tables) left intact.
 
 ### Notes
 - Cross-confirmed clean: dispatcher exit-contract is **not** confused by the shared `## Implementation` type — both adversarial passes independently verified the count-delta (`entry_count` PRE vs POST) mechanism in `dispatch_subagent.sh`.

--- a/.claude/skills/address-findings/SKILL.md
+++ b/.claude/skills/address-findings/SKILL.md
@@ -51,14 +51,21 @@ python3 .agent/scripts/progress_read.py \
     .agent/work-plans/issue-<N>/progress.md --type "Integrated Review"
 ```
 
-`progress_read.py` emits JSON; take the **last** `Integrated Review`
-entry's `findings[]` array. Each finding is
-`{section, checked, source_hint, text}`. The action items are the
-entries with `checked == false`. (False positives are plain bullets, so
-they never appear in `findings[]` — no special handling needed.)
+`progress_read.py` emits JSON; filter to `Integrated Review` entries
+(its `entries[]` already only contains the requested `--type`). Then:
 
-If there are no unchecked findings, report "nothing to address — the
-latest Integrated Review has no open actions" and exit without a commit.
+- **No `Integrated Review` entry at all** (empty list — the file exists
+  but `triage-reviews` never ran, or only earlier phases have run):
+  report "no Integrated Review to address — run `triage-reviews` first"
+  and exit without a commit. Do **not** fall back to other entry types.
+- Otherwise take the **last** `Integrated Review` entry's `findings[]`
+  array. Each finding is `{section, checked, source_hint, text}`. The
+  action items are the entries with `checked == false`. (False positives
+  are plain bullets, so they never appear in `findings[]` — no special
+  handling needed.)
+- **No unchecked findings** in that entry: report "nothing to address —
+  the latest Integrated Review has no open actions" and exit without a
+  commit.
 
 ### 3. Address each open finding
 

--- a/.claude/skills/address-findings/SKILL.md
+++ b/.claude/skills/address-findings/SKILL.md
@@ -34,6 +34,13 @@ next `review-code` pass). It only *acts on an agreed fix plan*.
 no new type is minted). The orchestrator (`/run-issue`, #492) reads the
 last entry: `## Implementation` → dispatch a re-review.
 
+> **Note for #492:** `## Implementation` is shared — both this skill and a
+> future `implement` skill write it — so the orchestrator can't route on
+> entry type alone (a fresh implement pass and a post-triage fix pass both
+> land as `## Implementation`). It should disambiguate by what *precedes*
+> the entry (a `## Integrated Review` immediately before ⇒ this was an
+> address-findings pass ⇒ next is re-review). Flagged here for #492's design.
+
 ## Steps
 
 ### 1. Locate the issue and its progress.md
@@ -51,15 +58,17 @@ python3 .agent/scripts/progress_read.py \
     .agent/work-plans/issue-<N>/progress.md --type "Integrated Review"
 ```
 
-`progress_read.py` emits JSON; filter to `Integrated Review` entries
-(its `entries[]` already only contains the requested `--type`). Then:
+`progress_read.py` emits JSON. **Filter on `base_type == "Integrated
+Review"`**, not the raw `--type` match: `--type "Integrated Review"`
+also returns legacy `## External Review` entries (its recognized
+predecessor), which this skill must not act on. Then:
 
-- **No `Integrated Review` entry at all** (empty list — the file exists
-  but `triage-reviews` never ran, or only earlier phases have run):
+- **No `Integrated Review` entry at all** (no entry whose `base_type` is
+  `Integrated Review` — the file exists but `triage-reviews` never ran,
+  or only earlier phases / a legacy `External Review` are present):
   report "no Integrated Review to address — run `triage-reviews` first"
   and exit without a commit. Do **not** fall back to other entry types.
-- Otherwise take the **last** `Integrated Review` entry's `findings[]`
-  array. Each finding is `{section, checked, source_hint, text}`. The
+- Otherwise take the **last** such entry's `findings[]` array. Each finding is `{section, checked, source_hint, text}`. The
   action items are the entries with `checked == false`. (False positives
   are plain bullets, so they never appear in `findings[]` — no special
   handling needed.)
@@ -76,22 +85,29 @@ For each unchecked finding, in listed order (cross-confirmed first):
    against the current source before acting (a finding can be stale if
    an earlier round already touched the area).
 2. If, on inspection, the finding is **not** actionable (already fixed,
-   or a genuine false negative on re-read), do **not** fake a change —
-   leave the box unchecked and record why in the `## Implementation`
-   entry's deferred list (step 5). Never check a box you didn't act on.
-3. Stage only the files for this finding and commit atomically with
-   pre-commit hooks and per-invocation identity (AGENTS.md § Agent
-   Commit Identity):
+   or a genuine false negative on re-read), do **not** fake a change.
+   Record it as a **deferred** item: check its box in the `## Integrated
+   Review` entry with a `(deferred: <reason>)` annotation and list it in
+   the `## Implementation` deferred actions (step 5). Checking it (rather
+   than leaving it open) is deliberate — a later run acts only on
+   `checked == false` items, so an unchecked deferral would be
+   re-attempted every run. "Checked" here means *consciously handled*,
+   not *code changed*; the `(deferred: …)` annotation records which.
+3. From the issue worktree, stage the files for this finding and commit
+   atomically with pre-commit hooks and per-invocation identity (AGENTS.md
+   § Agent Commit Identity):
 
    ```bash
    git -c user.name="$AGENT_NAME" -c user.email="$AGENT_EMAIL" \
        commit -m "<area>: <what was fixed> (#<N>)"
    ```
 
-   Never `--no-verify`. One logical fix per commit.
+   Never `--no-verify`. One logical fix per commit. The `## Integrated
+   Review` box-check (next step) is the one permitted addition to a
+   finding's commit beyond the finding's own files.
 4. Check the box for that finding in the `## Integrated Review` entry
-   (`- [ ]` → `- [x]`) so the timeline tracks resolution. This edit can
-   ride in the same commit as the fix, or a trailing progress commit.
+   (`- [ ]` → `- [x]`) so the timeline tracks resolution — in the same
+   commit as the fix, or a trailing progress commit.
 
 ### 4. Re-run hooks / quick local checks
 
@@ -102,7 +118,10 @@ the re-review.
 
 ### 5. Write the `## Implementation` entry
 
-Append one entry (per ADR-0013; reuse `## Implementation`):
+Append one entry (per ADR-0013; reuse `## Implementation`). ADR-0013 lists
+`## Implementation` among the PR/Branch-correlated types, so the entry **must**
+carry a `**Branch**:`/`**PR**:` line — without it `progress_read.py` parses the
+entry's `correlation` as `null`:
 
 ```markdown
 
@@ -111,19 +130,26 @@ Append one entry (per ADR-0013; reuse `## Implementation`):
 **When**: <YYYY-MM-DD HH:MM ±HH:MM>
 **By**: <agent name> (<model>)
 
-**Addressed**: <integrated-review entry timestamp/sha it consumed>
+**Branch**: <branch-name> at `<short-sha>`   <!-- or **PR**: #<N> at `<sha>` if a PR exists -->
+**Addressed**: <the ## Integrated Review entry's When/SHA it consumed>
 **Commits**: <short-shas of the fix commits>
 
 ### Actions
 - [x] <finding addressed> — `file:line`
-- [ ] <finding deferred / not actionable> — `file:line` (reason)
+- [x] <finding consciously deferred — checked so it is NOT re-attempted> — `file:line` (deferred: <reason>)
 ```
 
-Commit and push:
+Deferred / not-actionable findings are written **checked** with a `(deferred:
+…)` annotation — checked means "consciously handled," so a later
+`address-findings` run (which acts only on `checked == false` items) won't
+re-attempt them. Never leave a deliberately-skipped finding unchecked.
+
+Commit (do **not** push — when dispatched as a sub-agent the host performs
+pushes; AGENTS.md § Agent Commit Identity). Run from the issue worktree:
 
 ```bash
-git -C <worktree> add .agent/work-plans/issue-<N>/progress.md
-git -C <worktree> -c user.name="$AGENT_NAME" -c user.email="$AGENT_EMAIL" \
+git add .agent/work-plans/issue-<N>/progress.md
+git -c user.name="$AGENT_NAME" -c user.email="$AGENT_EMAIL" \
     commit -m "progress: addressed integrated-review findings for #<N>"
 ```
 

--- a/.claude/skills/address-findings/SKILL.md
+++ b/.claude/skills/address-findings/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: address-findings
+description: Work through the open action items from the latest ## Integrated Review entry in progress.md — make each fix, commit atomically with pre-commit hooks, check the box, and record a ## Implementation entry. The close-the-loop phase between triage-reviews and a re-review.
+---
+
+# Address Findings
+
+## Usage
+
+```
+/address-findings [--issue <N>]
+```
+
+Run from the issue's worktree (or pass `--issue <N>`). Operates on the
+**latest** `## Integrated Review` entry in that issue's
+`.agent/work-plans/issue-<N>/progress.md`.
+
+## Overview
+
+**Lifecycle position**: triage-reviews → **address-findings** → review-code (re-review)
+
+`triage-reviews` produces a `## Integrated Review` entry: a fix plan of
+`- [ ]` checkbox actions (must-fix, cross-confirmed, and single-source
+findings), plus plain-bullet false positives that are *dismissals, not
+actions*. This skill consumes that entry — it works each open action,
+commits the fix atomically, checks the box, and writes one closing
+`## Implementation` entry so the timeline shows what was addressed.
+
+It is deliberately **thin**: it does not re-classify findings (that was
+`triage-reviews`' job) and does not re-review its own work (that is the
+next `review-code` pass). It only *acts on an agreed fix plan*.
+
+**Entry type** — writes `## Implementation` (an existing ADR-0013 type;
+no new type is minted). The orchestrator (`/run-issue`, #492) reads the
+last entry: `## Implementation` → dispatch a re-review.
+
+## Steps
+
+### 1. Locate the issue and its progress.md
+
+Resolve `<N>` from `--issue` or `$WORKTREE_ISSUE`. The file is
+`.agent/work-plans/issue-<N>/progress.md` in the issue's worktree. If it
+doesn't exist, stop with an error — there's no triage to address.
+
+### 2. Read the latest Integrated Review
+
+Use the shared parser rather than re-parsing markdown:
+
+```bash
+python3 .agent/scripts/progress_read.py \
+    .agent/work-plans/issue-<N>/progress.md --type "Integrated Review"
+```
+
+`progress_read.py` emits JSON; take the **last** `Integrated Review`
+entry's `findings[]` array. Each finding is
+`{section, checked, source_hint, text}`. The action items are the
+entries with `checked == false`. (False positives are plain bullets, so
+they never appear in `findings[]` — no special handling needed.)
+
+If there are no unchecked findings, report "nothing to address — the
+latest Integrated Review has no open actions" and exit without a commit.
+
+### 3. Address each open finding
+
+For each unchecked finding, in listed order (cross-confirmed first):
+
+1. Make the code/doc change the finding calls for. Read the cited
+   `file:line` and the surrounding code first — verify the finding
+   against the current source before acting (a finding can be stale if
+   an earlier round already touched the area).
+2. If, on inspection, the finding is **not** actionable (already fixed,
+   or a genuine false negative on re-read), do **not** fake a change —
+   leave the box unchecked and record why in the `## Implementation`
+   entry's deferred list (step 5). Never check a box you didn't act on.
+3. Stage only the files for this finding and commit atomically with
+   pre-commit hooks and per-invocation identity (AGENTS.md § Agent
+   Commit Identity):
+
+   ```bash
+   git -c user.name="$AGENT_NAME" -c user.email="$AGENT_EMAIL" \
+       commit -m "<area>: <what was fixed> (#<N>)"
+   ```
+
+   Never `--no-verify`. One logical fix per commit.
+4. Check the box for that finding in the `## Integrated Review` entry
+   (`- [ ]` → `- [x]`) so the timeline tracks resolution. This edit can
+   ride in the same commit as the fix, or a trailing progress commit.
+
+### 4. Re-run hooks / quick local checks
+
+After the last fix, run the relevant quick checks (the linters
+pre-commit already ran, plus any package test touched by the changes).
+This is not a full `review-code` — it's a sanity pass before handing to
+the re-review.
+
+### 5. Write the `## Implementation` entry
+
+Append one entry (per ADR-0013; reuse `## Implementation`):
+
+```markdown
+
+## Implementation
+**Status**: complete
+**When**: <YYYY-MM-DD HH:MM ±HH:MM>
+**By**: <agent name> (<model>)
+
+**Addressed**: <integrated-review entry timestamp/sha it consumed>
+**Commits**: <short-shas of the fix commits>
+
+### Actions
+- [x] <finding addressed> — `file:line`
+- [ ] <finding deferred / not actionable> — `file:line` (reason)
+```
+
+Commit and push:
+
+```bash
+git -C <worktree> add .agent/work-plans/issue-<N>/progress.md
+git -C <worktree> -c user.name="$AGENT_NAME" -c user.email="$AGENT_EMAIL" \
+    commit -m "progress: addressed integrated-review findings for #<N>"
+```
+
+### Next step
+
+Lifecycle: **Implementation** → **review-code** (re-review the fixes)
+
+Hand off to a **fresh-context sub-agent** — independence is what makes the
+re-review trustworthy. Use the dispatcher:
+
+    .agent/scripts/dispatch_subagent.sh --mode in-process --issue <N> --skill review-code
+
+The re-review reads the diff cold and confirms the findings are genuinely
+resolved. **No auto-chaining (Scope E):** this skill never dispatches the next
+phase itself — the host orchestrator (`/run-issue`, #492) drives, pausing at
+user checkpoints. This step only emits this prompt and its `progress.md` entry.
+
+## Guidelines
+
+- **Act on the agreed plan, don't re-litigate it** — `triage-reviews` already
+  classified each finding. If you disagree with a finding on inspection, defer
+  it with a reason; don't silently drop it or argue it in the commit.
+- **Never fake resolution** — a checked box must correspond to a real commit.
+  Deferred/non-actionable items stay unchecked with a recorded reason.
+- **Atomic commits** — one finding per commit where practical, so a re-review
+  (and a revert) can reason about each fix independently.
+- **Stay thin** — no re-classification, no self-review. The next `review-code`
+  pass is the quality gate on this work.

--- a/.claude/skills/address-findings/SKILL.md
+++ b/.claude/skills/address-findings/SKILL.md
@@ -89,10 +89,13 @@ For each unchecked finding, in listed order (cross-confirmed first):
    Record it as a **deferred** item: check its box in the `## Integrated
    Review` entry with a `(deferred: <reason>)` annotation and list it in
    the `## Implementation` deferred actions (step 5). Checking it (rather
-   than leaving it open) is deliberate — a later run acts only on
-   `checked == false` items, so an unchecked deferral would be
-   re-attempted every run. "Checked" here means *consciously handled*,
-   not *code changed*; the `(deferred: …)` annotation records which.
+   than leaving it open) is deliberate: a finding's checkbox should reflect
+   whether it still needs attention, and a deferred one does not. It also
+   keeps the skill idempotent — if `address-findings` is ever re-run against
+   the same `## Integrated Review` entry, it acts only on `checked == false`
+   items and so won't re-attempt a deferral. "Checked" here means
+   *consciously handled*, not *code changed*; the `(deferred: …)` annotation
+   records which.
 3. From the issue worktree, stage the files for this finding and commit
    atomically with pre-commit hooks and per-invocation identity (AGENTS.md
    § Agent Commit Identity):
@@ -136,13 +139,14 @@ entry's `correlation` as `null`:
 
 ### Actions
 - [x] <finding addressed> — `file:line`
-- [x] <finding consciously deferred — checked so it is NOT re-attempted> — `file:line` (deferred: <reason>)
+- [x] <finding consciously deferred — checked, so it reads as handled> — `file:line` (deferred: <reason>)
 ```
 
 Deferred / not-actionable findings are written **checked** with a `(deferred:
-…)` annotation — checked means "consciously handled," so a later
-`address-findings` run (which acts only on `checked == false` items) won't
-re-attempt them. Never leave a deliberately-skipped finding unchecked.
+…)` annotation — checked means "consciously handled," so the checkbox reflects
+that the finding no longer needs attention (and a re-run against the same entry,
+which acts only on `checked == false` items, won't re-attempt it). Never leave a
+deliberately-skipped finding unchecked.
 
 Commit (do **not** push — when dispatched as a sub-agent the host performs
 pushes; AGENTS.md § Agent Commit Identity). Run from the issue worktree:
@@ -172,8 +176,12 @@ user checkpoints. This step only emits this prompt and its `progress.md` entry.
 - **Act on the agreed plan, don't re-litigate it** — `triage-reviews` already
   classified each finding. If you disagree with a finding on inspection, defer
   it with a reason; don't silently drop it or argue it in the commit.
-- **Never fake resolution** — a checked box must correspond to a real commit.
-  Deferred/non-actionable items stay unchecked with a recorded reason.
+- **Never fake resolution** — a checked box on an *actioned* finding must
+  correspond to a real commit. A finding you consciously **defer** is also
+  checked, but annotated `(deferred: <reason>)` so it reads as "handled, not
+  changed" (see Step 3.2 / Step 5). What you must never do is leave a finding
+  *silently* untouched — every finding ends either fixed-and-checked or
+  deferred-checked-with-reason.
 - **Atomic commits** — one finding per commit where practical, so a re-review
   (and a revert) can reason about each fix independently.
 - **Stay thin** — no re-classification, no self-review. The next `review-code`

--- a/.claude/skills/triage-reviews/SKILL.md
+++ b/.claude/skills/triage-reviews/SKILL.md
@@ -358,26 +358,29 @@ persistence.)
 
 ### Next step
 
-Lifecycle: **Integrated Review** → address findings / done
+Lifecycle: **Integrated Review** → `address-findings` (if open findings) / done
 
-`triage-reviews` is the last automated skill in the per-issue lifecycle. After
-the `## Integrated Review` entry is committed, the next action is manual:
+After the `## Integrated Review` entry is committed:
 
-- **If must-fix or cross-confirmed findings remain** — address each item from
-  the `### Findings` list, commit, push, and re-run `/triage-reviews` for
-  another round. Each round writes a new `## Integrated Review` entry.
+- **If must-fix or cross-confirmed findings remain** — hand off to
+  `address-findings`, which works each open `- [ ]` action, commits the fixes
+  atomically, and writes a `## Implementation` entry; a re-review (`review-code`)
+  then follows. Dispatch to a fresh-context sub-agent:
+
+      .agent/scripts/dispatch_subagent.sh --mode in-process --issue <N> --skill address-findings
+
+  (You may still address findings by hand and re-run `/triage-reviews` for
+  another round instead — each round writes a new `## Integrated Review` entry.)
 - **If no must-fix findings remain** — the PR is ready for merge. Use
   `.agent/scripts/merge_pr.sh` (or `make merge-pr`) to merge, remove the
   worktree, delete the branches, and sync.
 
-No `dispatch_subagent.sh` call is issued here — there is no next skill to hand
-off to. The host orchestrator (`/run-issue`,
+**No auto-chaining (Scope E):** this skill does not dispatch `address-findings`
+itself — it only emits the handoff prompt + `progress.md` entry. The host
+orchestrator (`/run-issue`,
 [#492](https://github.com/rolker/ros2_agent_workspace/issues/492)) reads the
-last `## Integrated Review` entry and surfaces the outcome and recommended
-actions to the operator.
-
-**No auto-chaining (Scope E):** no skill in the lifecycle dispatches the next
-phase autonomously — the host orchestrator drives, pausing at user checkpoints.
+last `## Integrated Review` entry and drives the next phase, pausing at user
+checkpoints.
 
 ## Guidelines
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,7 +105,7 @@ corresponding SKILL.md and follow its steps.
 Available workflow skills: `review-issue`, `plan-task`, `review-plan`,
 `review-code`, `brainstorm`, `research`, `audit-workspace`, `audit-project`,
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
-`triage-reviews`, `skill-importer`, `document-package`, `issue-triage`,
+`triage-reviews`, `address-findings`, `skill-importer`, `document-package`, `issue-triage`,
 `test-engineering`, `inspiration-tracker`, `import-field-changes`,
 `start-deployment`.
 

--- a/docs/decisions/0013-progress-md-entry-type-vocabulary.md
+++ b/docs/decisions/0013-progress-md-entry-type-vocabulary.md
@@ -201,3 +201,13 @@ name for new entries; no migration of historical files.
   `## Integrated Review`. Read that paragraph as describing the transitional
   state, not current write behavior; this addendum is the current source of
   truth for what gets written.
+- Issue [#491](https://github.com/rolker/ros2_agent_workspace/issues/491) — the
+  `address-findings` skill (#481 phase C) is now an **additional writer of
+  `## Implementation`**: after `triage-reviews`, it works the open
+  `## Integrated Review` actions and records a `## Implementation` entry. The
+  Decision table's `## Implementation` Writer cell ("future `implement` skill")
+  is the original intent and is **unchanged**; this note registers the second
+  writer navigationally (no new entry type, no semantics change — a substantive
+  change would require a superseding ADR). Consumers filtering by entry type are
+  unaffected: `## Implementation` keeps its meaning ("implementation work
+  completed; references the commit SHA(s)").


### PR DESCRIPTION
Closes #491

# Plan: 'address-findings' skill (consume ## Integrated Review)

## Issue
https://github.com/rolker/ros2_agent_workspace/issues/491

## Context
Phase C of #481 needs a thin workflow skill that closes the review loop: after
`triage-reviews` writes a `## Integrated Review` entry (a fix plan of `- [ ]`
actions), `address-findings` works through those actions, commits the fixes
atomically, checks the boxes, and writes a closing entry. It's the phase the
`/run-issue` orchestrator (#492) dispatches between triage and re-review — the
reason we build C before D.

The integration points already exist:
- `progress_read.py --type "Integrated Review"` returns each entry's `findings[]`
  array (`{section, checked, source_hint, text}`) — the `- [ ]` actions, parsed.
  No markdown re-parsing needed.
- `## Integrated Review` entry type exists (#485 merged — the issue's stated
  blocker is cleared).

## Approach
1. **New skill** `.claude/skills/address-findings/SKILL.md` (thin), steps:
   1. Resolve the issue's `progress.md`; run `progress_read.py --type "Integrated Review"`; take the **last** entry's unchecked `findings[]` (`checked == false`). If none, report "nothing to address" and exit.
   2. For each finding: make the code change, run pre-commit, commit atomically (`git -c` identity per AGENTS.md), then check its box (`- [ ]`→`- [x]`) in the `## Integrated Review` entry — same-commit so the timeline tracks resolution.
   3. Skip/annotate findings that are dismissals (plain bullets) or already `- [x]`.
   4. Write one closing `## Implementation` entry (see ADR gate) summarizing what was addressed + what was deferred, with a `### Actions` checklist for anything left.
   5. Emit a "Next step" handoff to **review-code** (re-review the fixes) — no auto-chaining (Scope E).
2. **Adapter skill lists** — add `address-findings` to `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md`.
3. **De-dup note (scope decision)** — the issue says this "replaces ad-hoc external-review handling in `triage-reviews`+`review-code`." Propose: this PR only *adds* the skill; the removal of the old handling is a **follow-up** (keeps the PR focused and the removal independently reviewable). Open question 2.

## Files to Change
| File | Change |
|------|--------|
| `.claude/skills/address-findings/SKILL.md` | **New** — the thin skill |
| `.github/copilot-instructions.md` | Add skill to list |
| `.agent/instructions/gemini-cli.instructions.md` | Add skill to list |
| `.agent/AGENT_ONBOARDING.md` | Add skill to list |

## Principles Self-Check
| Principle | Consideration |
|---|---|
| Only what's needed | Reuse `progress_read.py` + an existing entry type; no new parser, no new ADR (per recommendation) |
| Capture decisions | Entry-type choice recorded; ADR-0013 honored |
| A change includes its consequences | Skill-list adapter updates in the same PR |
| Improve incrementally | De-dup of old handling deferred to a focused follow-up |

## ADR Compliance
| ADR | Triggered | How addressed |
|---|---|---|
| 0013 — progress.md vocabulary | **Yes** | Skill **writes `## Implementation`** (recommended) — an existing canonical type, no superseding ADR. Minting `## Findings Addressed` is rejected unless #492 needs to distinguish it (it doesn't: orchestrator reads the *last* entry; "Implementation → re-review" is the correct transition either way). |
| 0004/0005 — enforcement layering | Yes (satisfied) | Convention-only skill, consistent with peers |
| 0006 — shared AGENTS.md | Yes | Skill listed in all framework adapters |

## Consequences
| If we change... | Also update... | In plan? |
|---|---|---|
| Add a workflow skill | Skill list in non-Claude adapters | Yes |
| Add a skill that writes progress.md | Use an ADR-0013 type | Yes (`## Implementation`) |

## Open Questions
_Both resolved with the user (2026-06-15):_
- [x] **Entry type** → **reuse `## Implementation`** (no new ADR). Confirmed.
- [x] **De-dup scope** → **follow-up PR** (this PR only adds the skill). Confirmed; file the de-dup follow-up after merge.

## Estimated Scope
Single PR (skill + adapter lists). De-dup follow-up tracked separately.
