### PR TITLE
docs(ADR-0014): flip status Proposed → Accepted (#535)

### DIFF
--- a/docs/decisions/0014-deployment-mode.md
+++ b/docs/decisions/0014-deployment-mode.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-Proposed — recorded ahead of full implementation so the design has a stable
-reference; lifecycle skills (`/start-deployment` first, [#501](https://github.com/rolker/ros2_agent_workspace/issues/501))
-may land before this ADR is marked Accepted.
+Accepted — both lifecycle skills have shipped (`/start-deployment`,
+[#501](https://github.com/rolker/ros2_agent_workspace/issues/501); `/wrap-up-deployment`,
+[#530](https://github.com/rolker/ros2_agent_workspace/issues/530)) and the urgency
+contract has been exercised across multiple live deployments
+(`unh_echoboats_project11` #277 / #289 / #295 / #299).
 
 ## Context
 


### PR DESCRIPTION
Flip ADR-0014 status **Proposed → Accepted**. Both deployment-mode lifecycle skills have shipped — `/start-deployment` (#501) and `/wrap-up-deployment` (#530) — and the urgency contract has been exercised across multiple live deployments (rolker/unh_echoboats_project11 #277/#289/#295/#299). The ADR said it would be marked Accepted once the lifecycle skills land.

Closes #535. Part of #495.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
