### PR TITLE
#481 sub (D): /run-issue host orchestration skill

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -99,7 +99,7 @@ These are plain markdown — not Claude Code-specific. When asked to review an
 issue, plan a task, review a PR, brainstorm, or run research, read the
 corresponding SKILL.md and follow its steps.
 
-Available workflow skills: `review-issue`, `plan-task`, `review-plan`,
+Available workflow skills: `run-issue`, `review-issue`, `plan-task`, `review-plan`,
 `review-code`, `brainstorm`, `research`, `audit-workspace`, `audit-project`,
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
 `triage-reviews`, `address-findings`, `skill-importer`, `document-package`, `issue-triage`,

--- a/.agent/instructions/gemini-cli.instructions.md
+++ b/.agent/instructions/gemini-cli.instructions.md
@@ -71,7 +71,7 @@ These are plain markdown — not Claude Code-specific. When asked to review an
 issue, plan a task, review a PR, brainstorm, or run research, read the
 corresponding SKILL.md and follow its steps.
 
-Available workflow skills: `review-issue`, `plan-task`, `review-plan`,
+Available workflow skills: `run-issue`, `review-issue`, `plan-task`, `review-plan`,
 `review-code`, `brainstorm`, `research`, `audit-workspace`, `audit-project`,
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
 `triage-reviews`, `address-findings`, `skill-importer`, `document-package`, `issue-triage`,

--- a/.agent/knowledge/skill_workflows.md
+++ b/.agent/knowledge/skill_workflows.md
@@ -11,6 +11,15 @@ brainstorm → review-issue → plan-task → review-plan → implement
           → address-findings → review-code (re-review) → …
 ```
 
+**`/run-issue` orchestrates this whole sequence** (#492): it dispatches each
+phase as a fresh-context sub-agent, reads each phase's `progress.md` entry to
+choose the next action, and pauses at `AskUserQuestion` checkpoints. It is the
+*driver*, not a dispatched phase — running the lifecycle by hand (one
+`/review-issue`, `/plan-task`, … at a time) is the manual equivalent. The
+pipeline is **local-first**: `plan-task` no longer opens a PR by default (commit
+to branch only; `--draft-pr` to publish early), and `/run-issue` creates the PR
+**at the end**, after a clean local `review-code`, gated by a user checkpoint.
+
 Most steps are optional — simple issues can skip straight to
 `plan-task` or implementation. **`review-code` is the exception**:
 AGENTS.md Post-Task Verification step 5 makes a pre-push `review-code`
@@ -37,6 +46,7 @@ accepts a PR number / URL for post-PR review of someone else's work.
 
 | Skill | Position | Purpose |
 |-------|----------|---------|
+| `run-issue` | **Driver** (orchestrates the whole sequence) | Host orchestrator: dispatches each phase, reads its `progress.md` entry, pauses at checkpoints; local-first PR-at-end. Not itself a dispatched phase (#492) |
 | `brainstorm` | Before review-issue | Explore possibilities using research digests and project knowledge |
 | `review-issue` | Before plan-task | Evaluate issue scope, principle alignment, and ADR applicability |
 | `plan-task` | Before implementation | Generate a principles-aware work plan, commit to branch |

--- a/.agent/work-plans/issue-492/plan.md
+++ b/.agent/work-plans/issue-492/plan.md
@@ -1,0 +1,90 @@
+# Plan: /run-issue host orchestration skill (#492)
+
+## Issue
+https://github.com/rolker/ros2_agent_workspace/issues/492
+
+## Context
+Phase C's keystone. The lifecycle skills (review-issue → plan-task → review-plan
+→ implement → review-code → triage-reviews → address-findings) already each
+write a typed `progress.md` entry and emit a handoff; `dispatch_subagent.sh`
+already dispatches a phase and verifies the sub-agent wrote the expected entry
+(PRE/POST entry-count delta → reports the new entry or `FAILED`). What's missing
+is the **host driver**: a skill that runs the phases in order, reads each
+entry's verdict/findings/open-questions to pick the next action, and pauses at
+user checkpoints. This session's hand-driven #491 run *is* the manual version of
+exactly this.
+
+## Approach
+A new `.claude/skills/run-issue/SKILL.md` — host-agent orchestration logic, no
+new script (reuses `dispatch_subagent.sh` + `progress_read.py`). Its spine is a
+**phase-transition decision table**: given the last `progress.md` entry
+(type + verdict), pick the next dispatch and whether to checkpoint.
+
+1. **Decision table** (the core):
+
+   | Last entry | Condition | Next action | Checkpoint |
+   |---|---|---|---|
+   | (none) | — | dispatch `review-issue` | — |
+   | `## Issue Review` | open-question actions | ask the open Qs, then `plan-task` | **yes** (iff open Qs) |
+   | `## Issue Review` | none | dispatch `plan-task` | — |
+   | `## Plan Authored` | — | dispatch `review-plan` | — |
+   | `## Plan Review` | any | run implementation, then `review-code` | **always** |
+   | `## Local Review (Pre-Push)` | approved | push → PR (or field-push) | **yes** (before publish) |
+   | `## Local Review (Pre-Push)` | changes-requested | address inline, re-run `review-code` | maybe |
+   | `## Integrated Review` | open findings | dispatch `address-findings` | **yes** (non-trivial findings) |
+   | `## Integrated Review` | none | merge | **yes** (before merge) |
+   | `## Implementation` **preceded by** `## Integrated Review` | — | dispatch `review-code` (re-review) | — |
+
+   The last row is the **shared-routing-key disambiguation**: `## Implementation`
+   is written by both `address-findings` and a future `implement` skill, so route
+   on the *preceding* entry (Integrated Review before ⇒ address-findings pass ⇒
+   re-review).
+2. **Checkpoints** via `AskUserQuestion`, never silent: after `## Issue Review`
+   iff open questions; **always** after `## Plan Review`; after each
+   `## Integrated Review` with non-trivial findings; and **before any
+   push / PR creation / merge** (local-first).
+3. **Implementation phase**: there is no `implement` skill yet — the host runs
+   implementation inline (then dispatches `review-code`). Documented as such, not
+   stubbed.
+4. **Local-first PR-at-end**: orchestrated `plan-task` must **not** open its
+   early `[PLAN]` draft PR (step 7); the orchestrator pushes + opens the PR at
+   the end. Mechanism = open question 1.
+5. **Field mode** (ADR-0011): at the publish step, branch on `field_mode.sh` —
+   gitcloud-origin repos push to the field remote with **no PR and no Copilot**.
+6. **Consequences**: adapter skill lists + `skill_workflows.md`.
+
+## Files to Change
+| File | Change |
+|------|--------|
+| `.claude/skills/run-issue/SKILL.md` | **New** — orchestrator (decision table + checkpoints + publish step) |
+| `.claude/skills/plan-task/SKILL.md` | Make step-7 early draft PR suppressible when orchestrated (open question 1) |
+| `.agent/knowledge/skill_workflows.md` | Document `/run-issue` as the lifecycle driver |
+| `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md` | Add `run-issue` to skill lists |
+
+## Principles Self-Check
+| Principle | Consideration |
+|---|---|
+| Human control & transparency | Checkpoints at every publish/irreversible step; never auto-push/merge; the decision table is explicit and inspectable |
+| Only what's needed | No new script — reuse dispatch + progress_read; don't orchestrate phases that don't exist (implement stays inline) |
+| Capture decisions | Shared-routing-key disambiguation documented in the table |
+| A change includes its consequences | plan-task tweak + adapters + lifecycle doc in scope |
+
+## ADR Compliance
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0013 — progress.md vocabulary | Yes (consumer) | Routes by entry type; handles shared `## Implementation` via preceding-entry rule |
+| 0011 — Field mode | Yes | Publish step branches on `field_mode.sh` (push, no PR/Copilot) |
+| 0004/0005, 0006 | Yes | Convention-only skill; adapters updated |
+
+## Consequences
+| If we change... | Also update... | In plan? |
+|---|---|---|
+| Add a workflow skill | adapter skill lists + `skill_workflows.md` + `dispatch_subagent.sh` maps if dispatchable | Yes (run-issue is the driver, not itself dispatched — no skill_entry_type row needed) |
+| plan-task PR behavior | plan-task SKILL.md + its "During implementation" notes | Yes (open question 1) |
+
+## Open Questions
+- [ ] **plan-task PR-deferral mechanism** — (a) add a suppress signal (env/flag) so *orchestrated* plan-task skips the early PR, standalone default unchanged [recommended, least disruptive]; or (b) flip plan-task's default to no-early-PR with publish-early opt-in (changes standalone behavior). And: ship the plan-task tweak **in this PR** or a stacked follow-up?
+- [ ] **Copilot at publish** — default off (per the quota opt-in decision), `--copilot` opt-in surfaced as a checkpoint option? Confirm.
+
+## Estimated Scope
+Single PR (orchestrator + small plan-task tweak + adapters), unless we split the plan-task change to a stacked follow-up (open question 1).

