### PR TITLE
Deployment logging: generic dlog.sh helper — prompt-free + accurate timestamps (#515/#516)

### DIFF
--- a/.agent/knowledge/deployment_mode.md
+++ b/.agent/knowledge/deployment_mode.md
@@ -76,8 +76,12 @@ the skill puts the contract in context. The fuller treatment below explains
    durable lie the wrap-up integration and downstream analysis will trust;
    for an operator-reported event, `date`-stamp when you log it and mark
    their time `~HH:MM (operator-reported)`. (And `date '+…'`, not
-   `date | sed`.) The `start-deployment` skill provides a `dlog` helper that
-   bakes `date` into each entry so this is the easy path.
+   `date | sed`.) Use the committed `.agent/scripts/dlog.sh <logfile>
+   <message>` helper — it bakes `date` into each entry and, allowlisted
+   once (`Bash(.../dlog.sh:*)`), makes prompt-free logging the easy path.
+   The Edit tool is **not** a substitute: it dodges the prompt but cannot
+   run `date`, forcing a typed (inaccurate) time — the very failure this
+   rule prevents (see #515 / #516).
 7. **Sterile cockpit.** During live on-water ops, do *only* operation-essential
    work — no doc polish, refactors, or "while we're here" cleanups. Write
    them down for wrap-up.

--- a/.agent/knowledge/deployment_mode.md
+++ b/.agent/knowledge/deployment_mode.md
@@ -78,7 +78,8 @@ the skill puts the contract in context. The fuller treatment below explains
    their time `~HH:MM (operator-reported)`. (And `date '+…'`, not
    `date | sed`.) Use the committed `.agent/scripts/dlog.sh <logfile>
    <message>` helper — it bakes `date` into each entry and, allowlisted
-   once (`Bash(.../dlog.sh:*)`), makes prompt-free logging the easy path.
+   once (`Bash(<workspace_root>/.agent/scripts/dlog.sh:*)`), makes
+   prompt-free logging the easy path.
    The Edit tool is **not** a substitute: it dodges the prompt but cannot
    run `date`, forcing a typed (inaccurate) time — the very failure this
    rule prevents (see #515 / #516).

--- a/.agent/scripts/dlog.sh
+++ b/.agent/scripts/dlog.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# .agent/scripts/dlog.sh
+# Prompt-free, accurate-timestamp appender for deployment live-ops logging.
+#
+# Bakes the timestamp from `date` at WRITE time (never typed, never
+# approval-delayed) and appends one entry to a deployment log file. Allowlist
+# this ONE script -- Bash(.agent/scripts/dlog.sh:*) -- and every log entry is
+# then prompt-free AND carries a measured timestamp.
+#
+# Why a script (not the Edit tool): the Edit tool avoids per-entry permission
+# prompts (#516) but cannot run `date`, so the agent must TYPE the timestamp --
+# reintroducing the inaccurate / "durable lie" times that #515 exists to kill.
+# Only a shell can stamp the real write time. This helper does both: one
+# standing allowlist entry (prompt-free) + a measured `date` stamp (accurate).
+# Generic + committed, so it is NOT re-created per deployment (the abandoned
+# per-deployment dlog_<N>.sh approach #515 rightly flags as clunky).
+#
+# Usage:
+#   .agent/scripts/dlog.sh <logfile> <message...>
+#
+# Examples:
+#   .agent/scripts/dlog.sh docs/logs/2026/2026-06-20_dev_logs.md "in water; controls good"
+#   .agent/scripts/dlog.sh "$LOGFILE" "boat at dock (operator-reported ~12:35)"
+#
+# For an event you did NOT time yourself, let this stamp the real write time and
+# put the operator's reported time in the message text, e.g.
+# "... (operator-reported ~12:35)" -- never back-date the measured stamp.
+
+set -euo pipefail
+
+# Executed, not sourced.
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    echo "dlog.sh must be executed, not sourced" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+if [[ $# -lt 2 ]]; then
+    echo "usage: dlog.sh <logfile> <message...>" >&2
+    exit 2
+fi
+
+LOGFILE="$1"
+shift
+MSG="$*"
+
+if [[ ! -d "$(dirname "$LOGFILE")" ]]; then
+    echo "dlog.sh: log directory does not exist: $(dirname "$LOGFILE")" >&2
+    exit 1
+fi
+
+TS="$(date '+%Y-%m-%d %H:%M %:z')"
+printf '\n**%s** — %s\n' "$TS" "$MSG" >> "$LOGFILE"
+printf 'logged: %s — %s\n' "$TS" "$MSG"

--- a/.agent/scripts/dlog.sh
+++ b/.agent/scripts/dlog.sh
@@ -4,8 +4,8 @@
 #
 # Bakes the timestamp from `date` at WRITE time (never typed, never
 # approval-delayed) and appends one entry to a deployment log file. Allowlist
-# this ONE script -- Bash(.agent/scripts/dlog.sh:*) -- and every log entry is
-# then prompt-free AND carries a measured timestamp.
+# this ONE script -- Bash(<workspace_root>/.agent/scripts/dlog.sh:*) -- and
+# every log entry is then prompt-free AND carries a measured timestamp.
 #
 # Why a script (not the Edit tool): the Edit tool avoids per-entry permission
 # prompts (#516) but cannot run `date`, so the agent must TYPE the timestamp --
@@ -43,11 +43,20 @@ LOGFILE="$1"
 shift
 MSG="$*"
 
+# Reject an empty / whitespace-only message -- writing a contentless entry is a
+# silent live-ops logging failure (the contract is "fail loud on bad usage").
+if [[ ! "$MSG" =~ [^[:space:]] ]]; then
+    echo "dlog.sh: empty log message" >&2
+    exit 2
+fi
+
 if [[ ! -d "$(dirname "$LOGFILE")" ]]; then
     echo "dlog.sh: log directory does not exist: $(dirname "$LOGFILE")" >&2
     exit 1
 fi
 
+# %:z (colon timezone offset, e.g. -04:00) is a GNU coreutils `date` extension --
+# fine on the Linux dev/field hosts; would emit a literal "%:z" on BSD/macOS.
 TS="$(date '+%Y-%m-%d %H:%M %:z')"
 printf '\n**%s** — %s\n' "$TS" "$MSG" >> "$LOGFILE"
 printf 'logged: %s — %s\n' "$TS" "$MSG"

--- a/.agent/scripts/tests/test_dlog.sh
+++ b/.agent/scripts/tests/test_dlog.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# .agent/scripts/tests/test_dlog.sh
+# Tests the prompt-free deployment log appender (.agent/scripts/dlog.sh).
+#
+# The whole point of dlog.sh is to be BOTH prompt-free (one allowlist entry)
+# AND accurately stamped (a measured `date`, not a typed time) — resolving
+# #515 (timestamp accuracy) + #516 (per-entry prompts). These cases pin that
+# it appends a well-formed, timestamped entry and fails loudly on bad usage.
+#
+# Run: bash .agent/scripts/tests/test_dlog.sh
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DLOG="$SCRIPT_DIR/../dlog.sh"
+TEST_PASS=0
+TEST_FAIL=0
+
+pass() { echo "PASS: $1"; TEST_PASS=$((TEST_PASS + 1)); }
+fail() { echo "FAIL: $1"; TEST_FAIL=$((TEST_FAIL + 1)); }
+
+TMPD="$(mktemp -d)"
+trap 'rm -rf "$TMPD"' EXIT
+LOG="$TMPD/2026-01-01_dev_logs.md"
+: > "$LOG"
+
+# 1. appends a well-formed entry stamped with a real `date` value
+out=$("$DLOG" "$LOG" "boat in water" 2>&1); rc=$?
+if [ "$rc" -eq 0 ] \
+    && grep -qE '^\*\*[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2} [+-][0-9]{2}:[0-9]{2}\*\* ' "$LOG" \
+    && grep -q 'boat in water' "$LOG"; then
+    pass "appends a timestamped, well-formed entry"
+else
+    fail "appends a timestamped, well-formed entry (rc=$rc, out=$out)"
+fi
+
+# 2. multi-arg message is joined, not dropped
+"$DLOG" "$LOG" "in water" "(operator-reported ~12:35)" > /dev/null 2>&1
+if grep -qF 'in water (operator-reported ~12:35)' "$LOG"; then
+    pass "joins a multi-arg message"
+else
+    fail "joins a multi-arg message"
+fi
+
+# 3. appends rather than truncates (both entries present)
+if [ "$(grep -cE '^\*\*[0-9]' "$LOG")" -eq 2 ]; then
+    pass "appends rather than truncates"
+else
+    fail "appends rather than truncates"
+fi
+
+# 4. logfile but no message -> usage error, exit 2
+"$DLOG" "$LOG" > /dev/null 2>&1
+[ "$?" -eq 2 ] && pass "missing message exits 2" || fail "missing message exits 2"
+
+# 5. no args -> usage error, exit 2
+"$DLOG" > /dev/null 2>&1
+[ "$?" -eq 2 ] && pass "no args exits 2" || fail "no args exits 2"
+
+# 6. nonexistent log directory -> error, exit 1 (fail loud, don't create stray dirs)
+"$DLOG" "$TMPD/nope/x.md" "msg" > /dev/null 2>&1
+[ "$?" -eq 1 ] && pass "nonexistent log dir exits 1" || fail "nonexistent log dir exits 1"
+
+echo
+echo "dlog.sh tests: $TEST_PASS passed, $TEST_FAIL failed"
+[ "$TEST_FAIL" -eq 0 ]

--- a/.agent/scripts/tests/test_dlog.sh
+++ b/.agent/scripts/tests/test_dlog.sh
@@ -23,14 +23,17 @@ trap 'rm -rf "$TMPD"' EXIT
 LOG="$TMPD/2026-01-01_dev_logs.md"
 : > "$LOG"
 
-# 1. appends a well-formed entry stamped with a real `date` value
+# 1. appends an entry stamped with the CURRENT (measured) date -- not just any
+#    well-formed timestamp. A frozen/typed stamp (the exact #515 failure) would
+#    pass a format-only check; pinning today's date catches it.
+TODAY="$(date '+%Y-%m-%d')"
 out=$("$DLOG" "$LOG" "boat in water" 2>&1); rc=$?
 if [ "$rc" -eq 0 ] \
-    && grep -qE '^\*\*[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2} [+-][0-9]{2}:[0-9]{2}\*\* ' "$LOG" \
+    && grep -qE "^\\*\\*${TODAY} [0-9]{2}:[0-9]{2} [+-][0-9]{2}:[0-9]{2}\\*\\* " "$LOG" \
     && grep -q 'boat in water' "$LOG"; then
-    pass "appends a timestamped, well-formed entry"
+    pass "appends an entry stamped with the current date (measured, not frozen)"
 else
-    fail "appends a timestamped, well-formed entry (rc=$rc, out=$out)"
+    fail "appends an entry stamped with the current date (rc=$rc, out=$out)"
 fi
 
 # 2. multi-arg message is joined, not dropped
@@ -51,6 +54,16 @@ fi
 # 4. logfile but no message -> usage error, exit 2
 "$DLOG" "$LOG" > /dev/null 2>&1
 [ "$?" -eq 2 ] && pass "missing message exits 2" || fail "missing message exits 2"
+
+# 4b. empty / whitespace-only message -> exit 2 and write nothing (no contentless entry)
+before=$(grep -cE '^\*\*[0-9]' "$LOG")
+"$DLOG" "$LOG" "   " > /dev/null 2>&1; rc=$?
+after=$(grep -cE '^\*\*[0-9]' "$LOG")
+if [ "$rc" -eq 2 ] && [ "$before" -eq "$after" ]; then
+    pass "empty/blank message exits 2 and writes nothing"
+else
+    fail "empty/blank message exits 2 and writes nothing (rc=$rc, before=$before after=$after)"
+fi
 
 # 5. no args -> usage error, exit 2
 "$DLOG" > /dev/null 2>&1

--- a/.agent/work-plans/issue-515/progress.md
+++ b/.agent/work-plans/issue-515/progress.md
@@ -1,0 +1,22 @@
+---
+issue: 515
+---
+
+# Issue #515 — Deployment live-ops logging hits permission prompts → late/inaccurate timestamps
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 07:56 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: approved (round-1 must-fixes resolved in `6f4bf02`)
+**Branch**: feature/issue-515 at `6f4bf02`
+**Mode**: pre-push
+**Depth**: Standard (reason: instruction-file + skill change; 2 disjoint-lens adversarial passes)
+**Must-fix**: 2 (resolved) | **Suggestions**: 3 (2 applied, 1 deferred)
+
+### Findings
+- [x] (must-fix) dlog.sh wrote a contentless entry for empty/blank message — now exits 2 — `.agent/scripts/dlog.sh`
+- [x] (must-fix) test pinned timestamp format only (frozen stamp would pass) — now asserts current date + empty-message case — `.agent/scripts/tests/test_dlog.sh`
+- [x] (suggestion) allowlist-entry spelled 3 ways across docs — normalized to `<workspace_root>/...`
+- [x] (suggestion) %:z GNU-date dependency — noted in dlog.sh comment
+- [ ] (suggestion, deferred) trailing-slash logfile fails via raw set -e not the clean message — minor edge, left as-is

--- a/.claude/skills/start-deployment/SKILL.md
+++ b/.claude/skills/start-deployment/SKILL.md
@@ -298,22 +298,35 @@ Any title / body / log-stamp warnings emitted below append to this
 file. It is the canonical sink for field-side drift warnings; dev side
 also appends here for parity.
 
-**Append entries with a `date`-baked helper.** Define this once after
-creating the log file, then use it for every entry so a measured
-timestamp is the path of least resistance (rule 6 — never type times by
-hand):
+**Append entries with the committed `dlog` helper** —
+`<workspace_root>/.agent/scripts/dlog.sh`. It bakes the timestamp from
+`date` at write time (never typed, never approval-delayed) and appends
+one entry, so a measured timestamp is the path of least resistance
+(rule 6 — never type times by hand):
 
 ```bash
 LOGFILE="<project_repo>/<log_dir>/<YYYY>/<YYYY-MM-DD>_<label>_logs.md"
-dlog() { printf '\n**%s** — %s\n' "$(date '+%Y-%m-%d %H:%M %:z')" "$1" >> "$LOGFILE"; }
-dlog "charger disconnected; controls check good; going to launch"
+<workspace_root>/.agent/scripts/dlog.sh "$LOGFILE" "charger disconnected; controls check good; going to launch"
 ```
 
+`$LOGFILE` does not survive across the agent's separate Bash invocations
+(fresh subshell each call), so pass the **literal log-file path** to
+`dlog.sh` every time — the path is stable for the deployment.
+
+**Allowlist it once** so live-ops logging is prompt-free: add
+`Bash(<workspace_root>/.agent/scripts/dlog.sh:*)` to
+`.claude/settings.local.json` (one generic entry, reused across every
+deployment — *not* a per-deployment script). **Do not substitute the Edit
+tool for logging:** it avoids the prompt but cannot run `date`, so it
+forces a *typed* timestamp — the inaccurate, approval-skewed "durable
+lie" times #515 exists to prevent. `dlog.sh` is the only method that is
+both prompt-free *and* accurately stamped.
+
 For an event the operator reports after the fact — whose time you did
-**not** measure — let `dlog` stamp when you're recording it and put the
+**not** measure — let `dlog.sh` stamp when you're recording it and put the
 operator's time in the text, marked approximate:
-`dlog "in water (operator-reported ~12:35)"`. Never back-fill the
-header timestamp to the operator's time; the header is when *you* logged.
+`dlog.sh "$LOGFILE" "in water (operator-reported ~12:35)"`. Never
+back-fill the stamp to the operator's time; the stamp is when *you* logged.
 
 **Verify the issue title** (form: `Deployment <YYYY-MM-DD>: <scope>`):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -462,6 +462,7 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/worktree_remove.sh` | Remove worktree |
 | `.agent/scripts/worktree_list.sh` | List active worktrees |
 | `.agent/scripts/field_mode.sh` | Detect field mode (non-GitHub origin) vs. dev mode **(source or exec)** |
+| `.agent/scripts/dlog.sh` | Prompt-free, `date`-stamped deployment log appender (`dlog.sh <logfile> <message>`); allowlist once for prompt-free + accurate live-ops logging (#515/#516) |
 | `.agent/scripts/agent start-task <N>` | High-level wrapper: create + enter worktree |
 | `.agent/scripts/dispatch_subagent.sh` | Dispatch a workflow skill into a fresh-context sub-agent (in-process or container); reads the progress.md exit contract |
 | `.agent/scripts/docker_run_agent.sh` | Launch the sandboxed agent container for a worktree; interactive or headless dispatch (`--prompt`/`--prompt-file`, `--model`), reads `CLAUDE_CODE_OAUTH_TOKEN`. `--build` also stages layer `package.xml` manifests into the image build context to bake their rosdep deps (#520) |


### PR DESCRIPTION
## Prompt-free **and** accurately-timestamped deployment logging

Resolves the tension between **#515** (per-entry prompts skew the measured `date` → late timestamps) and **#516** (use the Edit tool to avoid prompts).

**The catch #516 missed:** the Edit tool avoids prompts but **cannot run `date`** — the agent has to *type* the timestamp, which reintroduces the inaccurate, approval-skewed "durable lie" times #515 exists to prevent. Only a shell can stamp measured time. So the Edit-tool route, adopted naively, regresses #515.

### Change
- **`.agent/scripts/dlog.sh`** — generic, committed, `date`-baked appender: `dlog.sh <logfile> <message...>`. Allowlist it **once** (`Bash(.agent/scripts/dlog.sh:*)` in `settings.local.json`) → every live-ops entry is prompt-free **and** carries a measured timestamp. Replaces the per-deployment `dlog_<N>.sh` stopgap #515 rightly flagged as clunky (this generalizes the `dlog295.sh` I used on #295/#299).
- **`start-deployment/SKILL.md` + `deployment_mode.md`** — prescribe the helper; retire the inline `dlog()` function and the Edit-tool suggestion, with the timestamp rationale spelled out.
- **`test_dlog.sh`** — 6 cases (well-formed timestamped entry, multi-arg join, append-not-truncate, usage/missing-dir error exits). Auto-discovered by `run_script_tests.sh`. Passing; pre-commit shellcheck clean.

### Validated in the field
This is the exact pattern run on the #295 and #299 wrap-ups (operator flagged the prompt/timestamp problem live). Prototype context posted on the umbrella: rolker/ros2_agent_workspace#495 (comment).

### Notes / follow-ups
- The allowlist entry lives in per-machine `settings.local.json` (the workspace's established mechanism — no committed `settings.json` exists). A committed shared allow rule is an option if the workspace wants it standard — flagging rather than creating shared permissions unilaterally.
- The `## Script Reference` table in `CLAUDE.md` should get a `dlog.sh` row, but that's an Ask-First instruction file — leaving it for approval.

Closes #515. Closes #516. Part of #495.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
