### PR TITLE
v1 /wrap-up-deployment skill — phase [3] orchestrator (#530)

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -104,7 +104,7 @@ Available workflow skills: `run-issue`, `review-issue`, `plan-task`, `review-pla
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
 `triage-reviews`, `address-findings`, `skill-importer`, `document-package`, `issue-triage`,
 `test-engineering`, `inspiration-tracker`, `import-field-changes`,
-`start-deployment`.
+`start-deployment`, `wrap-up-deployment`.
 
 ## References
 

--- a/.agent/instructions/gemini-cli.instructions.md
+++ b/.agent/instructions/gemini-cli.instructions.md
@@ -76,7 +76,7 @@ Available workflow skills: `run-issue`, `review-issue`, `plan-task`, `review-pla
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
 `triage-reviews`, `address-findings`, `skill-importer`, `document-package`, `issue-triage`,
 `test-engineering`, `inspiration-tracker`, `import-field-changes`,
-`start-deployment`.
+`start-deployment`, `wrap-up-deployment`.
 
 ## References
 

--- a/.agent/knowledge/deployment_mode.md
+++ b/.agent/knowledge/deployment_mode.md
@@ -139,9 +139,9 @@ analysis is the *expected* work.
 
 [3] Wrap-up — dev-side
     Contract relaxes. Import field changes; review-loop import
-    PRs; consolidate logs; extract bag DB; run standard
-    analyses; file analysis sub-issues; merge wrap-up PR
-    (closes deployment issue).
+    PRs; consolidate logs; merge wrap-up PR (closes deployment
+    issue). (Bag extraction and standard analyses are the debrief
+    skill's job — see #435; out of scope for v1 wrap-up.)
 
 [4] Next deployment-issue drafted from analysis outputs.
 ```

--- a/.agent/knowledge/deployment_mode.md
+++ b/.agent/knowledge/deployment_mode.md
@@ -22,9 +22,10 @@ Two halves, both load-bearing:
 1. **An urgency contract** — sterile-cockpit-style behavioral adjustments that
    keep the agent fast and operator-responsive during live ops.
 2. **Lifecycle tooling** — the skills and templates that run inside the mode
-   (`/start-deployment` is the first; `/wrap-up-deployment` and
-   `/next-deployment` are tracked as follow-ups under the umbrella
-   [#495](https://github.com/rolker/ros2_agent_workspace/issues/495)).
+   (`/start-deployment` for phase [0] and `/wrap-up-deployment`
+   (`.claude/skills/wrap-up-deployment/SKILL.md`) for phase [3] are
+   implemented; `/next-deployment` is tracked as a follow-up under the
+   umbrella [#495](https://github.com/rolker/ros2_agent_workspace/issues/495)).
 
 It's a sibling to **field mode** ([ADR-0011](../../docs/decisions/0011-field-mode-for-non-github-origins.md)):
 field mode is detected by origin URL and scopes *where commits go*; deployment
@@ -236,8 +237,8 @@ on-disk artifacts that already exist:
   links here as they appear).
 - Operator-authored sections (Purpose, Must-verify, Operators, Hosts in use,
   Notes) are left untouched.
-- No automatic wrap-up checklist (the future `/wrap-up-deployment` skill owns
-  that procedure).
+- No automatic wrap-up checklist (`/wrap-up-deployment` owns that procedure;
+  see `.claude/skills/wrap-up-deployment/SKILL.md`).
 - If the body is suspiciously empty, warn — don't impose structure.
 
 ## Project-config schema (`.agents/deployment.yaml`)
@@ -302,8 +303,6 @@ to GitHub, the skill auto-switches without any code change.
 
 Tracked separately under [#495](https://github.com/rolker/ros2_agent_workspace/issues/495):
 
-- `/wrap-up-deployment` — phase [3] orchestration (review-loop, log
-  integration, analysis kickoff).
 - `/next-deployment` — phase [4] drafting of the next deployment issue from
   analysis outputs.
 - Framework-level hook for auto-injecting the urgency contract into every

--- a/.agent/work-plans/issue-530/plan.md
+++ b/.agent/work-plans/issue-530/plan.md
@@ -29,19 +29,32 @@ development-pipeline step. ADR-0013 governs the development pipeline only.
    2. Verify dev-side (wrap-up must run on dev — `gh` access required for closing the issue)
    3. Find the open deployment issue via `gh issue list --label deployment`
    4. Collect all per-host log files for this deployment (match on `<start-date>_*_logs.md`)
-   5. Import field changes via `/import-field-changes` (each field host's repo)
-   6. Review and merge field-import PRs (standard review-loop flow)
-   7. Consolidate — add a `## Wrap-up` summary to the dev log; stamp the
-      deployment issue body with a summary (bag references, outcomes, follow-up
-      issue links); `dlog.sh` for all entries
-   8. File deferred analysis sub-issues from deployment logs (items marked
-      "deferred to wrap-up" during live ops)
-   9. Close the deployment issue: `gh issue close <N> --comment "Wrap-up complete."`
+   5. **Operator-correction interview — ONE QUESTION AT A TIME** (new, highest-value step):
+      interview the operator before consolidating to catch field-agent misreads —
+      misdated/mislabeled logs, wrong root-causes, agent overreach, premature conclusions.
+      Ask one question, wait for the answer, then the next.
+   6. Consolidate the dev log — append `## Summary`, `## Operator Corrections`,
+      `## Lessons Learned`, `## RCA / Follow-up Backlog`; fix misdated/mislabeled field
+      logs **in place**; use `dlog.sh` for timestamped entries.
+   7. **Reconcile field code — two distinct mechanisms** (clarified from original 7-step plan):
+      a. **SHA-preserving merge** of `gitcloud/<default_branch>` INTO the deployment branch
+         (`git merge`, NOT cherry-pick/squash) — for the primary deployment repo.
+         After the wrap-up PR merges to `<default_branch>`, gitcloud reconciles by
+         fast-forward: `git push gitcloud origin/<default_branch>:<default_branch>`.
+      b. **`/import-field-changes`** for OTHER repos that received field commits
+         (nav, sensors, etc.) — that skill opens per-repo import PRs.
+   8. PR (`Closes #<N>`) → merge (merge commit, NOT squash) → reconcile gitcloud →
+      remove the worktree.
+   9. File genuinely-NEW RCA issues selectively — dedup-check existing issues first;
+      close stale deployment issues. Do NOT over-file.
 
    ADR-0003 compliance: SKILL.md must not embed platform-specific paths, host
    names, or bag-extraction commands — these come from `.agents/deployment.yaml`.
-   The skill reads the `log_dir` key and `issue_sync.dev_push` as needed;
-   bag-extraction specifics are out of scope for v1.
+   The skill reads the `log_dir` key and `issue_sync.dev_push` as needed.
+   Bag-extraction/analysis is explicitly stated as operator-driven and out of
+   scope for v1 (deferred to debrief checklist #435).
+   `issue_sync`/`dev_push` absence is graceful — dev-side `issue_sync` is optional,
+   mirroring `start-deployment`.
 
 2. **Update `AGENTS.md` lines 254-255** — replace the placeholder "The wrap-up
    half (`/wrap-up-deployment`) and recovery checklist are tracked under umbrella

--- a/.agent/work-plans/issue-530/plan.md
+++ b/.agent/work-plans/issue-530/plan.md
@@ -1,0 +1,118 @@
+# Plan: v1 `/wrap-up-deployment` skill — phase [3] orchestrator (deployment-mode gap)
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/530
+
+## Context
+
+`/start-deployment` (phase [0]) shipped in #501. Phase [3] (wrap-up) has no
+tooling — operators have been executing the wrap-up workflow manually, with 4
+validated end-to-end runs accumulating a clear 7-step procedure. This skill
+codifies that procedure as a workspace-level SKILL.md, keeping project-specific
+details (log paths, issue-sync commands, bag paths) in `.agents/deployment.yaml`
+per ADR-0003.
+
+The issue review resolved one pre-implementation decision: the skill does **NOT**
+write a `progress.md` entry — it is a deployment-lifecycle skill (writes the
+deployment dev log + closes the deployment GitHub issue), not a per-issue
+development-pipeline step. ADR-0013 governs the development pipeline only.
+
+## Approach
+
+1. **Create `.claude/skills/wrap-up-deployment/SKILL.md`** — the main
+   deliverable. Follows the same structure as `start-deployment/SKILL.md`:
+   frontmatter → overview → lifecycle position → steps → guidelines → references.
+
+   Steps the skill documents (phase [3] from `deployment_mode.md`):
+   1. Read project config from `.agents/deployment.yaml`
+   2. Verify dev-side (wrap-up must run on dev — `gh` access required for closing the issue)
+   3. Find the open deployment issue via `gh issue list --label deployment`
+   4. Collect all per-host log files for this deployment (match on `<start-date>_*_logs.md`)
+   5. Import field changes via `/import-field-changes` (each field host's repo)
+   6. Review and merge field-import PRs (standard review-loop flow)
+   7. Consolidate — add a `## Wrap-up` summary to the dev log; stamp the
+      deployment issue body with a summary (bag references, outcomes, follow-up
+      issue links); `dlog.sh` for all entries
+   8. File deferred analysis sub-issues from deployment logs (items marked
+      "deferred to wrap-up" during live ops)
+   9. Close the deployment issue: `gh issue close <N> --comment "Wrap-up complete."`
+
+   ADR-0003 compliance: SKILL.md must not embed platform-specific paths, host
+   names, or bag-extraction commands — these come from `.agents/deployment.yaml`.
+   The skill reads the `log_dir` key and `issue_sync.dev_push` as needed;
+   bag-extraction specifics are out of scope for v1.
+
+2. **Update `AGENTS.md` lines 254-255** — replace the placeholder "The wrap-up
+   half (`/wrap-up-deployment`) and recovery checklist are tracked under umbrella
+   #495" with a sentence noting the skill location and that recovery checklist
+   (#496) remains a follow-up.
+
+3. **Update skill lists in all three non-Claude adapter files** (ADR-0006):
+   - `.github/copilot-instructions.md` — append `wrap-up-deployment` to the
+     `Available workflow skills:` line (currently ends with `start-deployment`)
+   - `.agent/instructions/gemini-cli.instructions.md` — same edit
+   - `.agent/AGENT_ONBOARDING.md` — same edit
+
+4. **Run `make generate-skills`** to register `/wrap-up-deployment` as a Claude
+   Code slash command (CLAUDE.md § Makefile targets).
+
+5. **Run `/review-code` (pre-push)** before pushing — catches ADR-0003 drift,
+   plan alignment, and static issues while they're cheap to fix locally.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.claude/skills/wrap-up-deployment/SKILL.md` | **Create** — new skill file |
+| `AGENTS.md` | Update "Deployment mode" section — replace `#495` placeholder with skill pointer |
+| `.github/copilot-instructions.md` | Add `wrap-up-deployment` to skill list |
+| `.agent/instructions/gemini-cli.instructions.md` | Add `wrap-up-deployment` to skill list |
+| `.agent/AGENT_ONBOARDING.md` | Add `wrap-up-deployment` to skill list |
+
+Plus: run `make generate-skills` (modifies auto-generated skill files; exact
+output determined at runtime).
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | All 4 adapter files and `make generate-skills` are in scope — no stale skill lists left behind |
+| Workspace vs. project separation | SKILL.md must reference `.agents/deployment.yaml` for every project-specific value (ADR-0003); the review check explicitly covers this |
+| Verify documentation claims against source code | SKILL.md step descriptions verified against `deployment_mode.md` phase [3] and the `start-deployment` precedent |
+| Never document from assumptions | `log_dir` and `issue_sync` keys verified against `deployment_config.yaml` template before referencing them |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0002 — Worktree isolation | Yes | Already in worktree `feature/issue-530` |
+| ADR-0003 — Project-agnostic workspace | Yes (key) | SKILL.md reads `log_dir`, `packages`, `layer`, `issue_sync` from `.agents/deployment.yaml`; no platform-specific content embedded |
+| ADR-0006 — Shared AGENTS.md | Yes | AGENTS.md update + all 3 non-Claude adapters updated in the same PR |
+| ADR-0013 — `progress.md` vocabulary | Watch | Skill does NOT write a `progress.md` entry (resolved; see Context above) |
+| ADR-0014 — Deployment mode | Yes (key) | Skill is explicitly phase [3]; urgency-contract relaxation at wrap-up is stated in the skill's overview; wording consistent with SKILL.md's own contract in `start-deployment` |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Add new skill directory | `make generate-skills` to register slash command | Yes — step 4 |
+| Add new skill | All non-Claude adapter skill lists | Yes — step 3 |
+| AGENTS.md "Deployment mode" section | Same section in `deployment_mode.md` knowledge doc (if text duplicates the same claim) | No — knowledge doc accurately says wrap-up is a follow-up; no drift after this change |
+| Wrap-up ships | ADR-0014 Status "Proposed" → "Accepted" candidate | No — leave as separate follow-up issue (the recovery checklist #496 and `/next-deployment` are still outstanding) |
+
+## Open Questions
+
+- Should `.agents/deployment.yaml` gain a `wrap_up:` section for project-specific
+  steps (e.g., bag extraction commands, analysis script paths)? V1 may reasonably
+  defer bag extraction to a manual operator step (out of scope per ADR-0003 unless
+  there is a generic hook). Decision: treat bag extraction as out-of-scope for v1;
+  skill documents that project-specific post-wrap steps (analysis, bag DB) are
+  operator-driven from the debrief checklist (#435). This avoids speculative config
+  schema before any project has configured it.
+
+## Estimated Scope
+
+Single PR — all changes are in workspace infrastructure files, no ROS package
+code. Estimated 5–7 files (SKILL.md + AGENTS.md + 3 adapters + generated
+skill files from `make generate-skills`).

--- a/.agent/work-plans/issue-530/progress.md
+++ b/.agent/work-plans/issue-530/progress.md
@@ -106,3 +106,58 @@ Also updated AGENTS.md "Deployment mode" section (replaced #495 placeholder with
 - [ ] (suggestion) Verify gitcloud push succeeded before removing the worktree (removal destroys retry context) — `.claude/skills/wrap-up-deployment/SKILL.md:355`
 - [ ] (suggestion) `rca` label may not exist; create-or-skip when filing RCA issues — `.claude/skills/wrap-up-deployment/SKILL.md:404`
 - [ ] (suggestion) `ls` log glob errors on no-match; add "if none, note and continue" guard — `.claude/skills/wrap-up-deployment/SKILL.md:145`
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-20
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+**Commit**: `7230154`
+**Summary**: Addressed review-code round 1 — all 6 must-fix findings and all 5 suggestions applied to `.claude/skills/wrap-up-deployment/SKILL.md` and `.agent/knowledge/deployment_mode.md`.
+
+**Changes by finding:**
+- **#1 (git -C project-repo worktree)**: Added `git -C "<project-repo-worktree-path>"` to all git ops in steps 4, 6a, 6d, 7a, and 8. Path derivation note added in step 4 and step 7a.
+- **#2 (gitcloud push ff-guard)**: Step 8 now re-fetches gitcloud + origin after PR merge, runs `merge-base --is-ancestor` to verify ff before pushing, stops on divergence with actionable message.
+- **#3 (draft PR → mergeable)**: Removed `--draft` flag from `gh pr create` in step 8.
+- **#4 (commit before PR create)**: Step 6a no longer says "do NOT commit yet"; new step 6d commits the dev log and all corrected field logs before step 8.
+- **#5 (idempotency/recovery)**: Step 8 opens with a "if re-running after interruption" block that checks PR state and issue state before repeating irreversible actions.
+- **#6 (deployment_mode.md)**: Three stale "future follow-up" references updated — lifecycle tooling description (line 25), wrap-up checklist note (line 239), and "What's NOT in v1" section (removed `/wrap-up-deployment` line from list).
+- **#7 (TODO guard)**: `issue_sync.dev_push` check now guards `== "TODO"` as absent.
+- **#8 (re-fetch + merge --abort)**: Step 7a now fetches gitcloud before merge, stops on fetch failure, documents `merge --abort` safe-out.
+- **#9 (verify push before remove)**: Step 8 notes "verify the push succeeded before proceeding to worktree removal."
+- **#10 (rca label create-or-skip)**: Step 9 adds `gh label create rca … 2>/dev/null || true` before filing.
+- **#11 (glob no-match guard)**: Step 4 adds "if the glob matches no files, note and continue — do not abort."
+
+**Files changed**:
+- `.claude/skills/wrap-up-deployment/SKILL.md` — steps 4, 6a, 6d (new), 7a, 8, 9 updated
+- `.agent/knowledge/deployment_mode.md` — 3 stale future-references updated
+
+**Next step**: re-review (`/review-code`) before opening the PR.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 14:40 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-530 at `7230154`
+**Mode**: pre-push
+**Depth**: Deep (reason: 562-line new SKILL.md + governance-trigger files AGENTS.md/deployment_mode.md/ADR-0006 adapters)
+**Must-fix**: 3 | **Suggestions**: 6
+
+Round 2. All 11 round-1 findings verified applied and correct (not re-reported).
+3 new must-fix items, all from SKILL.md assumptions about how `/start-deployment`'s
+worktree is actually created, plus a `git add` rename-staging bug. Both Lens B
+must-fix claims verified against `worktree_create.sh` (760/763/942) and
+`start-deployment/SKILL.md` (--type layer, no --plan-file).
+
+### Findings
+- [ ] (must-fix) Project-repo worktree path template wrong in all 3 segments — should be `layers/worktrees/issue-<REPO_SLUG>-<N>/<layer>_ws/src/<packages[0]>` (not `.workspace-worktrees/issue-<N>/layers/main/...`) — `.claude/skills/wrap-up-deployment/SKILL.md:136,325`
+- [ ] (must-fix) Deployment branch never pushed before `gh pr create`; start-deployment creates worktree without --plan-file (local-only branch), repo has two remotes so gh can't auto-pick — add explicit `git push -u origin <branch>` — `.claude/skills/wrap-up-deployment/SKILL.md:395`
+- [ ] (must-fix) Renamed mislabeled log's old-path deletion unstaged: shell-glob `git add` only sees existing files — use `git mv` or `git add -A <log_dir>/<YYYY>/` — `.claude/skills/wrap-up-deployment/SKILL.md:234,299`
+- [ ] (suggestion) Editing field logs in place (6a) before merging gitcloud (7a) guarantees a merge conflict on every corrected log; merge first or document expected-conflict resolution — `.claude/skills/wrap-up-deployment/SKILL.md:216,343`
+- [ ] (suggestion) Worktree removed (step 8) before RCA filing (step 9) breaks `gh` origin auto-detection; file RCA before removal or pass `-R <owner/repo>` — `.claude/skills/wrap-up-deployment/SKILL.md:471,477`
+- [ ] (suggestion) gitcloud reconcile doesn't confirm PR actually merged before re-fetch/ancestor-check; poll `gh pr view --json state` for MERGED first — `.claude/skills/wrap-up-deployment/SKILL.md:423`
+- [ ] (suggestion) Broken reference link: `import-field-changes` is a skill, not `.agent/scripts/`; point to `.claude/skills/import-field-changes/SKILL.md` — `.claude/skills/wrap-up-deployment/SKILL.md:558`
+- [ ] (suggestion) Surface `/import-field-changes`'s own config prereq (`.agent/project_config.yaml:field_remote`, different file than deployment.yaml) — `.claude/skills/wrap-up-deployment/SKILL.md:363`
+- [ ] (suggestion) deployment_mode.md phase [3] lists bag-DB extraction/analyses as wrap-up work, contradicting SKILL's explicit out-of-scope (#435); add a parenthetical — `.agent/knowledge/deployment_mode.md:~141`

--- a/.agent/work-plans/issue-530/progress.md
+++ b/.agent/work-plans/issue-530/progress.md
@@ -31,7 +31,7 @@ Issue proposes creating `.claude/skills/wrap-up-deployment/SKILL.md` + AGENTS.md
 ### Actions
 - [ ] Update non-Claude adapter skill lists when adding the skill (`.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md`)
 - [ ] Run `make generate-skills` after adding `.claude/skills/wrap-up-deployment/`
-- [ ] Decide and document ADR-0013 entry type used by the skill before implementation starts
+- [x] **RESOLVED** (operator, 2026-06-20): skill writes **NO `progress.md` entry**. `/wrap-up-deployment` is a deployment-lifecycle skill (writes the deployment dev log + GitHub issue), mirroring `/start-deployment`; `progress.md`/ADR-0013 govern the per-issue *development* pipeline only. No ADR-0013 addendum needed.
 - [ ] Keep project-specific config in `.agents/deployment.yaml`, not in SKILL.md (ADR-0003 three-tier split)
-- [ ] Post review-comment.md as GitHub issue comment (blocked by missing `gh` auth in this container)
+- [x] Posted by host (gh auth available on host) — #530 issue comment.
 - [ ] After merge: consider updating ADR-0014 Status from "Proposed" to "Accepted"

--- a/.agent/work-plans/issue-530/progress.md
+++ b/.agent/work-plans/issue-530/progress.md
@@ -35,3 +35,15 @@ Issue proposes creating `.claude/skills/wrap-up-deployment/SKILL.md` + AGENTS.md
 - [ ] Keep project-specific config in `.agents/deployment.yaml`, not in SKILL.md (ADR-0003 three-tier split)
 - [x] Posted by host (gh auth available on host) — #530 issue comment.
 - [ ] After merge: consider updating ADR-0014 Status from "Proposed" to "Accepted"
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-20 10:30 +00:00
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+**Plan**: `.agent/work-plans/issue-530/plan.md` at `7cc1133`
+**Branch**: feature/issue-530 at `7cc1133`
+**Phases**: single
+
+### Open questions
+- [ ] Should `.agents/deployment.yaml` gain a `wrap_up:` section for project-specific steps (bag extraction commands, analysis scripts)? V1 defers bag extraction to operator/debrief (#435); out of scope unless a project has concrete needs.

--- a/.agent/work-plans/issue-530/progress.md
+++ b/.agent/work-plans/issue-530/progress.md
@@ -82,3 +82,27 @@ Also updated AGENTS.md "Deployment mode" section (replaced #495 placeholder with
 - `.agent/instructions/gemini-cli.instructions.md` — `wrap-up-deployment` added to skill list
 - `.agent/AGENT_ONBOARDING.md` — `wrap-up-deployment` added to skill list
 - `.agent/work-plans/issue-530/plan.md` — synced to reflect 9-step flow
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 14:14 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-530 at `6b09e11`
+**Mode**: pre-push
+**Depth**: Deep (reason: 455-line new SKILL.md / 743 lines >200 + governance-trigger files)
+**Must-fix**: 6 | **Suggestions**: 5
+
+### Findings
+- [ ] (must-fix) Step-8/7a git ops don't specify the project-repo worktree (gitcloud/origin remotes live there, not workspace root); add `git -C` — `.claude/skills/wrap-up-deployment/SKILL.md:292,355`
+- [ ] (must-fix) gitcloud push assumes unconditional fast-forward; no `--ff-only`/re-fetch guard for a gitcloud that advances during the long wrap-up window — `.claude/skills/wrap-up-deployment/SKILL.md:356`
+- [ ] (must-fix) Draft PR cannot be merged: `--draft` create then immediate `gh pr merge --merge`; need `gh pr ready` or drop `--draft` — `.claude/skills/wrap-up-deployment/SKILL.md:330,345`
+- [ ] (must-fix) Operator corrections + dev-log sections are staged/written but step 8 has no `git commit` before `gh pr create` → corrections never enter PR, lost on worktree removal — `.claude/skills/wrap-up-deployment/SKILL.md:225,320`
+- [ ] (must-fix) No idempotency/interruption recovery across irreversible step 8 (PR-merge closes issue; re-run is stranded, worktree orphaned) — `.claude/skills/wrap-up-deployment/SKILL.md:320`
+- [ ] (must-fix) Consequence miss: knowledge doc still calls `/wrap-up-deployment` a future follow-up in 3 places — `.agent/knowledge/deployment_mode.md:25,239,303`
+- [ ] (suggestion) Treat `issue_sync.dev_push == "TODO"` as absent so step 8 doesn't run `TODO` as a shell command — `.claude/skills/wrap-up-deployment/SKILL.md:362`
+- [ ] (suggestion) Re-fetch gitcloud before 7a merge, handle fetch failure, document `git merge --abort` safe-out — `.claude/skills/wrap-up-deployment/SKILL.md:136,292`
+- [ ] (suggestion) Verify gitcloud push succeeded before removing the worktree (removal destroys retry context) — `.claude/skills/wrap-up-deployment/SKILL.md:355`
+- [ ] (suggestion) `rca` label may not exist; create-or-skip when filing RCA issues — `.claude/skills/wrap-up-deployment/SKILL.md:404`
+- [ ] (suggestion) `ls` log glob errors on no-match; add "if none, note and continue" guard — `.claude/skills/wrap-up-deployment/SKILL.md:145`

--- a/.agent/work-plans/issue-530/progress.md
+++ b/.agent/work-plans/issue-530/progress.md
@@ -1,0 +1,37 @@
+---
+issue: 530
+---
+
+# Issue #530 — v1 `/wrap-up-deployment` skill — phase [3] orchestrator (deployment-mode gap)
+
+## Issue Review
+**Status**: partial
+**When**: 2026-06-20 00:00 +00:00
+**By**: Claude Code Agent (Claude Opus 4.6)
+
+**Issue**: #530
+**Comment**: not posted — `gh` CLI lacks auth in this container environment (no GH_TOKEN, no `~/.config/gh/`). Review content saved to `.agent/work-plans/issue-530/review-comment.md` for the host to post.
+**Scope verdict**: well-scoped
+
+### Review Summary
+
+Issue proposes creating `.claude/skills/wrap-up-deployment/SKILL.md` + AGENTS.md pointer update, codifying a 4-times-validated manual deployment wrap-up workflow. Single PR, clear acceptance criteria, no blocking dependencies.
+
+**Principle findings** (Action needed):
+- A change includes its consequences: Non-Claude adapter skill lists (`.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md`) and `make generate-skills` are not called out in acceptance criteria but are required by the consequences map.
+
+**ADR findings** (Action needed):
+- ADR-0006: Non-Claude adapter skill lists need updating alongside AGENTS.md.
+- ADR-0013: SKILL.md must specify which `progress.md` entry type the skill writes (or confirm it does not write one). If a new type is needed, an ADR addendum is required before implementation.
+
+**Watch items**:
+- ADR-0003: SKILL.md must not embed project-specific content; all project details must come from `.agents/deployment.yaml`.
+- ADR-0014: ADR Status is "Proposed" — updating to "Accepted" after this skill ships is a follow-up.
+
+### Actions
+- [ ] Update non-Claude adapter skill lists when adding the skill (`.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md`)
+- [ ] Run `make generate-skills` after adding `.claude/skills/wrap-up-deployment/`
+- [ ] Decide and document ADR-0013 entry type used by the skill before implementation starts
+- [ ] Keep project-specific config in `.agents/deployment.yaml`, not in SKILL.md (ADR-0003 three-tier split)
+- [ ] Post review-comment.md as GitHub issue comment (blocked by missing `gh` auth in this container)
+- [ ] After merge: consider updating ADR-0014 Status from "Proposed" to "Accepted"

--- a/.agent/work-plans/issue-530/progress.md
+++ b/.agent/work-plans/issue-530/progress.md
@@ -63,3 +63,22 @@ Issue proposes creating `.claude/skills/wrap-up-deployment/SKILL.md` + AGENTS.md
 - [ ] (suggestion) State bag-extraction/analysis as operator-driven / out-of-scope for v1 in SKILL.md so adopters see the deferral — `plan.md:108-112`
 
 Plan is well-scoped, addresses all review-issue findings, and correctly resolves the ADR-0003 (project-agnostic config) and ADR-0013 (no per-issue progress entry) risks. Config keys referenced (`log_dir`, `issue_sync.dev_push`) verified against the template. Ready for implementation; the three items are refinements, not blockers.
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-20 (sub-agent)
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+Created `.claude/skills/wrap-up-deployment/SKILL.md` — a 9-step wrap-up orchestrator mirroring `start-deployment/SKILL.md` in structure and tone. The skill adds an operator-correction interview (step 5, one question at a time before consolidating logs) and separates field-code reconciliation into two distinct mechanisms: SHA-preserving `git merge` for the primary deployment repo (step 7a) and `/import-field-changes` for other repos (step 7b). Bag extraction is explicitly deferred to the project debrief checklist (#435). `issue_sync`/`dev_push` absence is graceful (dev-side optional, mirroring start-deployment).
+
+Also updated AGENTS.md "Deployment mode" section (replaced #495 placeholder with skill pointer + #496 recovery note), all three non-Claude adapter skill lists, and plan.md to reflect the 9-step implemented flow. `make generate-skills` ran successfully (generated `.claude/skills/make_*/` files which are gitignored).
+
+**Host follow-up**: ADR-0014 Status "Proposed"→"Accepted" flip requires `gh` auth to post — post once the PR merges to main.
+
+**Files changed**:
+- `.claude/skills/wrap-up-deployment/SKILL.md` — created (main deliverable)
+- `AGENTS.md` — deployment mode section updated
+- `.github/copilot-instructions.md` — `wrap-up-deployment` added to skill list
+- `.agent/instructions/gemini-cli.instructions.md` — `wrap-up-deployment` added to skill list
+- `.agent/AGENT_ONBOARDING.md` — `wrap-up-deployment` added to skill list
+- `.agent/work-plans/issue-530/plan.md` — synced to reflect 9-step flow

--- a/.agent/work-plans/issue-530/progress.md
+++ b/.agent/work-plans/issue-530/progress.md
@@ -47,3 +47,19 @@ Issue proposes creating `.claude/skills/wrap-up-deployment/SKILL.md` + AGENTS.md
 
 ### Open questions
 - [ ] Should `.agents/deployment.yaml` gain a `wrap_up:` section for project-specific steps (bag extraction commands, analysis scripts)? V1 defers bag extraction to operator/debrief (#435); out of scope unless a project has concrete needs.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-20 13:34 +00:00
+**By**: Claude Code Agent (Claude Opus 4.6) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-530/plan.md` at `7cc1133`
+**PR**: PR-less (--issue mode; dispatched sub-agent review)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) Make `issue_sync`/`dev_push` absence graceful in SKILL.md — dev-side optional per `deployment_config.yaml:79-81`; mirror `start-deployment` — `plan.md:40`
+- [ ] (suggestion) Open the ADR-0014 Status-flip ("Proposed"→"Accepted") follow-up issue rather than leaving it implicit — `plan.md:102`
+- [ ] (suggestion) State bag-extraction/analysis as operator-driven / out-of-scope for v1 in SKILL.md so adopters see the deferral — `plan.md:108-112`
+
+Plan is well-scoped, addresses all review-issue findings, and correctly resolves the ADR-0003 (project-agnostic config) and ADR-0013 (no per-issue progress entry) risks. Config keys referenced (`log_dir`, `issue_sync.dev_push`) verified against the template. Ready for implementation; the three items are refinements, not blockers.

--- a/.agent/work-plans/issue-530/progress.md
+++ b/.agent/work-plans/issue-530/progress.md
@@ -161,3 +161,50 @@ must-fix claims verified against `worktree_create.sh` (760/763/942) and
 - [ ] (suggestion) Broken reference link: `import-field-changes` is a skill, not `.agent/scripts/`; point to `.claude/skills/import-field-changes/SKILL.md` — `.claude/skills/wrap-up-deployment/SKILL.md:558`
 - [ ] (suggestion) Surface `/import-field-changes`'s own config prereq (`.agent/project_config.yaml:field_remote`, different file than deployment.yaml) — `.claude/skills/wrap-up-deployment/SKILL.md:363`
 - [ ] (suggestion) deployment_mode.md phase [3] lists bag-DB extraction/analyses as wrap-up work, contradicting SKILL's explicit out-of-scope (#435); add a parenthetical — `.agent/knowledge/deployment_mode.md:~141`
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-20
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+Addressed review-code round 2: 3 must-fix + 6 suggestions. Commit: `0bb34a6`.
+
+**Must-fix**:
+1. Fixed wrong project-repo worktree path template in both occurrences — changed `.workspace-worktrees/issue-<N>/layers/main/...` to `layers/worktrees/issue-<REPO_SLUG>-<N>/...` (the correct layer-worktree path from `worktree_create.sh`).
+2. Added explicit `git push -u origin "<branch-name>"` before `gh pr create` in step 9.
+3. Changed `git add <glob>` in step 7a to `git mv` for renames + `git add -A <log_dir>/<YYYY>/` to correctly stage old-path deletions.
+
+**Suggestions (all applied)**:
+4. Reordered: SHA-preserving gitcloud merge (step 5) now precedes operator interview (step 6) and log corrections (step 7) — avoids merge conflicts on every corrected log.
+5. Moved RCA issue filing (step 10) before worktree removal (which is now the last action inside step 10) — `gh` origin auto-detection intact during RCA filing.
+6. Added `gh pr view <PR_number> --json state --jq '.state'` confirm-MERGED poll before gitcloud reconcile in step 9.
+7. Fixed broken reference link: `.agent/scripts/import-field-changes` → `.claude/skills/import-field-changes/SKILL.md`.
+8. Added `/import-field-changes` config prereq note (reads `field_remote` from `.agent/project_config.yaml`) at step 8 invocation.
+9. Added parenthetical to `deployment_mode.md` phase [3] noting bag extraction/analyses are the debrief skill's job (#435), not v1 wrap-up.
+
+**Files changed**: `.claude/skills/wrap-up-deployment/SKILL.md`, `.agent/knowledge/deployment_mode.md`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 15:05 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-530 at `0bb34a6`
+**Mode**: pre-push
+**Depth**: Deep (reason: 598-line new SKILL.md orchestrating irreversible git/gh ops + governance-trigger files AGENTS.md/deployment_mode.md/ADR-0006 adapters)
+**Must-fix**: 4 | **Suggestions**: 3
+
+Round 3. All 11 round-1 + 9 round-2 findings verified applied (not re-reported).
+4 new must-fix from reading the final flow end-to-end (2 Lens B, 2 Lens A); both
+Lens B merge/CI claims verified against git/pre-commit stage semantics and the
+`gh pr merge --auto` queue behavior. Static analysis: `.md` only, no linter profile.
+
+### Findings
+- [ ] (must-fix) Step-5 `git merge gitcloud/<default_branch>` omits `-c user.name/-c user.email`; merge commit lands under wrong/absent author silently (identity hook is `pre-commit` stage, doesn't fire on merge commits) — `.claude/skills/wrap-up-deployment/SKILL.md:206`
+- [ ] (must-fix) `gh pr merge --merge` (no `--auto`) + "wait and re-poll" hangs forever on required CI checks — the command fails immediately, nothing drives the merge; use `--auto` or re-invoke after checks — `.claude/skills/wrap-up-deployment/SKILL.md:437,452`
+- [ ] (must-fix) `<branch-name>` is an undefined placeholder (used only at the push), never derived like every other identifier — define as `feature/issue-<N>` or read worktree HEAD — `.claude/skills/wrap-up-deployment/SKILL.md:413`
+- [ ] (must-fix) Dev-log/field-log paths bare-relative: `dlog.sh`/`ls` resolve against CWD, `git -C` staging against worktree root; run from workspace root → dev log written but never committed, lost on worktree removal — anchor to `<project-repo-worktree-path>` — `.claude/skills/wrap-up-deployment/SKILL.md:152,169-170`
+- [ ] (suggestion) `.agent/project_config.yaml` write uses CWD-dependent bare path; anchor to `<workspace_root>/.agent/...` or note run-from-root — `.claude/skills/wrap-up-deployment/SKILL.md:382`
+- [ ] (suggestion) Step-7d hardcodes `Claude Code Agent` identity; skill is advertised to non-Claude runtimes (gemini/copilot adapter lists) → wrong author lands silently; use `$AGENT_NAME`/`$AGENT_EMAIL` or placeholder — `.claude/skills/wrap-up-deployment/SKILL.md:363-366`
+- [ ] (suggestion) "squash → force-push" rationale imprecise: a squash would fail the ancestor check and block the push, not force it; reword — `.claude/skills/wrap-up-deployment/SKILL.md:568`

--- a/.agent/work-plans/issue-530/review-comment.md
+++ b/.agent/work-plans/issue-530/review-comment.md
@@ -1,0 +1,60 @@
+## Review
+
+### Scope Assessment
+
+**Well-scoped?** Yes — creates one new file (`.claude/skills/wrap-up-deployment/SKILL.md`), one AGENTS.md pointer update, and a `/review-code` clean pass. The seven-step workflow is already validated (4 manual end-to-end runs). Acceptance criteria is explicit and bounded to a single PR.
+
+**Right repo?** Yes — workspace repo; deployment-mode lifecycle tooling belongs in workspace `.claude/skills/` per ADR-0014 and ADR-0003.
+
+**Dependencies**: `/import-field-changes` already exists (`.claude/skills/import-field-changes/`). `/debrief-deployment` (#435) is a *downstream consumer* of this skill ("feeds"), not a prerequisite — this skill can ship independently. Related issues: #495 (umbrella), #496 (recovery checklist), #497 (import-field-changes).
+
+---
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | Skill documents each step; sterile-cockpit relaxation is intentional per ADR-0014 and well-framed. |
+| Enforcement over documentation | Watch | Skills are documentation, not mechanically enforced. Consistent with `/start-deployment` precedent; ADR-0014 accepts this trade-off for behavioral modes. |
+| Capture decisions, not just implementations | OK | ADR-0014 already records the wrap-up phase design; SKILL.md is the implementation. No new ADR needed unless the skill introduces design choices not covered by ADR-0014. |
+| A change includes its consequences | Action needed | AGENTS.md pointer update is in scope (listed in acceptance criteria). Also: the skill list in non-Claude adapters (`.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md`) will also need updating per the consequences map. `make generate-skills` must be run to register `/wrap-up-deployment` as a slash command. |
+| Only what's needed | OK | Codifying a 4-times-validated manual workflow; no speculative features. |
+| Improve incrementally | OK | Adds phase [3] tooling without touching phases [0]–[2]. |
+| Test what breaks | Watch | Workflow skills have no automated tests; the acceptance criteria includes `/review-code` clean as a quality gate. The 4-run manual validation is appropriate evidence for a SKILL.md-only change. |
+| Workspace vs. project separation | Watch | SKILL.md must keep project-specific details (gitcloud reconciliation paths, bag data offload steps) in `.agents/deployment.yaml` config, not embedded in the skill. The ADR-0014 three-tier split is the key constraint for the implementation. |
+| Workspace improvements cascade | OK | Skill is portable across deployment projects via `.agents/deployment.yaml`. |
+| Primary framework first, portability where free | OK | Claude Code skill format; AGENTS.md update is framework-agnostic. |
+
+---
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| 0001 — Adopt ADRs | No | ADR-0014 already records the wrap-up phase design. A new ADR is only needed if the implementation introduces a significant design choice not covered there. |
+| 0002 — Worktree isolation | Yes | Workspace issue; worktree is already created. OK. |
+| 0003 — Project-agnostic workspace | Yes | SKILL.md must not embed project-specific content (gitcloud paths, platform inventory, bag paths). All project-specific config must come from `.agents/deployment.yaml` at runtime. Verify the three-tier split during implementation. |
+| 0006 — Shared AGENTS.md | Yes | AGENTS.md update is in scope. Also update the skill list in non-Claude adapters (`.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md`) — these list available workflow skills and will be stale without this update. |
+| 0013 — `progress.md` vocabulary | Watch | If `/wrap-up-deployment` writes a `progress.md` entry to the deployment issue's timeline (likely, as it closes the deployment issue), clarify which ADR-0013 entry type it uses. Existing types: `## Issue Review`, `## Plan Authored`, `## Plan Review`, `## Local Review`, `## Local Review (Pre-Push)`, `## Integrated Review`, `## Implementation`. A "deployment wrap-up completion" could fit `## Implementation`. If none fit, a new type requires an ADR addendum (ADR-0012/0013 rules). This must be decided in the SKILL.md, not left implicit. |
+| 0014 — Deployment mode | Yes (key) | Skill is explicitly phase [3] per ADR-0014's lifecycle. Ensure the urgency-contract language in SKILL.md ("relaxes in wrap-up") is consistent with ADR-0014's wording. ADR-0014 Status is currently "Proposed" — once the full lifecycle tooling ships, updating to "Accepted" is worth a note or a follow-up issue. |
+
+---
+
+### Consequences
+
+- New skill added → non-Claude adapter skill lists must be updated (`.github/copilot-instructions.md` skill list, `.agent/instructions/gemini-cli.instructions.md`, `.agent/AGENT_ONBOARDING.md` `## Workflow Skills` section).
+- `make generate-skills` must be run after adding the new skill directory to register `/wrap-up-deployment` as a slash command.
+- AGENTS.md "Deployment mode" section currently says "The wrap-up half (`/wrap-up-deployment`) and recovery checklist are tracked under umbrella #495" — this placeholder text should be updated to reference the skill's location and usage once it lands.
+- ADR-0014 Status is "Proposed" — consider filing a follow-up issue to update it to "Accepted" once `/wrap-up-deployment` ships (this is the last major lifecycle piece).
+
+---
+
+### Recommendations
+
+1. In the SKILL.md, explicitly document which fields are read from `.agents/deployment.yaml` and which steps are generic vs. project-driven — this is the primary ADR-0003 compliance risk and helps future adopters.
+2. Early in the SKILL.md, specify which ADR-0013 `progress.md` entry type the skill writes (or note that it doesn't write one). If a new type is needed, flag it as a pre-implementation decision.
+3. After the PR merges, update ADR-0014 Status from "Proposed" to "Accepted" (or open a follow-up issue to do so) — the lifecycle tooling is now substantially complete.
+
+---
+**Authored-By**: `Claude Code Agent`
+**Model**: `Claude Opus 4.6`

--- a/.claude/skills/wrap-up-deployment/SKILL.md
+++ b/.claude/skills/wrap-up-deployment/SKILL.md
@@ -1,0 +1,455 @@
+---
+name: wrap-up-deployment
+description: Close out a field deployment. Verifies dev-side access, finds the open deployment issue, collects field logs, interviews the operator for corrections, consolidates the dev log, reconciles field code via SHA-preserving merge and /import-field-changes, opens the wrap-up PR (Closes #N), merges, reconciles gitcloud, and files new RCA issues selectively.
+---
+
+# Wrap Up Deployment
+
+## Usage
+
+```
+/wrap-up-deployment
+```
+
+No arguments. The skill discovers everything it needs from the current
+working directory's project config (`<project_repo>/.agents/deployment.yaml`),
+`field_mode.sh`, and the open deployment issue. Run from inside the project
+repo or the workspace root. **Dev side only** — wrap-up requires `gh` access
+to close the deployment issue and open PRs; the skill stops immediately if
+run from a field host.
+
+## Overview
+
+Close out a deployment under **deployment mode**
+([ADR-0014](../../../docs/decisions/0014-deployment-mode.md)) — the complement
+to `/start-deployment`. Operationally: pull the field logs in, interview the
+operator to catch agent misreads before they become permanent record, consolidate
+the dev log, reconcile field code, open and merge the wrap-up PR (which closes
+the deployment issue), and file any genuinely new RCA issues.
+
+**Lifecycle position**: [0] start → [1] session → [2] recovery → [3] wrap-up (this skill) → [4] next
+
+**The urgency contract relaxes here.** Wrap-up is where deep analysis is the
+*expected* work — root-cause investigation, log integration, lessons-learned
+synthesis. Sterile-cockpit bites hardest during live ops [1]; at [3] the boat
+is out of the water and there is no real-time cost to investigation depth. The
+invariants (pre-commit hooks, AI signature, atomic commits, no secrets, no
+destructive ops without operator approval) do not relax.
+
+**Bag extraction and data-analysis** (mission databases, trajectory post-processing,
+sensor QA) are operator-driven steps that belong in the project's debrief checklist
+([#435](https://github.com/rolker/ros2_agent_workspace/issues/435)). They are
+deliberately out of scope for this skill: the commands and paths are
+project-specific and cannot be abstracted generically at the workspace level
+(ADR-0003). `/wrap-up-deployment` covers the dev-record and code-reconciliation
+halves only.
+
+The fuller operational reference is
+[`.agent/knowledge/deployment_mode.md`](../../../.agent/knowledge/deployment_mode.md).
+
+**ADR-0013 note**: this skill does **not** write a `progress.md` entry — it is
+a deployment-lifecycle skill (writes the deployment dev log and closes the
+deployment GitHub issue), not a per-issue development-pipeline step.
+
+## Steps
+
+### 1. Read the project config
+
+Locate `<project_repo>/.agents/deployment.yaml` using the same discovery
+logic as `/start-deployment`:
+
+- If the current working directory is inside a project repo, the config is at
+  `<repo_root>/.agents/deployment.yaml`.
+- If the current working directory is the workspace root, ask the operator
+  which platform's deployment is wrapping up.
+
+If the config file is missing, stop with:
+
+> `<project_repo>/.agents/deployment.yaml` not found. See
+> `.agent/templates/deployment_config.yaml` for the template and
+> `.agent/knowledge/deployment_mode.md` for the schema.
+
+Read the config and extract: `platform`, `default_branch`, `log_dir`,
+`packages`, `layer`, `issue_sync` (optional on dev side), `labels`.
+
+**Validation**: if any required value is the literal string `TODO` (or empty /
+null where required), stop with:
+
+> `<key>` is unconfigured in `<project_repo>/.agents/deployment.yaml` —
+> fill in before running `/wrap-up-deployment`.
+
+Required keys: `platform`, `default_branch`, `log_dir`, `packages[0]`, `layer`.
+
+### 2. Verify dev-side
+
+Run `field_mode.sh` against the project repo's path. Discover the workspace
+root by walking up from `$PWD` until a directory containing
+`.agent/scripts/setup.bash` is found:
+
+```bash
+# Form A — CWD is workspace root:
+.agent/scripts/field_mode.sh --describe layers/main/<layer>_ws/src/<packages[0]>
+
+# Form B — CWD is inside the project repo:
+<workspace_root>/.agent/scripts/field_mode.sh --describe
+```
+
+If `field_mode.sh` reports field mode, **stop** with:
+
+> `/wrap-up-deployment` requires `gh` access (to close the deployment issue
+> and open PRs). Run this from a dev host. On field hosts, finish any
+> in-session logging and recovery ([2]), then hand off to a dev host for
+> wrap-up.
+
+Record the workspace root path; subsequent steps use it to call workspace-root
+scripts from any working directory.
+
+### 3. Find the open deployment issue
+
+```bash
+gh issue list --label deployment --state open --json number,title,createdAt,body
+```
+
+Run from inside the project repo (or with `-R <owner/repo>` if not). `gh`
+auto-detects the remote from `origin`.
+
+- **No open deployment issue**: nothing to wrap up; confirm with the operator
+  whether this was intentional.
+- **Exactly one**: proceed.
+- **Multiple**: list them and ask the operator which deployment this wrap-up is for.
+
+Note the issue number `<N>` and its start date (from the title:
+`Deployment <YYYY-MM-DD>: <scope>`). The start date drives log-file matching
+in the next step.
+
+If `issue_sync.dev_push` is absent from the config, note this and continue —
+dev-side `issue_sync` is optional; `gh` alone handles issue edits.
+
+### 4. Collect per-host field logs
+
+The deployment start date from the issue title is `<start-date>` (format
+`YYYY-MM-DD`).
+
+Fetch the field remote so its branches are up to date:
+
+```bash
+git fetch gitcloud
+```
+
+(If `gitcloud` is not a configured remote for the project repo, ask the
+operator for the correct field-remote name.)
+
+Gather all log files for this deployment in `<log_dir>/<YYYY>/`:
+
+```bash
+ls <log_dir>/<YYYY>/<start-date>_*_logs.md
+```
+
+Read each file. List them for the operator: one line per file, showing the
+host label extracted from the filename (`<start-date>_<label>_logs.md`).
+Note any log whose label doesn't match a known host from
+`deployment.yaml:hosts.field` — these may be mislabeled and will be raised
+in the operator interview.
+
+Also read the dev log (`<start-date>_dev_logs.md`) — it is the canonical sink
+for wrap-up additions. Check that it exists; if not, create it with a minimal
+header now (using `dlog.sh` for the timestamp):
+
+```bash
+LOGFILE="<log_dir>/<YYYY>/<start-date>_dev_logs.md"
+<workspace_root>/.agent/scripts/dlog.sh "$LOGFILE" "wrap-up started"
+```
+
+### 5. Operator-correction interview
+
+**This is the highest-value step. Do not skip or compress it.**
+
+Field agents log in good faith during live ops — but under sterile-cockpit
+pressure, with limited time, they make errors: misdated entries, wrong host
+labels, premature conclusions, agent overreach that the operator didn't
+actually endorse. These errors propagate into the permanent dev record if not
+caught here.
+
+**Interview the operator ONE QUESTION AT A TIME** — ask a question, wait for
+the answer, then ask the next. Do not present a form or a numbered list to fill
+in all at once; operator attention is fragmented at wrap-up.
+
+Minimum questions:
+
+1. "Does the deployment start date `<start-date>` match when the boat actually
+   went in the water? (Checking log filename accuracy.)"
+2. For each field-log label that looks suspect (unknown host, misspelled
+   hostname, etc.): "Log file `<name>` — does this match what you'd expect for
+   `<platform>` on this deployment?"
+3. "Were there any events or decisions in the field logs that the agent logged
+   incorrectly or overstated? (Root causes, action taken, outcome?)"
+4. "Anything the agent concluded that you'd walk back — either the root cause
+   was wrong, or the mitigation was the agent's idea that you didn't actually
+   try?"
+5. "Any events or runs that didn't make it into the logs at all?"
+
+Record the operator's answers verbatim or close to it — these become the
+`## Operator Corrections` section in the next step. If the operator says
+"no corrections," record that explicitly; it distinguishes "we checked" from
+"we forgot to ask."
+
+Ask follow-up questions if an answer surfaces a new issue (e.g., a mislabeled
+log file implies all its timestamps may also be off). This step is conversational,
+not mechanical.
+
+### 6. Consolidate the dev log
+
+Append the following sections to the dev log file
+(`<log_dir>/<YYYY>/<start-date>_dev_logs.md`). Use
+`<workspace_root>/.agent/scripts/dlog.sh` for any entries that need a
+timestamp; write Markdown section headers and body prose directly.
+
+#### 6a. Apply operator corrections to field logs in place
+
+For each correction from the interview that pertains to a specific field log
+file (wrong label, misdated entry, incorrect root cause attributed to the
+agent):
+
+- **Mislabeled log file**: rename the file to the correct name (preserving the
+  `<start-date>_<label>_logs.md` pattern with the corrected label).
+- **Misdated entry**: edit the entry's timestamp in the file to the corrected
+  value; add an inline note: `<!-- corrected at wrap-up: operator reported
+  actual time was <HH:MM> -->`.
+- **Incorrect conclusion**: add a correction block directly after the
+  offending entry:
+
+  ```
+  > **Wrap-up correction**: [operator's correction verbatim or paraphrased]
+  ```
+
+Stage all corrected field log files for commit (`git add`); do NOT commit yet
+(step 8 is where the commit lands).
+
+#### 6b. Append structured summary to dev log
+
+Append these four sections to the dev log (use `dlog.sh` only for
+timestamped *events*; section headers and prose go in directly):
+
+```markdown
+## Summary
+
+<2–4 sentences: what ran, what worked, what broke, overall outcome.
+Written in past tense. No invented mechanisms; only what happened.>
+
+## Operator Corrections
+
+<Verbatim or close-to-verbatim record of corrections from step 5.
+If the operator reported no corrections, write "Operator confirmed
+logs accurate; no corrections." Attribute each item: "Operator:
+'…'">
+
+## Lessons Learned
+
+<Observations that should change future deployments: tooling gaps,
+config values to update, procedures that helped or hurt.
+Bullet list. No speculation.>
+
+## RCA / Follow-up Backlog
+
+<Items deferred from live ops or surfaced by this wrap-up that
+need a GitHub issue. Format: "- [ ] <title> — <one-line root
+cause or outstanding question>". Dedup against existing open issues
+before this list drives issue-filing in step 9.>
+```
+
+#### 6c. Stamp the dev log link in the deployment issue
+
+Verify the deployment issue's `## Logs` section includes a link to the dev
+log:
+
+```
+- [dev log](<log_dir>/<YYYY>/<start-date>_dev_logs.md)
+```
+
+If the dev log link is missing, add it:
+
+```bash
+gh issue edit <N> --body-file <tmpfile>
+```
+
+(Read the current body first, append the link, write to a temp file, then
+`--body-file`. Use `gh issue view <N> --json body --jq '.body'` to get the
+current body.)
+
+### 7. Reconcile field code
+
+Two distinct mechanisms. Do both.
+
+#### 7a. SHA-preserving merge — deployment repo's own field commits
+
+The deployment repo (primary project repo in `packages[0]`) accumulates field
+commits on `gitcloud/<default_branch>` during live ops. Bring these into the
+deployment branch with a **merge commit** — NOT cherry-pick, NOT squash — to
+preserve SHA lineage and make reconciliation to gitcloud a fast-forward after
+the wrap-up PR merges:
+
+```bash
+git merge gitcloud/<default_branch>
+```
+
+Run from inside the deployment worktree (`feature/issue-<N>` on the deployment
+repo). Resolve any conflicts with the operator; do not auto-resolve anything
+that touches control logic.
+
+After this merge, the wrap-up branch is ahead of both `origin/<default_branch>`
+(via the PR) and `gitcloud/<default_branch>` (which will fast-forward after
+merge). Record the merge commit SHA in the dev log via `dlog.sh`.
+
+#### 7b. `/import-field-changes` — other repos
+
+Other repos that received field commits (nav packages, sensors, interfaces,
+etc.) use the `/import-field-changes` skill — that skill opens per-repo import
+PRs with pre-review against the Quality Standard. `/wrap-up-deployment` does
+NOT attempt to merge those repos directly; it delegates:
+
+> Invoke `/import-field-changes` for each repo that has field commits on
+> `gitcloud` but is NOT the primary deployment repo (`packages[0]`).
+
+Ask the operator: "Which other repos received field commits during this
+deployment?" Run `/import-field-changes` for each answer. Record the resulting
+PR URLs in the dev log.
+
+If no other repos had field commits, record that explicitly in the dev log:
+"No other repos had field commits; `/import-field-changes` not needed."
+
+### 8. PR → merge → gitcloud reconcile → remove worktree
+
+**Open the wrap-up PR**:
+
+```bash
+BODY_FILE=$(mktemp /tmp/gh_body.XXXXXX.md)
+# Write PR body to $BODY_FILE — include dev-log link, summary, operator-corrections summary
+gh pr create \
+    --title "Wrap up deployment #<N>: <scope>" \
+    --body-file "$BODY_FILE" \
+    --draft
+rm "$BODY_FILE"
+```
+
+The PR body should include:
+- Link to the deployment issue (will be closed by the merge).
+- One-paragraph summary from the dev log's `## Summary` section.
+- Link to each per-host log file and each import-field-changes PR.
+- AI signature.
+
+Add `Closes #<N>` in the PR body so GitHub closes the deployment issue on merge.
+
+**Merge** — use a **merge commit** (not squash, not rebase):
+
+```bash
+gh pr merge <PR_number> --merge
+```
+
+Squash would discard the field-commit history folded in by step 7a; rebase
+would break the SHA-preserving intent. The deployment issue closes automatically
+via the `Closes #<N>` reference.
+
+**Reconcile gitcloud** after the PR merges to `<default_branch>`:
+
+```bash
+git fetch origin
+git push gitcloud origin/<default_branch>:<default_branch>
+```
+
+This fast-forwards `gitcloud/<default_branch>` to match `origin/<default_branch>`,
+completing the SHA-preserving round-trip from step 7a.
+
+If `issue_sync.dev_push` is configured, run it now to propagate the closed
+issue status to the field-visible issue source:
+
+```bash
+<issue_sync.dev_push>
+```
+
+On failure, print `issue_sync.failure_hint`. This is advisory — the GitHub
+issue is already closed; `dev_push` just keeps the field-side view in sync.
+
+**Remove the worktree**:
+
+```bash
+<workspace_root>/.agent/scripts/worktree_remove.sh --issue <N>
+```
+
+### 9. File new RCA issues selectively
+
+From the `## RCA / Follow-up Backlog` in the dev log and any items surfaced
+during wrap-up, decide which warrant a GitHub issue.
+
+**Dedup first.** Before filing any issue, run:
+
+```bash
+gh issue list --search "<title keywords>" --state open
+```
+
+If a matching issue already exists, add a comment linking the deployment
+evidence rather than opening a duplicate. Known / already-on-radar items
+stay in the dev-log backlog — do not re-file them.
+
+**File selectively.** The operator has issue overload. File issues only for:
+- Bugs confirmed as root causes (not suspected).
+- Tooling or config gaps that will repeat without a fix.
+- Follow-up analysis that needs tracking (e.g., "analyze bag from run 3 for
+  the heading oscillation observed").
+
+Do NOT file issues for:
+- Speculation or unconfirmed hypotheses.
+- Items the operator explicitly said "we know about it."
+- One-off field conditions unlikely to repeat.
+
+Each filed issue gets the project's standard labels plus `rca` if appropriate.
+Include the AI signature and a link to the deployment issue.
+
+**Close stale deployment issues** — if there are leftover open `deployment`-labeled
+issues from prior deployments that were never wrapped up, list them for the
+operator and ask whether to close them with a note. Do not close them unilaterally.
+
+## Guidelines
+
+- **This is a dev-side-only skill.** The very first step after reading config is
+  checking for dev side. Field-side wrap-up is not possible — no `gh` access,
+  no PR, no merges.
+- **The operator-correction interview is the highest-value step.** Field agent logs
+  are written under sterile-cockpit pressure and may contain misattributions,
+  premature conclusions, or events that didn't happen as logged. This is the only
+  opportunity to fix the permanent record before it propagates.
+- **Two merge mechanisms, not one.** The SHA-preserving `git merge` (step 7a) is
+  for the primary deployment repo. `/import-field-changes` (step 7b) is for
+  everything else. Do not conflate them — cherry-pick or squash on the primary
+  repo would break the gitcloud fast-forward.
+- **Merge commit, not squash.** The PR merge MUST be `--merge`. Squash discards
+  the field-commit SHAs folded in by step 7a, making gitcloud reconciliation a
+  force-push rather than a fast-forward.
+- **`issue_sync` is optional on dev side.** If `dev_push` is absent from the
+  config, skip silently — `gh` handles everything. Only field-side wrap-up
+  (which is disallowed) would need the full `issue_sync` suite.
+- **Bag extraction is out of scope.** Data analysis, bag database ingestion, and
+  trajectory post-processing are operator-driven, project-specific steps that
+  belong in the project's debrief checklist (#435). Document where the bags are;
+  don't attempt extraction from the SKILL.
+- **`dlog.sh` for timestamped entries, prose for sections.** Timestamped log
+  entries go through `dlog.sh` to guarantee accurate timestamps (never type a
+  time). Section headers and prose in the dev log write directly.
+- **One platform at a time.** The skill assumes a single active deployment per
+  project repo — same as `/start-deployment`.
+- **ADR-0013**: this skill writes no `progress.md` entry. It is a
+  deployment-lifecycle skill (writes the deployment dev log and closes the
+  deployment GitHub issue), not a development-pipeline step.
+
+## References
+
+- [ADR-0014](../../../docs/decisions/0014-deployment-mode.md) — decision record
+- [ADR-0011](../../../docs/decisions/0011-field-mode-for-non-github-origins.md) — field mode (`field_mode.sh` is the side-detection authority)
+- [ADR-0003](../../../docs/decisions/0003-workspace-infrastructure-is-project-agnostic.md) — three-tier content split (this skill is generic; all project specifics in `.agents/deployment.yaml`)
+- [`.claude/skills/start-deployment/SKILL.md`](../start-deployment/SKILL.md) — sibling skill (phase [0])
+- [`.agent/knowledge/deployment_mode.md`](../../../.agent/knowledge/deployment_mode.md) — operational reference (fuller treatment of contract, lifecycle, schema)
+- [`.agent/templates/deployment_config.yaml`](../../../.agent/templates/deployment_config.yaml) — per-project config template
+- [`.agent/scripts/import-field-changes`](../../../.agent/scripts/) (skill: `/import-field-changes`) — per-repo field import PRs (step 7b)
+- [#435](https://github.com/rolker/ros2_agent_workspace/issues/435) — debrief / bag analysis checklist (out of scope here; tracked there)
+- [#495](https://github.com/rolker/ros2_agent_workspace/issues/495) — umbrella for the full deployment lifecycle
+- [#496](https://github.com/rolker/ros2_agent_workspace/issues/496) — recovery checklist (phase [2]; follow-up)
+- [#530](https://github.com/rolker/ros2_agent_workspace/issues/530) — v1 implementation issue

--- a/.claude/skills/wrap-up-deployment/SKILL.md
+++ b/.claude/skills/wrap-up-deployment/SKILL.md
@@ -149,7 +149,7 @@ files are already on disk, and revisit the fetch before step 5.)
 Gather all log files for this deployment in `<log_dir>/<YYYY>/`:
 
 ```bash
-ls <log_dir>/<YYYY>/<start-date>_*_logs.md
+ls "<project-repo-worktree-path>/<log_dir>/<YYYY>/<start-date>_*_logs.md"
 ```
 
 If the glob matches no files, note "no per-host field logs found for
@@ -166,7 +166,7 @@ for wrap-up additions. Check that it exists; if not, create it with a minimal
 header now (using `dlog.sh` for the timestamp):
 
 ```bash
-LOGFILE="<log_dir>/<YYYY>/<start-date>_dev_logs.md"
+LOGFILE="<project-repo-worktree-path>/<log_dir>/<YYYY>/<start-date>_dev_logs.md"
 <workspace_root>/.agent/scripts/dlog.sh "$LOGFILE" "wrap-up started"
 ```
 
@@ -200,10 +200,17 @@ If the fetch fails, stop and report to the operator before merging — merging
 from a stale remote risks missing field commits. Resolve the fetch error
 (network, wrong remote name) before continuing.
 
-Then merge:
+Then merge (carry identity flags — merge commits do not trigger the pre-commit
+identity hook, so the identity must travel with the command; `$AGENT_NAME` and
+`$AGENT_EMAIL` come from `set_git_identity_env.sh`; substitute literal values
+if the env vars are not live in this shell — AGENTS.md § Agent Commit Identity):
 
 ```bash
-git -C "<project-repo-worktree-path>" merge gitcloud/<default_branch>
+GIT_EDITOR=true git -C "<project-repo-worktree-path>" \
+    -c user.name="$AGENT_NAME" \
+    -c user.email="$AGENT_EMAIL" \
+    merge gitcloud/<default_branch> \
+    -m "merge: field commits from gitcloud/<default_branch> into wrap-up branch"
 ```
 
 If conflicts arise that cannot be cleanly resolved, abort and surface for the
@@ -361,9 +368,11 @@ git -C "<project-repo-worktree-path>" add \
     "<log_dir>/<YYYY>/<start-date>_dev_logs.md" \
     "<log_dir>/<YYYY>/<start-date>_*_logs.md"
 git -C "<project-repo-worktree-path>" \
-    -c user.name="Claude Code Agent" \
-    -c user.email="roland+claude-code@ccom.unh.edu" \
+    -c user.name="$AGENT_NAME" \
+    -c user.email="$AGENT_EMAIL" \
     commit -m "chore: wrap-up deployment #<N> — consolidated dev log and operator corrections"
+# $AGENT_NAME/$AGENT_EMAIL come from set_git_identity_env.sh; substitute
+# literal values if the env vars are not live in this shell (AGENTS.md § Agent Commit Identity).
 ```
 
 ### 8. `/import-field-changes` — other repos
@@ -379,7 +388,8 @@ NOT attempt to merge those repos directly; it delegates:
 **Prerequisite**: `/import-field-changes` reads `field_remote` from
 `.agent/project_config.yaml` (not `.agents/deployment.yaml`) — verify that
 file exists and contains the `field_remote` key before invoking the skill.
-If missing, create it: `echo "field_remote: gitcloud" > .agent/project_config.yaml`
+If missing, create it (run from workspace root):
+`echo "field_remote: gitcloud" > .agent/project_config.yaml`
 (substituting the actual remote name if different).
 
 Ask the operator: "Which other repos received field commits during this
@@ -410,7 +420,9 @@ feature branch is local-only until this push, and with two remotes on the
 project repo `gh` cannot auto-pick:
 
 ```bash
-git -C "<project-repo-worktree-path>" push -u origin "<branch-name>"
+BRANCH="$(git -C "<project-repo-worktree-path>" branch --show-current)"
+# or: BRANCH="feature/issue-<N>"
+git -C "<project-repo-worktree-path>" push -u origin "$BRANCH"
 ```
 
 **Open the wrap-up PR** (skip if already open or merged):
@@ -431,26 +443,32 @@ The PR body must include:
 - Link to each per-host log file and each import-field-changes PR.
 - AI signature.
 
-**Merge** — use a **merge commit** (not squash, not rebase):
+**Merge** — use a **merge commit** (not squash, not rebase). `gh pr merge --merge`
+with pending required CI checks fails immediately — nothing drives the merge from
+that point — so poll checks first:
 
 ```bash
+# 1. Wait for required CI checks to pass (re-run until all required checks show "pass")
+gh pr checks <PR_number>
+
+# 2. Once checks are green, merge
 gh pr merge <PR_number> --merge
+# Alternative when the repo has auto-merge enabled:
+#   gh pr merge <PR_number> --merge --auto
 ```
 
 Squash would discard the field-commit history folded in by step 5; rebase
 would break the SHA-preserving intent. The deployment issue closes automatically
 via the `Closes #<N>` reference.
 
-**Confirm the PR merged** before starting the gitcloud reconcile — poll until
-the state is `MERGED`:
+**Confirm the PR merged** before starting the gitcloud reconcile:
 
 ```bash
 gh pr view <PR_number> --json state --jq '.state'
 # Must output "MERGED" before continuing
 ```
 
-If the state is not `MERGED` (e.g., CI checks still pending), wait and
-re-poll. Do not force-push or skip checks.
+Do not force-push or skip checks.
 
 **Reconcile gitcloud** after the PR merges to `<default_branch>`. Re-fetch
 both remotes to get their latest states — gitcloud may have received commits
@@ -565,8 +583,9 @@ push in step 9 succeeded):
   everything else. Do not conflate them — cherry-pick or squash on the primary
   repo would break the gitcloud fast-forward.
 - **Merge commit, not squash.** The PR merge MUST be `--merge`. Squash discards
-  the field-commit SHAs folded in by step 5, making gitcloud reconciliation a
-  force-push rather than a fast-forward.
+  the field-commit SHAs folded in by step 5; the resulting non-fast-forward would
+  be refused by gitcloud when pushing (step 9's ancestor check would also fail).
+  The merge approach keeps gitcloud reconcilable by fast-forward.
 - **`issue_sync` is optional on dev side.** If `dev_push` is absent from the
   config, skip silently — `gh` handles everything. Only field-side wrap-up
   (which is disallowed) would need the full `issue_sync` suite.

--- a/.claude/skills/wrap-up-deployment/SKILL.md
+++ b/.claude/skills/wrap-up-deployment/SKILL.md
@@ -133,8 +133,9 @@ The deployment start date from the issue title is `<start-date>` (format
 Fetch the field remote so its branches are up to date. Use `git -C` to target
 the project-repo worktree (not the workspace root); the `gitcloud` remote is
 configured there. The project-repo worktree path is derived from the config:
-`<workspace_root>/.workspace-worktrees/issue-<N>/layers/main/<layer>_ws/src/<packages[0]>` —
-confirm with `<workspace_root>/.agent/scripts/worktree_list.sh`.
+`<workspace_root>/layers/worktrees/issue-<REPO_SLUG>-<N>/<layer>_ws/src/<packages[0]>` —
+where `<REPO_SLUG>` is the project-repo directory name — confirm with
+`<workspace_root>/.agent/scripts/worktree_list.sh`.
 
 ```bash
 git -C "<project-repo-worktree-path>" fetch gitcloud
@@ -143,7 +144,7 @@ git -C "<project-repo-worktree-path>" fetch gitcloud
 (If `gitcloud` is not a configured remote for the project repo, ask the
 operator for the correct field-remote name. If the fetch fails — network
 unreachable, wrong remote name — note the error, continue with whatever log
-files are already on disk, and revisit the fetch before step 7a.)
+files are already on disk, and revisit the fetch before step 5.)
 
 Gather all log files for this deployment in `<log_dir>/<YYYY>/`:
 
@@ -169,7 +170,57 @@ LOGFILE="<log_dir>/<YYYY>/<start-date>_dev_logs.md"
 <workspace_root>/.agent/scripts/dlog.sh "$LOGFILE" "wrap-up started"
 ```
 
-### 5. Operator-correction interview
+### 5. Reconcile field code — SHA-preserving merge
+
+Merge the deployment repo's own field commits into the wrap-up branch
+**before** interviewing the operator. Editing field logs in place before the
+gitcloud merge risks merge conflicts on every corrected log — merging first
+gives a clean, up-to-date base for the operator interview and corrections.
+
+All git operations below target the **project-repo worktree** — the git repo
+for `<packages[0]>` inside the deployment worktree, where the `gitcloud` and
+`origin` remotes live:
+
+```
+<project-repo-worktree-path> =
+  <workspace_root>/layers/worktrees/issue-<REPO_SLUG>-<N>/<layer>_ws/src/<packages[0]>
+```
+
+(Confirm with `<workspace_root>/.agent/scripts/worktree_list.sh` if the exact
+path is uncertain.)
+
+Re-fetch gitcloud to get its latest state before the merge — field hosts may
+have pushed commits during the interval since step 4:
+
+```bash
+git -C "<project-repo-worktree-path>" fetch gitcloud
+```
+
+If the fetch fails, stop and report to the operator before merging — merging
+from a stale remote risks missing field commits. Resolve the fetch error
+(network, wrong remote name) before continuing.
+
+Then merge:
+
+```bash
+git -C "<project-repo-worktree-path>" merge gitcloud/<default_branch>
+```
+
+If conflicts arise that cannot be cleanly resolved, abort and surface for the
+operator:
+
+```bash
+git -C "<project-repo-worktree-path>" merge --abort
+```
+
+Do not auto-resolve anything that touches control logic.
+
+After a successful merge, the wrap-up branch is ahead of both
+`origin/<default_branch>` (via the PR) and `gitcloud/<default_branch>`
+(which will fast-forward after merge). Record the merge commit SHA in the
+dev log via `dlog.sh`.
+
+### 6. Operator-correction interview
 
 **This is the highest-value step. Do not skip or compress it.**
 
@@ -206,21 +257,30 @@ Ask follow-up questions if an answer surfaces a new issue (e.g., a mislabeled
 log file implies all its timestamps may also be off). This step is conversational,
 not mechanical.
 
-### 6. Consolidate the dev log
+### 7. Consolidate the dev log
 
 Append the following sections to the dev log file
 (`<log_dir>/<YYYY>/<start-date>_dev_logs.md`). Use
 `<workspace_root>/.agent/scripts/dlog.sh` for any entries that need a
 timestamp; write Markdown section headers and body prose directly.
 
-#### 6a. Apply operator corrections to field logs in place
+#### 7a. Apply operator corrections to field logs in place
 
 For each correction from the interview that pertains to a specific field log
 file (wrong label, misdated entry, incorrect root cause attributed to the
 agent):
 
-- **Mislabeled log file**: rename the file to the correct name (preserving the
-  `<start-date>_<label>_logs.md` pattern with the corrected label).
+- **Mislabeled log file**: use `git mv` to rename the file to the correct name
+  (preserving the `<start-date>_<label>_logs.md` pattern with the corrected
+  label) — a shell-glob `git add` only stages existing paths and leaves the
+  old path as an unstaged deletion:
+
+  ```bash
+  git -C "<project-repo-worktree-path>" mv \
+      "<log_dir>/<YYYY>/<start-date>_<old-label>_logs.md" \
+      "<log_dir>/<YYYY>/<start-date>_<corrected-label>_logs.md"
+  ```
+
 - **Misdated entry**: edit the entry's timestamp in the file to the corrected
   value; add an inline note: `<!-- corrected at wrap-up: operator reported
   actual time was <HH:MM> -->`.
@@ -231,13 +291,14 @@ agent):
   > **Wrap-up correction**: [operator's correction verbatim or paraphrased]
   ```
 
-Stage all corrected field log files:
+Stage all corrected field log files (including any renames already done with
+`git mv`):
 
 ```bash
-git -C "<project-repo-worktree-path>" add <log_dir>/<YYYY>/<start-date>_*_logs.md
+git -C "<project-repo-worktree-path>" add -A "<log_dir>/<YYYY>/"
 ```
 
-#### 6b. Append structured summary to dev log
+#### 7b. Append structured summary to dev log
 
 Append these four sections to the dev log (use `dlog.sh` only for
 timestamped *events*; section headers and prose go in directly):
@@ -250,7 +311,7 @@ Written in past tense. No invented mechanisms; only what happened.>
 
 ## Operator Corrections
 
-<Verbatim or close-to-verbatim record of corrections from step 5.
+<Verbatim or close-to-verbatim record of corrections from step 6.
 If the operator reported no corrections, write "Operator confirmed
 logs accurate; no corrections." Attribute each item: "Operator:
 '…'">
@@ -266,10 +327,10 @@ Bullet list. No speculation.>
 <Items deferred from live ops or surfaced by this wrap-up that
 need a GitHub issue. Format: "- [ ] <title> — <one-line root
 cause or outstanding question>". Dedup against existing open issues
-before this list drives issue-filing in step 9.>
+before this list drives issue-filing in step 10.>
 ```
 
-#### 6c. Stamp the dev log link in the deployment issue
+#### 7c. Stamp the dev log link in the deployment issue
 
 Verify the deployment issue's `## Logs` section includes a link to the dev
 log:
@@ -288,10 +349,10 @@ gh issue edit <N> --body-file <tmpfile>
 `--body-file`. Use `gh issue view <N> --json body --jq '.body'` to get the
 current body.)
 
-#### 6d. Commit the consolidated dev log
+#### 7d. Commit the consolidated dev log
 
 Stage the dev log and all corrected field logs, then commit. This commit
-**must land on the branch before `gh pr create`** in step 8 — without it the
+**must land on the branch before `gh pr create`** in step 9 — without it the
 log additions and operator corrections are never part of the PR and are lost
 when the worktree is removed:
 
@@ -305,62 +366,7 @@ git -C "<project-repo-worktree-path>" \
     commit -m "chore: wrap-up deployment #<N> — consolidated dev log and operator corrections"
 ```
 
-### 7. Reconcile field code
-
-Two distinct mechanisms. Do both.
-
-#### 7a. SHA-preserving merge — deployment repo's own field commits
-
-The deployment repo (primary project repo in `packages[0]`) accumulates field
-commits on `gitcloud/<default_branch>` during live ops. Bring these into the
-deployment branch with a **merge commit** — NOT cherry-pick, NOT squash — to
-preserve SHA lineage and make reconciliation to gitcloud a fast-forward after
-the wrap-up PR merges.
-
-All git operations below target the **project-repo worktree** — the git repo
-for `<packages[0]>` inside the deployment worktree, where the `gitcloud` and
-`origin` remotes live:
-
-```
-<project-repo-worktree-path> =
-  <workspace_root>/.workspace-worktrees/issue-<N>/layers/main/<layer>_ws/src/<packages[0]>
-```
-
-(Confirm with `<workspace_root>/.agent/scripts/worktree_list.sh` if the exact
-path is uncertain.)
-
-Re-fetch gitcloud to get its latest state before the merge — field hosts may
-have pushed commits during the wrap-up window:
-
-```bash
-git -C "<project-repo-worktree-path>" fetch gitcloud
-```
-
-If the fetch fails, stop and report to the operator before merging — merging
-from a stale remote risks missing field commits. Resolve the fetch error
-(network, wrong remote name) before continuing.
-
-Then merge:
-
-```bash
-git -C "<project-repo-worktree-path>" merge gitcloud/<default_branch>
-```
-
-If conflicts arise that cannot be cleanly resolved, abort and surface for the
-operator:
-
-```bash
-git -C "<project-repo-worktree-path>" merge --abort
-```
-
-Do not auto-resolve anything that touches control logic.
-
-After a successful merge, the wrap-up branch is ahead of both
-`origin/<default_branch>` (via the PR) and `gitcloud/<default_branch>`
-(which will fast-forward after merge). Record the merge commit SHA in the
-dev log via `dlog.sh`.
-
-#### 7b. `/import-field-changes` — other repos
+### 8. `/import-field-changes` — other repos
 
 Other repos that received field commits (nav packages, sensors, interfaces,
 etc.) use the `/import-field-changes` skill — that skill opens per-repo import
@@ -370,6 +376,12 @@ NOT attempt to merge those repos directly; it delegates:
 > Invoke `/import-field-changes` for each repo that has field commits on
 > `gitcloud` but is NOT the primary deployment repo (`packages[0]`).
 
+**Prerequisite**: `/import-field-changes` reads `field_remote` from
+`.agent/project_config.yaml` (not `.agents/deployment.yaml`) — verify that
+file exists and contains the `field_remote` key before invoking the skill.
+If missing, create it: `echo "field_remote: gitcloud" > .agent/project_config.yaml`
+(substituting the actual remote name if different).
+
 Ask the operator: "Which other repos received field commits during this
 deployment?" Run `/import-field-changes` for each answer. Record the resulting
 PR URLs in the dev log.
@@ -377,7 +389,7 @@ PR URLs in the dev log.
 If no other repos had field commits, record that explicitly in the dev log:
 "No other repos had field commits; `/import-field-changes` not needed."
 
-### 8. PR → merge → gitcloud reconcile → remove worktree
+### 9. PR → merge → gitcloud reconcile
 
 **If re-running after interruption**, check what already completed before
 repeating any irreversible action:
@@ -388,9 +400,18 @@ gh issue view <N> --json state --jq '.state'
 ```
 
 - PR already merged and issue closed → skip PR create and merge; proceed to
-  the gitcloud reconcile and worktree removal below if not yet done.
+  the gitcloud reconcile if not yet done, then step 10.
 - PR open but not merged → skip `gh pr create`; proceed from the merge step.
-- Issue already closed and worktree already removed → no further action needed.
+- Issue already closed and gitcloud already reconciled → skip to step 10 if
+  not yet done.
+
+**Push the deployment branch** so `gh pr create` can find it on origin — the
+feature branch is local-only until this push, and with two remotes on the
+project repo `gh` cannot auto-pick:
+
+```bash
+git -C "<project-repo-worktree-path>" push -u origin "<branch-name>"
+```
 
 **Open the wrap-up PR** (skip if already open or merged):
 
@@ -416,9 +437,20 @@ The PR body must include:
 gh pr merge <PR_number> --merge
 ```
 
-Squash would discard the field-commit history folded in by step 7a; rebase
+Squash would discard the field-commit history folded in by step 5; rebase
 would break the SHA-preserving intent. The deployment issue closes automatically
 via the `Closes #<N>` reference.
+
+**Confirm the PR merged** before starting the gitcloud reconcile — poll until
+the state is `MERGED`:
+
+```bash
+gh pr view <PR_number> --json state --jq '.state'
+# Must output "MERGED" before continuing
+```
+
+If the state is not `MERGED` (e.g., CI checks still pending), wait and
+re-poll. Do not force-push or skip checks.
 
 **Reconcile gitcloud** after the PR merges to `<default_branch>`. Re-fetch
 both remotes to get their latest states — gitcloud may have received commits
@@ -452,11 +484,11 @@ Only after the ancestor check passes:
 git -C "<project-repo-worktree-path>" push gitcloud origin/<default_branch>:<default_branch>
 ```
 
-**Verify the push succeeded** before proceeding to worktree removal. If the
-push fails, stop here — the worktree is the retry context. Do not remove it.
+**Verify the push succeeded** before proceeding. If the push fails, stop here —
+the worktree is the retry context. Do not remove it.
 
 This fast-forwards `gitcloud/<default_branch>` to match `origin/<default_branch>`,
-completing the SHA-preserving round-trip from step 7a.
+completing the SHA-preserving round-trip from step 5.
 
 If `issue_sync.dev_push` is configured **and is not the literal string `TODO`**,
 run it now to propagate the closed issue status to the field-visible issue source:
@@ -468,13 +500,10 @@ run it now to propagate the closed issue status to the field-visible issue sourc
 On failure, print `issue_sync.failure_hint`. This is advisory — the GitHub
 issue is already closed; `dev_push` just keeps the field-side view in sync.
 
-**Remove the worktree** (only after a successful gitcloud push):
+### 10. File new RCA issues selectively
 
-```bash
-<workspace_root>/.agent/scripts/worktree_remove.sh --issue <N>
-```
-
-### 9. File new RCA issues selectively
+File RCA issues **before** removing the worktree — worktree removal breaks
+`gh` origin auto-detection for the project repo.
 
 From the `## RCA / Follow-up Backlog` in the dev log and any items surfaced
 during wrap-up, decide which warrant a GitHub issue.
@@ -515,6 +544,13 @@ link to the deployment issue.
 issues from prior deployments that were never wrapped up, list them for the
 operator and ask whether to close them with a note. Do not close them unilaterally.
 
+**Remove the worktree** (only after RCA filing is complete and the gitcloud
+push in step 9 succeeded):
+
+```bash
+<workspace_root>/.agent/scripts/worktree_remove.sh --issue <N>
+```
+
 ## Guidelines
 
 - **This is a dev-side-only skill.** The very first step after reading config is
@@ -524,12 +560,12 @@ operator and ask whether to close them with a note. Do not close them unilateral
   are written under sterile-cockpit pressure and may contain misattributions,
   premature conclusions, or events that didn't happen as logged. This is the only
   opportunity to fix the permanent record before it propagates.
-- **Two merge mechanisms, not one.** The SHA-preserving `git merge` (step 7a) is
-  for the primary deployment repo. `/import-field-changes` (step 7b) is for
+- **Two merge mechanisms, not one.** The SHA-preserving `git merge` (step 5) is
+  for the primary deployment repo. `/import-field-changes` (step 8) is for
   everything else. Do not conflate them — cherry-pick or squash on the primary
   repo would break the gitcloud fast-forward.
 - **Merge commit, not squash.** The PR merge MUST be `--merge`. Squash discards
-  the field-commit SHAs folded in by step 7a, making gitcloud reconciliation a
+  the field-commit SHAs folded in by step 5, making gitcloud reconciliation a
   force-push rather than a fast-forward.
 - **`issue_sync` is optional on dev side.** If `dev_push` is absent from the
   config, skip silently — `gh` handles everything. Only field-side wrap-up
@@ -555,7 +591,7 @@ operator and ask whether to close them with a note. Do not close them unilateral
 - [`.claude/skills/start-deployment/SKILL.md`](../start-deployment/SKILL.md) — sibling skill (phase [0])
 - [`.agent/knowledge/deployment_mode.md`](../../../.agent/knowledge/deployment_mode.md) — operational reference (fuller treatment of contract, lifecycle, schema)
 - [`.agent/templates/deployment_config.yaml`](../../../.agent/templates/deployment_config.yaml) — per-project config template
-- [`.agent/scripts/import-field-changes`](../../../.agent/scripts/) (skill: `/import-field-changes`) — per-repo field import PRs (step 7b)
+- [`.claude/skills/import-field-changes/SKILL.md`](../import-field-changes/SKILL.md) (skill: `/import-field-changes`) — per-repo field import PRs (step 8)
 - [#435](https://github.com/rolker/ros2_agent_workspace/issues/435) — debrief / bag analysis checklist (out of scope here; tracked there)
 - [#495](https://github.com/rolker/ros2_agent_workspace/issues/495) — umbrella for the full deployment lifecycle
 - [#496](https://github.com/rolker/ros2_agent_workspace/issues/496) — recovery checklist (phase [2]; follow-up)

--- a/.claude/skills/wrap-up-deployment/SKILL.md
+++ b/.claude/skills/wrap-up-deployment/SKILL.md
@@ -130,20 +130,29 @@ dev-side `issue_sync` is optional; `gh` alone handles issue edits.
 The deployment start date from the issue title is `<start-date>` (format
 `YYYY-MM-DD`).
 
-Fetch the field remote so its branches are up to date:
+Fetch the field remote so its branches are up to date. Use `git -C` to target
+the project-repo worktree (not the workspace root); the `gitcloud` remote is
+configured there. The project-repo worktree path is derived from the config:
+`<workspace_root>/.workspace-worktrees/issue-<N>/layers/main/<layer>_ws/src/<packages[0]>` —
+confirm with `<workspace_root>/.agent/scripts/worktree_list.sh`.
 
 ```bash
-git fetch gitcloud
+git -C "<project-repo-worktree-path>" fetch gitcloud
 ```
 
 (If `gitcloud` is not a configured remote for the project repo, ask the
-operator for the correct field-remote name.)
+operator for the correct field-remote name. If the fetch fails — network
+unreachable, wrong remote name — note the error, continue with whatever log
+files are already on disk, and revisit the fetch before step 7a.)
 
 Gather all log files for this deployment in `<log_dir>/<YYYY>/`:
 
 ```bash
 ls <log_dir>/<YYYY>/<start-date>_*_logs.md
 ```
+
+If the glob matches no files, note "no per-host field logs found for
+`<start-date>`" and continue — do not abort.
 
 Read each file. List them for the operator: one line per file, showing the
 host label extracted from the filename (`<start-date>_<label>_logs.md`).
@@ -222,8 +231,11 @@ agent):
   > **Wrap-up correction**: [operator's correction verbatim or paraphrased]
   ```
 
-Stage all corrected field log files for commit (`git add`); do NOT commit yet
-(step 8 is where the commit lands).
+Stage all corrected field log files:
+
+```bash
+git -C "<project-repo-worktree-path>" add <log_dir>/<YYYY>/<start-date>_*_logs.md
+```
 
 #### 6b. Append structured summary to dev log
 
@@ -276,6 +288,23 @@ gh issue edit <N> --body-file <tmpfile>
 `--body-file`. Use `gh issue view <N> --json body --jq '.body'` to get the
 current body.)
 
+#### 6d. Commit the consolidated dev log
+
+Stage the dev log and all corrected field logs, then commit. This commit
+**must land on the branch before `gh pr create`** in step 8 — without it the
+log additions and operator corrections are never part of the PR and are lost
+when the worktree is removed:
+
+```bash
+git -C "<project-repo-worktree-path>" add \
+    "<log_dir>/<YYYY>/<start-date>_dev_logs.md" \
+    "<log_dir>/<YYYY>/<start-date>_*_logs.md"
+git -C "<project-repo-worktree-path>" \
+    -c user.name="Claude Code Agent" \
+    -c user.email="roland+claude-code@ccom.unh.edu" \
+    commit -m "chore: wrap-up deployment #<N> — consolidated dev log and operator corrections"
+```
+
 ### 7. Reconcile field code
 
 Two distinct mechanisms. Do both.
@@ -286,19 +315,50 @@ The deployment repo (primary project repo in `packages[0]`) accumulates field
 commits on `gitcloud/<default_branch>` during live ops. Bring these into the
 deployment branch with a **merge commit** — NOT cherry-pick, NOT squash — to
 preserve SHA lineage and make reconciliation to gitcloud a fast-forward after
-the wrap-up PR merges:
+the wrap-up PR merges.
 
-```bash
-git merge gitcloud/<default_branch>
+All git operations below target the **project-repo worktree** — the git repo
+for `<packages[0]>` inside the deployment worktree, where the `gitcloud` and
+`origin` remotes live:
+
+```
+<project-repo-worktree-path> =
+  <workspace_root>/.workspace-worktrees/issue-<N>/layers/main/<layer>_ws/src/<packages[0]>
 ```
 
-Run from inside the deployment worktree (`feature/issue-<N>` on the deployment
-repo). Resolve any conflicts with the operator; do not auto-resolve anything
-that touches control logic.
+(Confirm with `<workspace_root>/.agent/scripts/worktree_list.sh` if the exact
+path is uncertain.)
 
-After this merge, the wrap-up branch is ahead of both `origin/<default_branch>`
-(via the PR) and `gitcloud/<default_branch>` (which will fast-forward after
-merge). Record the merge commit SHA in the dev log via `dlog.sh`.
+Re-fetch gitcloud to get its latest state before the merge — field hosts may
+have pushed commits during the wrap-up window:
+
+```bash
+git -C "<project-repo-worktree-path>" fetch gitcloud
+```
+
+If the fetch fails, stop and report to the operator before merging — merging
+from a stale remote risks missing field commits. Resolve the fetch error
+(network, wrong remote name) before continuing.
+
+Then merge:
+
+```bash
+git -C "<project-repo-worktree-path>" merge gitcloud/<default_branch>
+```
+
+If conflicts arise that cannot be cleanly resolved, abort and surface for the
+operator:
+
+```bash
+git -C "<project-repo-worktree-path>" merge --abort
+```
+
+Do not auto-resolve anything that touches control logic.
+
+After a successful merge, the wrap-up branch is ahead of both
+`origin/<default_branch>` (via the PR) and `gitcloud/<default_branch>`
+(which will fast-forward after merge). Record the merge commit SHA in the
+dev log via `dlog.sh`.
 
 #### 7b. `/import-field-changes` — other repos
 
@@ -319,25 +379,36 @@ If no other repos had field commits, record that explicitly in the dev log:
 
 ### 8. PR → merge → gitcloud reconcile → remove worktree
 
-**Open the wrap-up PR**:
+**If re-running after interruption**, check what already completed before
+repeating any irreversible action:
+
+```bash
+gh pr list --search "Wrap up deployment #<N>" --state all --json number,state,title
+gh issue view <N> --json state --jq '.state'
+```
+
+- PR already merged and issue closed → skip PR create and merge; proceed to
+  the gitcloud reconcile and worktree removal below if not yet done.
+- PR open but not merged → skip `gh pr create`; proceed from the merge step.
+- Issue already closed and worktree already removed → no further action needed.
+
+**Open the wrap-up PR** (skip if already open or merged):
 
 ```bash
 BODY_FILE=$(mktemp /tmp/gh_body.XXXXXX.md)
 # Write PR body to $BODY_FILE — include dev-log link, summary, operator-corrections summary
 gh pr create \
     --title "Wrap up deployment #<N>: <scope>" \
-    --body-file "$BODY_FILE" \
-    --draft
+    --body-file "$BODY_FILE"
 rm "$BODY_FILE"
 ```
 
-The PR body should include:
-- Link to the deployment issue (will be closed by the merge).
+The PR body must include:
+- `Closes #<N>` so GitHub closes the deployment issue on merge.
+- Link to the deployment issue.
 - One-paragraph summary from the dev log's `## Summary` section.
 - Link to each per-host log file and each import-field-changes PR.
 - AI signature.
-
-Add `Closes #<N>` in the PR body so GitHub closes the deployment issue on merge.
 
 **Merge** — use a **merge commit** (not squash, not rebase):
 
@@ -349,18 +420,46 @@ Squash would discard the field-commit history folded in by step 7a; rebase
 would break the SHA-preserving intent. The deployment issue closes automatically
 via the `Closes #<N>` reference.
 
-**Reconcile gitcloud** after the PR merges to `<default_branch>`:
+**Reconcile gitcloud** after the PR merges to `<default_branch>`. Re-fetch
+both remotes to get their latest states — gitcloud may have received commits
+during the long wrap-up window:
 
 ```bash
-git fetch origin
-git push gitcloud origin/<default_branch>:<default_branch>
+git -C "<project-repo-worktree-path>" fetch gitcloud
+git -C "<project-repo-worktree-path>" fetch origin
 ```
+
+Verify `origin/<default_branch>` is ahead of or equal to
+`gitcloud/<default_branch>` before pushing — the push must be a fast-forward:
+
+```bash
+git -C "<project-repo-worktree-path>" merge-base --is-ancestor \
+    gitcloud/<default_branch> origin/<default_branch>
+```
+
+If this exits non-zero, `gitcloud/<default_branch>` has commits not yet in
+`origin/<default_branch>`. **Do not push; do not force-push.** Surface for
+manual reconcile:
+
+> `gitcloud/<default_branch>` has diverged from `origin/<default_branch>`.
+> Inspect with:
+> `git -C <repo> log --oneline gitcloud/<default_branch>..origin/<default_branch>`
+> and its reverse. Resolve with the operator before pushing.
+
+Only after the ancestor check passes:
+
+```bash
+git -C "<project-repo-worktree-path>" push gitcloud origin/<default_branch>:<default_branch>
+```
+
+**Verify the push succeeded** before proceeding to worktree removal. If the
+push fails, stop here — the worktree is the retry context. Do not remove it.
 
 This fast-forwards `gitcloud/<default_branch>` to match `origin/<default_branch>`,
 completing the SHA-preserving round-trip from step 7a.
 
-If `issue_sync.dev_push` is configured, run it now to propagate the closed
-issue status to the field-visible issue source:
+If `issue_sync.dev_push` is configured **and is not the literal string `TODO`**,
+run it now to propagate the closed issue status to the field-visible issue source:
 
 ```bash
 <issue_sync.dev_push>
@@ -369,7 +468,7 @@ issue status to the field-visible issue source:
 On failure, print `issue_sync.failure_hint`. This is advisory — the GitHub
 issue is already closed; `dev_push` just keeps the field-side view in sync.
 
-**Remove the worktree**:
+**Remove the worktree** (only after a successful gitcloud push):
 
 ```bash
 <workspace_root>/.agent/scripts/worktree_remove.sh --issue <N>
@@ -402,7 +501,15 @@ Do NOT file issues for:
 - One-off field conditions unlikely to repeat.
 
 Each filed issue gets the project's standard labels plus `rca` if appropriate.
-Include the AI signature and a link to the deployment issue.
+If the `rca` label does not exist in the project repo, create it before filing:
+
+```bash
+gh label create rca --color B60205 --description "Root cause analysis" 2>/dev/null || true
+```
+
+This is a create-or-skip: the `|| true` means a pre-existing label or a
+missing-label error does not abort issue filing. Include the AI signature and a
+link to the deployment issue.
 
 **Close stale deployment issues** — if there are leftover open `deployment`-labeled
 issues from prior deployments that were never wrapped up, list them for the

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -107,7 +107,7 @@ Available workflow skills: `run-issue`, `review-issue`, `plan-task`, `review-pla
 `gather-project-knowledge`, `onboard-project`, `brand-guidelines`,
 `triage-reviews`, `address-findings`, `skill-importer`, `document-package`, `issue-triage`,
 `test-engineering`, `inspiration-tracker`, `import-field-changes`,
-`start-deployment`.
+`start-deployment`, `wrap-up-deployment`.
 
 ## References
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,8 +251,11 @@ on the same host are unaffected.
 See [ADR-0014](docs/decisions/0014-deployment-mode.md) for the decision record
 and [`.agent/knowledge/deployment_mode.md`](.agent/knowledge/deployment_mode.md)
 for the operational reference (urgency contract, lifecycle phases, log-naming
-convention, project-config schema). The wrap-up half (`/wrap-up-deployment`)
-and recovery checklist are tracked under umbrella [#495](https://github.com/rolker/ros2_agent_workspace/issues/495).
+convention, project-config schema). The wrap-up skill
+([`.claude/skills/wrap-up-deployment/SKILL.md`](.claude/skills/wrap-up-deployment/SKILL.md))
+closes the deployment issue, reconciles field code, and files RCA follow-ups.
+The recovery checklist ([#496](https://github.com/rolker/ros2_agent_workspace/issues/496))
+remains a follow-up.
 
 ## AI Signature (Required on all GitHub Issues/PRs/Comments)
 


### PR DESCRIPTION
## v1 `/wrap-up-deployment` skill — phase [3] orchestrator

Codifies the deployment wrap-up flow run end-to-end **4× manually** (echoboats #277/#289/#295/#299) into the missing sibling of `/start-deployment` (#501). Closes #530, part of #495.

### What's here
- **`.claude/skills/wrap-up-deployment/SKILL.md`** — 10-step generic orchestrator (ADR-0003: all project specifics via `.agents/deployment.yaml`): read config → verify dev-side → find deployment issue → collect per-host field logs → **SHA-preserving gitcloud merge** → **operator-correction interview (one question at a time)** → consolidate dev log (Summary/Corrections/Lessons/RCA backlog) → `/import-field-changes` for other repos → PR→merge→gitcloud reconcile → file new RCA issues selectively → remove worktree. Writes **no `progress.md` entry** (deployment-lifecycle, not the dev pipeline — mirrors `start-deployment`); wrap-up **relaxes** the sterile-cockpit contract.
- AGENTS.md deployment-mode pointer, all 3 non-Claude adapter skill lists, `deployment_mode.md` updated (ADR-0006 / consequences).

### Lifecycle (run-issue, local-first)
review-issue → plan → review-plan → implement → **review-code ×3** → publish. **24 findings across 3 review rounds resolved** (broad correctness → step ordering → git/gh-flag semantics); the merge-before-correct reorder, `git -C` project-repo targeting, merge-commit identity, and CI-aware merge were the substantive catches.

### Follow-up
- ADR-0014 status flip "Proposed → Accepted" (post-merge).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