--- a/.agent/work-plans/issue-492/plan.md
+++ b/.agent/work-plans/issue-492/plan.md
@@ -31,14 +31,20 @@ new script (reuses `dispatch_subagent.sh` + `progress_read.py`). Its spine is a
    | `## Plan Review` | any | run implementation, then `review-code` | **always** |
    | `## Local Review (Pre-Push)` | approved | push → PR (or field-push) | **yes** (before publish) |
    | `## Local Review (Pre-Push)` | changes-requested | address inline, re-run `review-code` | maybe |
+   | `## Local Review (Pre-Push)` | (PR published) | dispatch `triage-reviews` after review comments land | **yes** (async — host waits for comments) |
    | `## Integrated Review` | open findings | dispatch `address-findings` | **yes** (non-trivial findings) |
    | `## Integrated Review` | none | merge | **yes** (before merge) |
    | `## Implementation` **preceded by** `## Integrated Review` | — | dispatch `review-code` (re-review) | — |
 
-   The last row is the **shared-routing-key disambiguation**: `## Implementation`
-   is written by both `address-findings` and a future `implement` skill, so route
-   on the *preceding* entry (Integrated Review before ⇒ address-findings pass ⇒
-   re-review).
+   The shared-routing-key disambiguation: `## Implementation` is written by both
+   `address-findings` and a future `implement` skill, so route on the *preceding*
+   entry (Integrated Review before ⇒ address-findings pass ⇒ re-review).
+   **Entry-type variant matching**: the table keys on `## Local Review
+   (Pre-Push)`, but `skill_workflows.md`'s handoff table says `## Local Review`;
+   the orchestrator must match by **base type / prefix** (the same rule
+   `dispatch_subagent.sh:217-235` already uses), not exact string.
+   **PR-published ⇒ triage-reviews** is the one transition the host can't fully
+   drive — it waits for review comments to arrive before dispatching.
 2. **Checkpoints** via `AskUserQuestion`, never silent: after `## Issue Review`
    iff open questions; **always** after `## Plan Review`; after each
    `## Integrated Review` with non-trivial findings; and **before any
@@ -52,7 +58,11 @@ new script (reuses `dispatch_subagent.sh` + `progress_read.py`). Its spine is a
    The orchestrator pushes + opens the PR at the end. This ships **in this PR**.
    Downstream `review-plan` already accepts a plan **file / `--issue <N>`** (not
    only a PR), so it still works with no early PR — verify and adjust its default
-   resolution to prefer the local plan file when no PR exists.
+   resolution to prefer the local plan file when no PR exists. Note:
+   `worktree_create.sh --plan-file` is a **second** publish-early entry point
+   (it auto-opens a draft PR) — it's the equivalent opt-in to the new
+   `--draft-pr` flag; document the relationship so the two paths stay coherent
+   (no code change to the script).
 5. **Field mode** (ADR-0011): at the publish step, branch on `field_mode.sh` —
    gitcloud-origin repos push to the field remote with **no PR and no Copilot**.
 6. **Consequences**: adapter skill lists + `skill_workflows.md`.
@@ -63,6 +73,7 @@ new script (reuses `dispatch_subagent.sh` + `progress_read.py`). Its spine is a
 | `.claude/skills/run-issue/SKILL.md` | **New** — orchestrator (decision table + checkpoints + publish step incl. field-mode + opt-in Copilot) |
 | `.claude/skills/plan-task/SKILL.md` | **Flip default**: step 7 no longer opens a draft PR; add `--draft-pr` opt-in; update the "Next step" + "During implementation" prose that assumes an early PR |
 | `.claude/skills/review-plan/SKILL.md` | Confirm/adjust no-PR resolution: prefer the local plan file via `--issue <N>` when no PR exists |
+| `.claude/skills/review-issue/SKILL.md` | **(must-fix, review-plan)** line 272 "A draft PR will follow when `plan-task` runs" is false post-flip — correct it |
 | `.agent/knowledge/skill_workflows.md` | Document `/run-issue` as the lifecycle driver; note plan-task no longer auto-publishes |
 | `AGENTS.md` | Post-Task-Verification "Plan-first workflow" wording mentions "if the PR opened with a work plan" — already conditional, but verify it reads correctly now that no early PR is the default (**instruction file — confirm with user before edit**) |
 | `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md` | Add `run-issue` to skill lists |

--- a/.agent/work-plans/issue-492/plan.md
+++ b/.agent/work-plans/issue-492/plan.md
@@ -72,10 +72,10 @@ new script (reuses `dispatch_subagent.sh` + `progress_read.py`). Its spine is a
 |------|--------|
 | `.claude/skills/run-issue/SKILL.md` | **New** — orchestrator (decision table + checkpoints + publish step incl. field-mode + opt-in Copilot) |
 | `.claude/skills/plan-task/SKILL.md` | **Flip default**: step 7 no longer opens a draft PR; add `--draft-pr` opt-in; update the "Next step" + "During implementation" prose that assumes an early PR |
-| `.claude/skills/review-plan/SKILL.md` | Confirm/adjust no-PR resolution: prefer the local plan file via `--issue <N>` when no PR exists |
-| `.claude/skills/review-issue/SKILL.md` | **(must-fix, review-plan)** line 272 "A draft PR will follow when `plan-task` runs" is false post-flip — correct it |
-| `.agent/knowledge/skill_workflows.md` | Document `/run-issue` as the lifecycle driver; note plan-task no longer auto-publishes |
-| `AGENTS.md` | Post-Task-Verification "Plan-first workflow" wording mentions "if the PR opened with a work plan" — already conditional, but verify it reads correctly now that no early PR is the default (**instruction file — confirm with user before edit**) |
+| `.claude/skills/review-plan/SKILL.md` | **No change needed** — already supports PR-less review via `--issue <N>` / file-path forms (SKILL.md:16-30) |
+| `.claude/skills/review-issue/SKILL.md` | **(must-fix, review-plan)** ✅ line 272 corrected — plan-task no longer auto-opens a PR |
+| `.agent/knowledge/skill_workflows.md` | ✅ `/run-issue` documented as the lifecycle driver + Skill Index row; local-first note (plan-task no auto-publish) |
+| `AGENTS.md` | **No change needed** — "Plan-first workflow" wording is already conditional ("if the PR opened with a work plan…") and reads correctly post-flip (confirmed by review-plan) |
 | `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md` | Add `run-issue` to skill lists |
 
 ## Principles Self-Check

--- a/.agent/work-plans/issue-492/plan.md
+++ b/.agent/work-plans/issue-492/plan.md
@@ -46,9 +46,13 @@ new script (reuses `dispatch_subagent.sh` + `progress_read.py`). Its spine is a
 3. **Implementation phase**: there is no `implement` skill yet — the host runs
    implementation inline (then dispatches `review-code`). Documented as such, not
    stubbed.
-4. **Local-first PR-at-end**: orchestrated `plan-task` must **not** open its
-   early `[PLAN]` draft PR (step 7); the orchestrator pushes + opens the PR at
-   the end. Mechanism = open question 1.
+4. **Local-first PR-at-end** (decided): **flip `plan-task`'s default** — step 7
+   no longer opens an early `[PLAN]` draft PR; the plan is committed to the
+   branch and "publish early" becomes an **opt-in flag** (e.g. `--draft-pr`).
+   The orchestrator pushes + opens the PR at the end. This ships **in this PR**.
+   Downstream `review-plan` already accepts a plan **file / `--issue <N>`** (not
+   only a PR), so it still works with no early PR — verify and adjust its default
+   resolution to prefer the local plan file when no PR exists.
 5. **Field mode** (ADR-0011): at the publish step, branch on `field_mode.sh` —
    gitcloud-origin repos push to the field remote with **no PR and no Copilot**.
 6. **Consequences**: adapter skill lists + `skill_workflows.md`.
@@ -56,9 +60,11 @@ new script (reuses `dispatch_subagent.sh` + `progress_read.py`). Its spine is a
 ## Files to Change
 | File | Change |
 |------|--------|
-| `.claude/skills/run-issue/SKILL.md` | **New** — orchestrator (decision table + checkpoints + publish step) |
-| `.claude/skills/plan-task/SKILL.md` | Make step-7 early draft PR suppressible when orchestrated (open question 1) |
-| `.agent/knowledge/skill_workflows.md` | Document `/run-issue` as the lifecycle driver |
+| `.claude/skills/run-issue/SKILL.md` | **New** — orchestrator (decision table + checkpoints + publish step incl. field-mode + opt-in Copilot) |
+| `.claude/skills/plan-task/SKILL.md` | **Flip default**: step 7 no longer opens a draft PR; add `--draft-pr` opt-in; update the "Next step" + "During implementation" prose that assumes an early PR |
+| `.claude/skills/review-plan/SKILL.md` | Confirm/adjust no-PR resolution: prefer the local plan file via `--issue <N>` when no PR exists |
+| `.agent/knowledge/skill_workflows.md` | Document `/run-issue` as the lifecycle driver; note plan-task no longer auto-publishes |
+| `AGENTS.md` | Post-Task-Verification "Plan-first workflow" wording mentions "if the PR opened with a work plan" — already conditional, but verify it reads correctly now that no early PR is the default (**instruction file — confirm with user before edit**) |
 | `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md` | Add `run-issue` to skill lists |
 
 ## Principles Self-Check
@@ -83,8 +89,12 @@ new script (reuses `dispatch_subagent.sh` + `progress_read.py`). Its spine is a
 | plan-task PR behavior | plan-task SKILL.md + its "During implementation" notes | Yes (open question 1) |
 
 ## Open Questions
-- [ ] **plan-task PR-deferral mechanism** — (a) add a suppress signal (env/flag) so *orchestrated* plan-task skips the early PR, standalone default unchanged [recommended, least disruptive]; or (b) flip plan-task's default to no-early-PR with publish-early opt-in (changes standalone behavior). And: ship the plan-task tweak **in this PR** or a stacked follow-up?
-- [ ] **Copilot at publish** — default off (per the quota opt-in decision), `--copilot` opt-in surfaced as a checkpoint option? Confirm.
+_Resolved with the user (2026-06-15):_
+- [x] **plan-task PR behavior** → **flip the default to no-early-PR**; publish-early becomes an opt-in flag. Ships **in this PR** (not a stacked follow-up).
+- [x] **Copilot at publish** → **off by default**; the publish checkpoint offers `--copilot` as a per-run opt-in.
+- [ ] **AGENTS.md edit** — the "Plan-first workflow" wording may need a light tweak; AGENTS.md is an "ask first" instruction file → confirm the exact change with the user during implementation before editing.
 
 ## Estimated Scope
-Single PR (orchestrator + small plan-task tweak + adapters), unless we split the plan-task change to a stacked follow-up (open question 1).
+Single PR: orchestrator + plan-task default flip (+ `--draft-pr` opt-in) +
+review-plan no-PR resolution + skill_workflows + adapters. Larger than a typical
+new-skill PR because of the plan-task default flip and its ripple.

--- a/.agent/work-plans/issue-492/plan.md
+++ b/.agent/work-plans/issue-492/plan.md
@@ -57,8 +57,9 @@ new script (reuses `dispatch_subagent.sh` + `progress_read.py`). Its spine is a
    branch and "publish early" becomes an **opt-in flag** (e.g. `--draft-pr`).
    The orchestrator pushes + opens the PR at the end. This ships **in this PR**.
    Downstream `review-plan` already accepts a plan **file / `--issue <N>`** (not
-   only a PR), so it still works with no early PR — verify and adjust its default
-   resolution to prefer the local plan file when no PR exists. Note:
+   only a PR — see review-plan SKILL.md:16-32), so it works with no early PR with
+   **no change**: the orchestrator dispatches it with `--issue <N>`, which
+   resolves the local `.agent/work-plans/issue-<N>/plan.md`. Note:
    `worktree_create.sh --plan-file` is a **second** publish-early entry point
    (it auto-opens a draft PR) — it's the equivalent opt-in to the new
    `--draft-pr` flag; document the relationship so the two paths stay coherent

--- a/.agent/work-plans/issue-492/progress.md
+++ b/.agent/work-plans/issue-492/progress.md
@@ -34,3 +34,21 @@ issue: 492
 - [x] plan-task PR behavior → **flip default to no-early-PR** (publish-early = opt-in `--draft-pr`); ships **in this PR**. Confirmed 2026-06-15.
 - [x] Copilot at publish → **off by default**, `--copilot` opt-in at the publish checkpoint. Confirmed 2026-06-15.
 - [ ] AGENTS.md "Plan-first workflow" wording tweak — confirm exact change with user before editing (instruction file).
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-15 15:40 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-492/plan.md` at `3068207`
+**PR**: https://github.com/rolker/ros2_agent_workspace/pull/525
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (must-fix) plan-task-flip ripple incomplete: `review-issue/SKILL.md:272` states "A draft PR will follow when `plan-task` runs" — false once the default flips. Add `review-issue/SKILL.md` to Files to Change. — `plan.md:60-68`
+- [ ] (suggestion) Second early-PR path unreconciled: `worktree_create.sh --plan-file` also auto-opens a draft PR. Note it as the equivalent opt-in to `--draft-pr` so the two publish-early paths stay consistent (no code change required). — `plan.md:64`
+- [ ] (suggestion) Decision table has no row for "PR published ⇒ dispatch `triage-reviews`"; the async wait for review comments to arrive is the one transition the host can't fully automate. Add a row/prose note so the gap is explicit. — `plan.md:23-37`
+- [ ] (suggestion) Decision-table key `## Local Review (Pre-Push)` is correct, but `skill_workflows.md` handoff table still lists `## Local Review`; the orchestrator must match the parenthetical variant (dispatch_subagent.sh already does this — count-by-prefix at lines 217-235). Call this matching rule out in the skill. — `plan.md:32`
+- [ ] (good) Claim #3 (orchestrator needs no `skill_entry_type` row) verified — `dispatch_subagent.sh:53-62` map has no `run-issue` case; the driver is never dispatched as a phase.
+- [ ] (good) ADR-0011 field-mode + never-auto-push guarantee solid: checkpoint before every push/PR/merge, publish branches on `field_mode.sh` (push, no PR/Copilot). — `plan.md:42-57`
+- [ ] (good) Shared-`## Implementation` disambiguation (route by preceding entry) matches the address-findings note at `address-findings/SKILL.md:37-42`. — `plan.md:36`

--- a/.agent/work-plans/issue-492/progress.md
+++ b/.agent/work-plans/issue-492/progress.md
@@ -1,0 +1,22 @@
+---
+issue: 492
+---
+
+# Issue #492 — /run-issue host orchestration skill
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-15 14:05 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Issue**: #492
+**Comment**: https://github.com/rolker/ros2_agent_workspace/issues/492#issuecomment-4711263199
+**Scope verdict**: well-scoped (design-heavy)
+
+### Actions
+- [ ] (plan-task, primary) Resolve plan-task early-PR vs local-first PR-at-end: recommend a plan-task opt-in flag (PR-at-end orchestrated default); decide in-PR vs stacked follow-up.
+- [ ] (plan-task) Specify the phase-transition decision table (last entry type + verdict → next dispatch/checkpoint), incl. `## Implementation` preceding-entry disambiguation (shared routing key).
+- [ ] (plan-task) Define field-mode end-of-pipeline behavior (push, no PR, no Copilot for gitcloud) per ADR-0011.
+- [ ] (plan-task) Enumerate checkpoints precisely (post Issue Review iff open Qs; always post Plan Review; post each Integrated Review w/ findings; before any push/PR/merge).
+- [ ] (consequences) Adapter skill lists + skill_workflows.md.
+- [ ] Note overlap with the pending #491 de-dup follow-up so findings aren't double-handled.

--- a/.agent/work-plans/issue-492/progress.md
+++ b/.agent/work-plans/issue-492/progress.md
@@ -31,5 +31,6 @@ issue: 492
 **Phases**: single (possible stacked plan-task tweak — open question 1)
 
 ### Open questions
-- [ ] plan-task PR-deferral mechanism: (a) suppress signal for orchestrated runs [recommended] vs (b) flip default to no-early-PR; and in-PR vs stacked follow-up.
-- [ ] Copilot at publish: default off, `--copilot` opt-in surfaced as a checkpoint option — confirm.
+- [x] plan-task PR behavior → **flip default to no-early-PR** (publish-early = opt-in `--draft-pr`); ships **in this PR**. Confirmed 2026-06-15.
+- [x] Copilot at publish → **off by default**, `--copilot` opt-in at the publish checkpoint. Confirmed 2026-06-15.
+- [ ] AGENTS.md "Plan-first workflow" wording tweak — confirm exact change with user before editing (instruction file).

--- a/.agent/work-plans/issue-492/progress.md
+++ b/.agent/work-plans/issue-492/progress.md
@@ -87,3 +87,24 @@ issue: 492
 - [ ] (suggestion) Reconcile plan prose "adjust review-plan default resolution" with "No change needed" Files-to-Change row — `.agent/work-plans/issue-492/plan.md:120-122`
 - [ ] (suggestion) Clarify what `--copilot` consumes at the publish step (push + `gh pr create` only) — `.claude/skills/run-issue/SKILL.md` (Publish step)
 - [ ] (suggestion) Confirm `Agent`-tool availability in container mode for the review-code fan-out path — `.claude/skills/run-issue/SKILL.md:46-48`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-16 02:21 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-492 at `29fafef`
+**Mode**: pre-push
+**Depth**: Deep (reason: 455 changed lines ≥200; multiple governance override-trigger files — SKILL.md / knowledge / instruction files)
+**Must-fix**: 2 | **Suggestions**: 4
+
+Round 2. Prior round-1 must-fixes (entry-type routing ambiguity, `--type` filter contradiction) verified **resolved** against `progress_read.py` + `dispatch_subagent.sh`.
+
+### Findings
+- [ ] (must-fix) Dangling `$DRAFT_PR` var: `[ -n "$DRAFT_PR" ] && git push` tests a never-set var (gate is the `--draft-pr` flag everywhere else), so the push is silently skipped even with `--draft-pr` — contradicts step 7 + step 8 prose — `.claude/skills/plan-task/SKILL.md:266`
+- [ ] (must-fix) SKILL claims `## Local Review` (no parenthetical) "appears only as the abbreviation in skill_workflows.md … not routed on" — but it is the real canonical heading `review-code` writes in post-PR mode (`review-code/SKILL.md:872`); decision table has no row for it. Clarify pre-push-only dispatch or add a post-PR row — `.claude/skills/run-issue/SKILL.md:109-112`
+- [ ] (suggestion) `(PR published)` table state not determinable from last entry (Publish step writes no progress.md entry); a re-run could double-publish — document out-of-band tracking or write a publish marker — `.claude/skills/run-issue/SKILL.md:102,140-160`
+- [ ] (suggestion) Field path omits the `no-commit-to-branch` hook caveat (AGENTS.md § Field Mode); add a one-line pointer (never `--no-verify`) — `.claude/skills/run-issue/SKILL.md:157-160`
+- [ ] (suggestion) Note in PR body that 3 instruction (adapter) files were edited (additive list-only; consequence-map ripple) so the "Ask First" touch is visible — PR body
+- [ ] (suggestion) Forward-compat: "table is unchanged" for a future `implement` skill doesn't hold — a bare `## Implementation` (not preceded by `## Integrated Review`) has no row (unreachable today) — `.claude/skills/run-issue/SKILL.md:114-122`

--- a/.agent/work-plans/issue-492/progress.md
+++ b/.agent/work-plans/issue-492/progress.md
@@ -69,3 +69,21 @@ issue: 492
 - [x] (review-plan sugg) decision-table row for PR-published ⇒ triage-reviews; `## Local Review (Pre-Push)` variant-matching rule; `worktree_create.sh --plan-file` noted as equivalent publish-early opt-in.
 - [x] skill_workflows.md driver note + Skill Index row; run-issue added to all 3 adapters.
 - [x] review-plan + AGENTS.md confirmed **no change needed** (PR-less-capable / already conditional).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-15 22:26 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-492 at `64d2e83`
+**Mode**: pre-push
+**Depth**: Deep (reason: 398 changed lines ≥200; 7 governance override-trigger files)
+**Must-fix**: 2 | **Suggestions**: 3
+
+### Findings
+- [ ] (must-fix) `## Local Review` vs `## Local Review (Pre-Push)` routing ambiguous — post-PR re-review can match the pre-push publish row / no post-publish entry to key on (mitigated by always-on publish checkpoint) — `.claude/skills/run-issue/SKILL.md:54-62`
+- [ ] (must-fix) `progress_read.py --type "<Entry Type>"` read command contradicts the prefix-matching rule; `--type "Local Review"` misses `## Local Review (Pre-Push)` — use the dispatcher's `startswith` approach — `.claude/skills/run-issue/SKILL.md:56,59-62`
+- [ ] (suggestion) Reconcile plan prose "adjust review-plan default resolution" with "No change needed" Files-to-Change row — `.agent/work-plans/issue-492/plan.md:120-122`
+- [ ] (suggestion) Clarify what `--copilot` consumes at the publish step (push + `gh pr create` only) — `.claude/skills/run-issue/SKILL.md` (Publish step)
+- [ ] (suggestion) Confirm `Agent`-tool availability in container mode for the review-code fan-out path — `.claude/skills/run-issue/SKILL.md:46-48`

--- a/.agent/work-plans/issue-492/progress.md
+++ b/.agent/work-plans/issue-492/progress.md
@@ -52,3 +52,20 @@ issue: 492
 - [ ] (good) Claim #3 (orchestrator needs no `skill_entry_type` row) verified — `dispatch_subagent.sh:53-62` map has no `run-issue` case; the driver is never dispatched as a phase.
 - [ ] (good) ADR-0011 field-mode + never-auto-push guarantee solid: checkpoint before every push/PR/merge, publish branches on `field_mode.sh` (push, no PR/Copilot). — `plan.md:42-57`
 - [ ] (good) Shared-`## Implementation` disambiguation (route by preceding entry) matches the address-findings note at `address-findings/SKILL.md:37-42`. — `plan.md:36`
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-15 15:10 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Branch**: feature/issue-492 at `7ea516b`
+**Addressed**: `## Plan Review` (approve-with-suggestions) — all 4 findings folded into the plan + implemented.
+**Commits**: `7ea516b` (orchestrator + plan-task flip + ripple + adapters)
+
+### Actions
+- [x] New `.claude/skills/run-issue/SKILL.md` — decision table, checkpoints, shared-`## Implementation` disambiguation, entry-type variant matching, field-mode-aware local-first publish, Copilot opt-in.
+- [x] plan-task flipped to local-first: `--draft-pr` opt-in; step 7 optional, step 8 conditional push, step 9 + Plan Authored template + During-implementation prose updated.
+- [x] (review-plan must-fix) review-issue:272 corrected.
+- [x] (review-plan sugg) decision-table row for PR-published ⇒ triage-reviews; `## Local Review (Pre-Push)` variant-matching rule; `worktree_create.sh --plan-file` noted as equivalent publish-early opt-in.
+- [x] skill_workflows.md driver note + Skill Index row; run-issue added to all 3 adapters.
+- [x] review-plan + AGENTS.md confirmed **no change needed** (PR-less-capable / already conditional).

--- a/.agent/work-plans/issue-492/progress.md
+++ b/.agent/work-plans/issue-492/progress.md
@@ -108,3 +108,20 @@ Round 2. Prior round-1 must-fixes (entry-type routing ambiguity, `--type` filter
 - [ ] (suggestion) Field path omits the `no-commit-to-branch` hook caveat (AGENTS.md § Field Mode); add a one-line pointer (never `--no-verify`) — `.claude/skills/run-issue/SKILL.md:157-160`
 - [ ] (suggestion) Note in PR body that 3 instruction (adapter) files were edited (additive list-only; consequence-map ripple) so the "Ask First" touch is visible — PR body
 - [ ] (suggestion) Forward-compat: "table is unchanged" for a future `implement` skill doesn't hold — a bare `## Implementation` (not preceded by `## Integrated Review`) has no row (unreachable today) — `.claude/skills/run-issue/SKILL.md:114-122`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-16 03:00 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: approved
+
+**Branch**: feature/issue-492 at `da56e4a`
+**Mode**: pre-push
+**Depth**: Deep (reason: governance override-trigger files — SKILL/knowledge/instruction files; new orchestrator + plan-task default flip)
+**Must-fix**: 0 | **Suggestions**: 2
+
+Round 3. Both round-2 must-fixes verified **resolved** against source: (1) `$DRAFT_PR` dead var fully removed from plan-task — push now flag-gated by prose, consistent with step 7; (2) post-PR `## Local Review` fallback row present + accurate vs `review-code/SKILL.md:871`. One Lens-B "must-fix" (re-add `if [ -n "$DRAFT_PR" ]`) **dismissed as false positive** — it would regress the round-2 fix. Plan in sync; no scope creep.
+
+### Findings
+- [ ] (suggestion) Note the 3 instruction/adapter-file edits in the PR body at publish (Ask First governance touch; additive list-only) — PR body
+- [ ] (suggestion) `skill_workflows.md` handoff table abbreviates `## Local Review` (drops `(Pre-Push)`); already documented as intentional shorthand in run-issue SKILL — optional — `.agent/knowledge/skill_workflows.md:88`

--- a/.agent/work-plans/issue-492/progress.md
+++ b/.agent/work-plans/issue-492/progress.md
@@ -20,3 +20,16 @@ issue: 492
 - [ ] (plan-task) Enumerate checkpoints precisely (post Issue Review iff open Qs; always post Plan Review; post each Integrated Review w/ findings; before any push/PR/merge).
 - [ ] (consequences) Adapter skill lists + skill_workflows.md.
 - [ ] Note overlap with the pending #491 de-dup follow-up so findings aren't double-handled.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-15 14:20 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-492/plan.md` at `HEAD`
+**PR**: https://github.com/rolker/ros2_agent_workspace/pull/525 (`[PLAN]` prefix)
+**Phases**: single (possible stacked plan-task tweak — open question 1)
+
+### Open questions
+- [ ] plan-task PR-deferral mechanism: (a) suppress signal for orchestrated runs [recommended] vs (b) flip default to no-early-PR; and in-PR vs stacked follow-up.
+- [ ] Copilot at publish: default off, `--copilot` opt-in surfaced as a checkpoint option — confirm.

--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -8,8 +8,15 @@ description: Generate a principles-aware work plan for an issue. Saves to `.agen
 ## Usage
 
 ```
-/plan-task <issue-number>
+/plan-task <issue-number> [--draft-pr]
 ```
+
+By default `plan-task` keeps the work **local** — it commits the plan to the
+feature branch but does **not** push or open a PR (local-first, #492; the
+`/run-issue` orchestrator opens the PR at the end). Pass **`--draft-pr`** to
+publish an early `[PLAN]` draft PR now (the standalone "publish early" path;
+`worktree_create.sh --plan-file` is the equivalent opt-in at worktree-creation
+time).
 
 ## Overview
 
@@ -161,11 +168,18 @@ Step 8 (progress.md) uses the same pattern; both commits land on
 `feature/issue-<N>` and would otherwise trip the `check_pr_authors.py`
 CI check (Mechanism C from [#468](https://github.com/rolker/ros2_agent_workspace/issues/468)).
 
-### 7. Create or update a draft PR
+### 7. (Opt-in) Create or update a draft PR
 
-Push the branch and create (or update) a draft PR with a `[PLAN]` title
-prefix and the plan as the body. The prefix prevents agents from confusing
-the PR number with the issue number.
+**Skip this step unless `--draft-pr` was passed.** By default plan-task is
+local-first: the plan is committed to the branch (step 6) and that is enough for
+`review-plan` (which reads the plan via `--issue <N>` / the local file) and for
+the `/run-issue` orchestrator, which pushes and opens the real PR at the end.
+The branch is **not pushed** by default.
+
+When `--draft-pr` is passed (or the worktree was created with
+`worktree_create.sh --plan-file`), push the branch and create (or update) a
+draft PR with a `[PLAN]` title prefix and the plan as the body. The prefix
+prevents agents from confusing the PR number with the issue number.
 
 ```bash
 # Push current branch (name may vary: feature/issue-<N> or feature/ISSUE-<N>-<desc>)
@@ -227,7 +241,7 @@ Append:
 **By**: <agent name> (<model>)
 
 **Plan**: `.agent/work-plans/issue-<N>/plan.md` at `<short-sha-of-plan-commit>`
-**PR**: <draft-PR-URL> (`[PLAN]` prefix)
+**Branch**: <branch-name> at `<short-sha>`   <!-- default; or **PR**: <draft-PR-URL> (`[PLAN]` prefix) when --draft-pr published one -->
 **Phases**: <count, if the plan describes a stacked-PR breakdown; else "single">
 
 ### Open questions
@@ -239,14 +253,17 @@ under that header so the section stays uniformly parseable per
 ADR-0013's checkbox-list schema:
 `- [ ] No open questions — plan is review-plan-ready.`
 
-Commit and push:
+Commit (and push only with `--draft-pr`):
 
 ```bash
 git add .agent/work-plans/issue-<N>/progress.md
 git -c user.name="$AGENT_NAME" \
     -c user.email="$AGENT_EMAIL" \
     commit -m "progress: plan authored for #<N>"
-git push
+# Push ONLY when --draft-pr was used (step 7 published a PR this commit must
+# appear on). In the default local-first flow nothing is pushed here — the
+# orchestrator (or a later --draft-pr / manual push) publishes.
+[ -n "$DRAFT_PR" ] && git push
 ```
 
 The per-invocation `-c` overrides are required by
@@ -254,10 +271,11 @@ The per-invocation `-c` overrides are required by
 agents run each bash invocation in a fresh subshell, so the env
 exports from `set_git_identity_env.sh` aren't reliable here.
 
-The push is required — step 7 already pushed the branch (whether it
-created a new draft PR or updated an existing one), so the new commit
-needs its own push to appear on the PR alongside the plan. Without it
-the report (step 9) would cite a SHA that's only local.
+The `## Plan Authored` entry records a **`**Branch**: <name> at <sha>`** line by
+default, or a **`**PR**: <url>`** line when `--draft-pr` published one. With
+`--draft-pr`, the push above is required so the progress commit appears on the
+PR alongside the plan; without it, the commit stays local until the orchestrator
+publishes.
 
 ### 9. Report to user
 
@@ -265,7 +283,9 @@ Summarize:
 - What the plan proposes
 - Which principles and ADRs were considered
 - Any open questions that need input
-- Link to the draft PR
+- Link to the draft PR **if `--draft-pr` opened one**; otherwise state the plan
+  is committed locally on the branch (no PR yet — the orchestrator opens it at
+  the end, or re-run with `--draft-pr` to publish early)
 - **Cite the `progress.md` commit SHA from step 8** (`progress: plan
   authored for #<N>`) so the report references the durable timeline
   artifact, not just the PR
@@ -299,7 +319,8 @@ pausing at user checkpoints. This step only emits this prompt and its
 ## During implementation
 
 The `plan-task` skill's primary artifact is the committed plan file
-created in steps 5–6; step 7 publishes that plan into a draft PR.
+created in steps 5–6 (step 7 optionally publishes it into a draft PR with
+`--draft-pr`; otherwise it stays local until the orchestrator publishes).
 Implementation then proceeds on the same branch — and typically deviates
 from the plan: types get refined, functions change signatures, a "pure
 logic" module picks up a dependency. Keep the plan in sync as this

--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -253,18 +253,27 @@ under that header so the section stays uniformly parseable per
 ADR-0013's checkbox-list schema:
 `- [ ] No open questions — plan is review-plan-ready.`
 
-Commit (and push only with `--draft-pr`):
+Commit the progress entry:
 
 ```bash
 git add .agent/work-plans/issue-<N>/progress.md
 git -c user.name="$AGENT_NAME" \
     -c user.email="$AGENT_EMAIL" \
     commit -m "progress: plan authored for #<N>"
-# Push ONLY when --draft-pr was used (step 7 published a PR this commit must
-# appear on). In the default local-first flow nothing is pushed here — the
-# orchestrator (or a later --draft-pr / manual push) publishes.
-[ -n "$DRAFT_PR" ] && git push
 ```
+
+**Then push only if `--draft-pr` was passed** (step 7 published a PR this commit
+must appear on) — same flag gate as step 7, decided from the invocation, not a
+shell variable:
+
+```bash
+# Run ONLY in the --draft-pr path:
+git push
+```
+
+In the default local-first flow nothing is pushed here — the branch stays local
+and the `/run-issue` orchestrator (or a later manual `--draft-pr` / push)
+publishes.
 
 The per-invocation `-c` overrides are required by
 [AGENTS.md § Agent Commit Identity](../../../AGENTS.md#agent-commit-identity);

--- a/.claude/skills/review-issue/SKILL.md
+++ b/.claude/skills/review-issue/SKILL.md
@@ -268,8 +268,11 @@ issues — same logic as `plan-task` step 4). Create the worktree:
   ```
 
 `worktree_create.sh` does NOT open a draft PR when invoked without
-`--plan-file`; only the worktree + branch are created. A draft PR
-will follow when `plan-task` runs.
+`--plan-file`; only the worktree + branch are created. `plan-task` then
+commits the plan to the branch but, by default, does **not** open a PR
+(local-first, #492) — a draft PR follows only if `plan-task` is run with
+`--draft-pr` (or the worktree was created with `--plan-file`); otherwise
+the `/run-issue` orchestrator opens the real PR at the end.
 
 **8b. Append the entry.** Create the parent directory if needed
 (`review-issue` typically runs *before* `plan-task`, so

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -105,11 +105,18 @@ Read the **last** progress.md entry; act per its type + verdict:
 | `## Implementation` **preceded by** `## Integrated Review` | — | dispatch `review-code` (re-review) | — |
 
 **`## Local Review (Pre-Push)` is the exact heading** every pre-push
-`review-code` writes; the table keys on it verbatim. `## Local Review` (no
-parenthetical) appears only as the abbreviation in `skill_workflows.md`'s
-handoff table — it is *not* a separate entry the orchestrator routes on, and it
-is not the same canonical type (see "How phases are dispatched" above). Route on
-`## Local Review (Pre-Push)`.
+`review-code` writes, and **the orchestrator only ever dispatches `review-code`
+in pre-push mode** — so within this flow that is the only Local-Review heading
+produced, and the table keys on it verbatim. `## Local Review` (no parenthetical)
+is review-code's real **post-PR** heading (`review-code/SKILL.md:864-866, 872`),
+*not* a mere abbreviation — but the orchestrator never drives post-PR
+`review-code`: post-PR review feedback is consumed by `triage-reviews`, which
+writes `## Integrated Review`. (`skill_workflows.md`'s handoff table does
+abbreviate the pre-push entry as `## Local Review`; that is a doc shorthand, not
+the routed heading.) **Fallback**: if a bare `## Local Review` (post-PR) is
+nonetheless the last entry — e.g. someone ran `/review-code <PR>` by hand —
+route it like the `## Integrated Review` rows (open findings ⇒ `address-findings`;
+none ⇒ merge checkpoint).
 
 **Shared `## Implementation` routing key**: `## Implementation` is written by
 both `address-findings` and a future `implement` skill. Disambiguate by the
@@ -119,7 +126,11 @@ an address-findings pass, so the next action is a re-review.
 **Implementation phase**: there is no `implement` skill yet. After
 `## Plan Review`, the host runs implementation **inline** (edits, commits,
 plan-sync), then dispatches `review-code`. When an `implement` skill lands,
-swap the inline step for a dispatch — the table is unchanged.
+swap the inline step for a dispatch — **and add a table row** for a bare
+`## Implementation` *not* preceded by `## Integrated Review` (a fresh
+implementation pass ⇒ dispatch `review-code`). That state is unreachable today
+(inline implementation writes no such entry before the host itself runs
+`review-code`), so the table has no row for it yet.
 
 ## Checkpoints
 
@@ -143,6 +154,19 @@ Reached when a `## Local Review (Pre-Push)` is `approved` and the user confirms
 at the publish checkpoint. Branch on origin via
 [`field_mode.sh`](../../.agent/scripts/field_mode.sh):
 
+**Idempotency guard (publish writes no progress.md entry).** The publish step
+does **not** append an entry, so after a successful publish the last entry is
+*still* `## Local Review (Pre-Push)` (`approved`) — the same state that triggered
+publish. A naive re-run would double-publish. Before publishing, check for an
+already-open real PR on the branch and, if found, treat the work as published —
+skip to the `triage-reviews` wait instead of pushing/opening again:
+
+```bash
+# A non-[PLAN] open PR on this branch ⇒ already published.
+gh pr list --head "$(git branch --show-current)" --state open \
+    --json url,title --jq '.[] | select(.title | startswith("[PLAN]") | not) | .url'
+```
+
 - **GitHub-origin (dev mode)**: `git push`, then `gh pr create` (drop any
   `[PLAN]` framing — this is the real PR). After the PR accrues review comments,
   resume at the `triage-reviews` row.
@@ -157,7 +181,10 @@ at the publish checkpoint. Branch on origin via
 - **Field mode (gitcloud / non-GitHub origin)**: push to the field remote with
   **no PR and no Copilot** (the field workflow — see AGENTS.md § Field Mode).
   The lifecycle ends at the push; reconciliation to GitHub is a later dev-side
-  `/import-field-changes`.
+  `/import-field-changes`. **Hook caveat**: if the field repo lists its default
+  branch in a `no-commit-to-branch` pre-commit hook, commits fail there — fix the
+  project's hook config (drop its default branch from the list), **never
+  `--no-verify`** (AGENTS.md § Field Mode).
 
 Never `git push`, open a PR, or merge without having passed the corresponding
 checkpoint.

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -43,23 +43,48 @@ Each phase runs in a **fresh-context sub-agent** via the dispatcher:
 .agent/scripts/dispatch_subagent.sh --mode <in-process|container> --issue <N> --skill <phase>
 ```
 
-- **in-process** (default) for reviews and short phases — fast, same context root.
+- **in-process** (default) for reviews and short phases — fast, same context
+  root. In-process dispatch spawns the phase via Claude Code's **`Agent` tool**,
+  which exists in the **host** session but **not** inside a headless container.
+  This is precisely why `run-issue` is a *host* orchestrator (see Scope E): run
+  it on the host, where it can fan phases out in-process; it is never itself
+  dispatched into a container. (Non-Claude host runtimes lack the `Agent` tool
+  too — there, drive the phases manually or use `--mode container`.)
 - **container** when isolation is wanted (e.g. running the full review-code
-  specialist fan-out, or implementation that benefits from a clean OS).
+  specialist fan-out, or implementation that benefits from a clean OS). Container
+  mode is headless and self-contained, so it needs no host `Agent` tool.
 
 The dispatcher already verifies the sub-agent wrote the expected entry type
 (PRE/POST entry-count delta — `dispatch_subagent.sh:216-282`); treat a `FAILED`
 report as a stop-and-surface, not a silent retry. After each dispatch, read the
-**newest** matching entry:
+timeline and act on the **last** entry — that is the one the phase just wrote:
 
 ```bash
-python3 .agent/scripts/progress_read.py .agent/work-plans/issue-<N>/progress.md --type "<Entry Type>"
+# Whole timeline; `.entries[-1]` is the just-written entry, whatever its type.
+python3 .agent/scripts/progress_read.py .agent/work-plans/issue-<N>/progress.md
 ```
 
-**Entry-type matching is by base type / prefix, not exact string.** `review-code`
-pre-push writes `## Local Review (Pre-Push)`; `skill_workflows.md`'s handoff
-table abbreviates it `## Local Review`. Match the same way the dispatcher does
-(`dispatch_subagent.sh:217-235`) so the variant doesn't slip past.
+To pull a *specific* phase's entry later (e.g. an Integrated Review's findings),
+filter with `--type`, **passing the full canonical entry type verbatim** — not
+an abbreviation:
+
+```bash
+python3 .agent/scripts/progress_read.py .agent/work-plans/issue-<N>/progress.md \
+    --type "Local Review (Pre-Push)"
+```
+
+**`Local Review (Pre-Push)` is its own canonical type, distinct from `Local
+Review`.** The parenthetical is part of the name (`progress_read.py`
+`CANONICAL_TYPES`), and `--type` matches on the full heading / `base_type`
+*exactly* — so `--type "Local Review"` will **not** match the `(Pre-Push)`
+variant. (The dispatcher's PRE/POST gate, by contrast, adds a `startswith`
+prefix match in its own one-liner — `dispatch_subagent.sh:225-235` — which is
+why a pre-push dispatch resolved as `Local Review` still counts the
+`(Pre-Push)` entry. The `--type` filter does not have that fallback; pass the
+real type.) Pre-push `review-code` always writes `## Local Review (Pre-Push)`;
+`skill_workflows.md`'s handoff table abbreviates it `## Local Review`, but the
+orchestrator routes on the real heading. When you need either Local Review
+variant, pass both (`--type` is repeatable).
 
 ## Decision table (the spine)
 
@@ -78,6 +103,13 @@ Read the **last** progress.md entry; act per its type + verdict:
 | `## Integrated Review` | open findings remain | dispatch `address-findings` | **yes** (non-trivial findings) |
 | `## Integrated Review` | none | merge | **yes** (before merge) |
 | `## Implementation` **preceded by** `## Integrated Review` | — | dispatch `review-code` (re-review) | — |
+
+**`## Local Review (Pre-Push)` is the exact heading** every pre-push
+`review-code` writes; the table keys on it verbatim. `## Local Review` (no
+parenthetical) appears only as the abbreviation in `skill_workflows.md`'s
+handoff table — it is *not* a separate entry the orchestrator routes on, and it
+is not the same canonical type (see "How phases are dispatched" above). Route on
+`## Local Review (Pre-Push)`.
 
 **Shared `## Implementation` routing key**: `## Implementation` is written by
 both `address-findings` and a future `implement` skill. Disambiguate by the
@@ -112,10 +144,16 @@ at the publish checkpoint. Branch on origin via
 [`field_mode.sh`](../../.agent/scripts/field_mode.sh):
 
 - **GitHub-origin (dev mode)**: `git push`, then `gh pr create` (drop any
-  `[PLAN]` framing — this is the real PR). **Copilot is off by default**; the
-  publish checkpoint offers `--copilot` as a per-run opt-in (the standing quota
-  decision — see review-code). After the PR accrues review comments, resume at
-  the `triage-reviews` row.
+  `[PLAN]` framing — this is the real PR). After the PR accrues review comments,
+  resume at the `triage-reviews` row.
+  - **Copilot opt-in scope**: `--copilot` is a **`review-code` flag** governing
+    its Copilot Adversarial specialist — it is *not* consumed by `git push` or
+    `gh pr create`. **Off by default** (the standing quota decision — see
+    review-code). The publish checkpoint surfaces it as a per-run choice because
+    that is where the user decides whether to spend Premium quota on cross-model
+    coverage for this PR; if opted in, pass `--copilot` to the `review-code`
+    re-runs (pre-push and any post-triage re-review), not to the publish
+    commands.
 - **Field mode (gitcloud / non-GitHub origin)**: push to the field remote with
   **no PR and no Copilot** (the field workflow — see AGENTS.md § Field Mode).
   The lifecycle ends at the push; reconciliation to GitHub is a later dev-side

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: run-issue
+description: Host orchestrator that drives an issue through the full per-issue lifecycle — dispatches each phase (review-issue → plan-task → review-plan → implement → review-code → triage-reviews → address-findings) as a fresh-context sub-agent, reads each phase's progress.md entry to choose the next action, and pauses at user checkpoints. Local-first: the PR is created at the end, never auto-pushes or auto-merges without confirmation.
+---
+
+# Run Issue
+
+## Usage
+
+```
+/run-issue <issue-number>
+```
+
+## Overview
+
+`run-issue` is the **host orchestrator** for the composable-timeline lifecycle
+(#470 / #481 phase C). It does not do review or implementation work itself —
+it *drives*: dispatch a phase via `dispatch_subagent.sh`, read the typed
+`progress.md` entry that phase wrote, decide the next action from the decision
+table below, and pause at `AskUserQuestion` checkpoints at every juncture where
+a human should weigh in or where work would otherwise publish.
+
+It is the automation of the hand-driven lifecycle — the same sequence an
+operator runs by issuing `/review-issue`, `/plan-task`, … one at a time.
+
+**This skill is the driver, not a dispatched phase.** It is never the target of
+`dispatch_subagent.sh` and has no `skill_entry_type` row; it *calls* the
+dispatcher for the other skills.
+
+**Principles this skill exists to honor:**
+- **Human control** — checkpoints gate every push, PR creation, and merge.
+  Nothing leaves the local machine without an explicit confirmation.
+- **Transparency** — the decision table is explicit; each step says what entry
+  it read and what it will dispatch next.
+- **Local-first** — the PR is created **at the end**, after a clean local
+  review (not early). `plan-task` no longer opens an early PR by default.
+
+## How phases are dispatched
+
+Each phase runs in a **fresh-context sub-agent** via the dispatcher:
+
+```bash
+.agent/scripts/dispatch_subagent.sh --mode <in-process|container> --issue <N> --skill <phase>
+```
+
+- **in-process** (default) for reviews and short phases — fast, same context root.
+- **container** when isolation is wanted (e.g. running the full review-code
+  specialist fan-out, or implementation that benefits from a clean OS).
+
+The dispatcher already verifies the sub-agent wrote the expected entry type
+(PRE/POST entry-count delta — `dispatch_subagent.sh:216-282`); treat a `FAILED`
+report as a stop-and-surface, not a silent retry. After each dispatch, read the
+**newest** matching entry:
+
+```bash
+python3 .agent/scripts/progress_read.py .agent/work-plans/issue-<N>/progress.md --type "<Entry Type>"
+```
+
+**Entry-type matching is by base type / prefix, not exact string.** `review-code`
+pre-push writes `## Local Review (Pre-Push)`; `skill_workflows.md`'s handoff
+table abbreviates it `## Local Review`. Match the same way the dispatcher does
+(`dispatch_subagent.sh:217-235`) so the variant doesn't slip past.
+
+## Decision table (the spine)
+
+Read the **last** progress.md entry; act per its type + verdict:
+
+| Last entry | Condition | Next action | Checkpoint |
+|---|---|---|---|
+| (none) | — | dispatch `review-issue` | — |
+| `## Issue Review` | open-question actions present | surface the open Qs, then `plan-task` | **yes** (iff open Qs) |
+| `## Issue Review` | none | dispatch `plan-task` | — |
+| `## Plan Authored` | — | dispatch `review-plan` | — |
+| `## Plan Review` | any verdict | run implementation, then `review-code` | **always** |
+| `## Local Review (Pre-Push)` | `approved` | push → open PR (or field-push) | **yes** (before publish) |
+| `## Local Review (Pre-Push)` | `changes-requested` | address inline, re-dispatch `review-code` | maybe |
+| (PR published) | review comments landed | dispatch `triage-reviews` | **yes** (async wait) |
+| `## Integrated Review` | open findings remain | dispatch `address-findings` | **yes** (non-trivial findings) |
+| `## Integrated Review` | none | merge | **yes** (before merge) |
+| `## Implementation` **preceded by** `## Integrated Review` | — | dispatch `review-code` (re-review) | — |
+
+**Shared `## Implementation` routing key**: `## Implementation` is written by
+both `address-findings` and a future `implement` skill. Disambiguate by the
+**preceding** entry — a `## Integrated Review` immediately before means this was
+an address-findings pass, so the next action is a re-review.
+
+**Implementation phase**: there is no `implement` skill yet. After
+`## Plan Review`, the host runs implementation **inline** (edits, commits,
+plan-sync), then dispatches `review-code`. When an `implement` skill lands,
+swap the inline step for a dispatch — the table is unchanged.
+
+## Checkpoints
+
+Use `AskUserQuestion` — **never block silently**. Mandatory checkpoints:
+
+1. **After `## Issue Review`** — only if it left open-question actions; surface
+   them and get answers before `plan-task`.
+2. **After `## Plan Review`** — always; the plan + its verdict are the last
+   cheap place to redirect.
+3. **After each `## Integrated Review` with non-trivial findings** — confirm the
+   fix approach before dispatching `address-findings`.
+4. **Before any push, PR creation, or merge** — local-first: the user confirms
+   that work publishes.
+
+Between checkpoints the orchestrator proceeds automatically, reporting each
+transition (entry read → next dispatch).
+
+## Publish step (local-first, field-mode aware)
+
+Reached when a `## Local Review (Pre-Push)` is `approved` and the user confirms
+at the publish checkpoint. Branch on origin via
+[`field_mode.sh`](../../.agent/scripts/field_mode.sh):
+
+- **GitHub-origin (dev mode)**: `git push`, then `gh pr create` (drop any
+  `[PLAN]` framing — this is the real PR). **Copilot is off by default**; the
+  publish checkpoint offers `--copilot` as a per-run opt-in (the standing quota
+  decision — see review-code). After the PR accrues review comments, resume at
+  the `triage-reviews` row.
+- **Field mode (gitcloud / non-GitHub origin)**: push to the field remote with
+  **no PR and no Copilot** (the field workflow — see AGENTS.md § Field Mode).
+  The lifecycle ends at the push; reconciliation to GitHub is a later dev-side
+  `/import-field-changes`.
+
+Never `git push`, open a PR, or merge without having passed the corresponding
+checkpoint.
+
+## No auto-chaining beyond the operator (Scope E)
+
+`run-issue` is the *single* orchestrator. The phase skills never dispatch each
+other — they emit a handoff prompt + progress.md entry, and `run-issue` reads
+the entry and drives the next step. Sub-agents do not spawn sub-agents. This
+keeps user-checkpoint control at one layer.
+
+## Guidelines
+
+- **Read the entry, don't assume the outcome** — always re-read the newest
+  progress.md entry after a dispatch; a phase may have failed, deferred, or
+  surfaced open questions.
+- **Surface, don't swallow** — a `FAILED` dispatch report, an unexpected entry
+  type, or a missing entry is a stop-and-ask, never a silent retry.
+- **One issue, linear** — single-issue pipeline; concurrent multi-issue
+  orchestration is a non-goal (per #481).
+- **Stay local until told otherwise** — the default posture is "keep it on this
+  machine"; publishing is always a confirmed, explicit step.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,7 +102,7 @@ These are plain markdown — not Claude Code-specific. When asked to review an
 issue, plan a task, review a PR, brainstorm, or run research, read the
 corresponding SKILL.md and follow its steps.
 
-Available workflow skills: `review-issue`, `plan-task`, `review-plan`,
+Available workflow skills: `run-issue`, `review-issue`, `plan-task`, `review-plan`,
 `review-code`, `brainstorm`, `research`, `audit-workspace`, `audit-project`,
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
 `triage-reviews`, `address-findings`, `skill-importer`, `document-package`, `issue-triage`,


### PR DESCRIPTION
Closes #492. Part of #481 (phase C of #470).

## What

Adds `.claude/skills/run-issue/SKILL.md` — the **host orchestrator** for the
composable-timeline lifecycle. It drives an issue through
review-issue → plan-task → review-plan → implement → review-code →
triage-reviews → address-findings by dispatching each phase as a fresh-context
sub-agent (via `dispatch_subagent.sh`), reading the typed `progress.md` entry
each phase writes, and choosing the next action from an explicit decision table.
It pauses at `AskUserQuestion` checkpoints at every juncture where a human should
weigh in or where work would otherwise publish. No new script — it reuses
`dispatch_subagent.sh` + `progress_read.py`.

**Local-first flip**: `plan-task` no longer opens an early `[PLAN]` draft PR by
default — the plan is committed to the branch and publishing early becomes an
opt-in `--draft-pr` flag. The orchestrator pushes and opens the real PR at the
end, after a clean local review.

## Key design points

- **Decision table** keyed on the last `progress.md` entry (type + verdict).
- **Shared `## Implementation` routing** disambiguated by the preceding entry
  (Integrated Review before ⇒ address-findings pass ⇒ re-review).
- **Pre-push-only `review-code` dispatch**; post-PR feedback flows through
  `triage-reviews` → `## Integrated Review`. A fallback rule handles a stray
  manual post-PR `## Local Review`.
- **Field-mode aware** (ADR-0011): gitcloud-origin repos push to the field
  remote with no PR / no Copilot; includes the `no-commit-to-branch` hook caveat.
- **Publish idempotency guard**: the publish step writes no entry, so it checks
  for an already-open non-`[PLAN]` PR before re-publishing.
- **Copilot opt-in** (`--copilot`) clarified as a `review-code` flag, off by
  default per the standing quota decision.

## Files changed

- `.claude/skills/run-issue/SKILL.md` — **new** orchestrator.
- `.claude/skills/plan-task/SKILL.md` — flipped to local-first (`--draft-pr`
  opt-in; conditional push; template + during-implementation prose).
- `.claude/skills/review-issue/SKILL.md` — line 272 corrected (plan-task no
  longer auto-opens a PR).
- `.agent/knowledge/skill_workflows.md` — `/run-issue` documented as the
  lifecycle driver + Skill Index row + local-first note.
- `.agent/work-plans/issue-492/plan.md`, `progress.md` — plan + lifecycle record.

**Instruction-file touch (governance note)**: three framework adapter files were
edited — `.github/copilot-instructions.md`,
`.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md`.
These are **additive, list-only** changes (adding `run-issue` to the skill
lists) — a consequence-map ripple of adding a workflow skill, not a behavioral
change to the "Ask First" instruction content. Flagged here so the touch is
visible to review.

## Review

Three rounds of pre-push `/review-code` (sandboxed container, Deep tier), all
findings resolved:
- Round 1 → changes-requested: entry-type matching precision (2 must-fix).
- Round 2 → changes-requested: dead `$DRAFT_PR` push guard in plan-task +
  post-PR `## Local Review` accuracy (2 must-fix).
- Round 3 → **approved**; both prior must-fixes verified resolved against source.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
