### PR TITLE
run-issue: background dispatch (#531) + address-findings fix-pass routing (#538)

### DIFF
--- a/.agent/work-plans/issue-531/progress.md
+++ b/.agent/work-plans/issue-531/progress.md
@@ -1,0 +1,24 @@
+---
+issue: 531
+---
+
+# Issue #531 — run-issue: background container dispatch
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 17:27 +00:00
+**By**: Claude Code Agent (Claude Opus 4.6)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-531 at `97463ac`
+**Mode**: pre-push
+**Depth**: Standard (reason: `.claude/skills/*/SKILL.md` is a Governance override-trigger)
+**Must-fix**: 1 | **Suggestions**: 4
+
+### Findings
+- [ ] (must-fix) Inaccurate rationale: `--type "Local Review (Pre-Push)"` does NOT surface `## Local Review` per `progress_read.py` `_matches_type`; drop the false claim — `.claude/skills/address-findings/SKILL.md:74`
+- [ ] (suggestion) Note that pre-push *suggestions* are auto-actioned (address-findings acts on all unchecked findings, unlike post-PR triage) — `.claude/skills/address-findings/SKILL.md:28`
+- [ ] (suggestion) Add a max-rounds/escalation note to the automated changes-requested → address-findings → review-code loop — `.claude/skills/run-issue/SKILL.md:147`
+- [ ] (suggestion) Document where the dispatcher FAILED report surfaces on the background re-invocation path — `.claude/skills/run-issue/SKILL.md:57`
+- [ ] (suggestion) Note that "single latest entry" relies on progress.md append order — `.claude/skills/address-findings/SKILL.md:75`
+- [ ] (consequence) Update `review-code/SKILL.md` Next-step to document the pre-push changes-requested → address-findings branch (file not in this diff) — `.claude/skills/review-code/SKILL.md:918`

--- a/.agent/work-plans/issue-531/progress.md
+++ b/.agent/work-plans/issue-531/progress.md
@@ -22,3 +22,21 @@ issue: 531
 - [ ] (suggestion) Document where the dispatcher FAILED report surfaces on the background re-invocation path — `.claude/skills/run-issue/SKILL.md:57`
 - [ ] (suggestion) Note that "single latest entry" relies on progress.md append order — `.claude/skills/address-findings/SKILL.md:75`
 - [ ] (consequence) Update `review-code/SKILL.md` Next-step to document the pre-push changes-requested → address-findings branch (file not in this diff) — `.claude/skills/review-code/SKILL.md:918`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 19:43 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-531 at `529d390`
+**Mode**: pre-push
+**Depth**: Standard (reason: `.claude/skills/*/SKILL.md` is a Governance override-trigger)
+**Must-fix**: 1 | **Suggestions**: 4
+
+### Findings
+- [ ] (must-fix) Decision-table row not generalized: `## Implementation` preceded by `## Local Review (Pre-Push)` (the new pre-push address-findings state) matches no table row, contradicting the prose at :137 — add "or `## Local Review (Pre-Push)`" — `.claude/skills/run-issue/SKILL.md:119`
+- [ ] (suggestion) Background path: instruct gating on the dispatch exit/FAILED report before routing on the timeline, so a no-entry failure isn't silently re-tried — `.claude/skills/run-issue/SKILL.md:67`
+- [ ] (suggestion) Give the host a durable round counter for the address-findings⇄review-code loop (count `## Local Review (Pre-Push)` entries) — `.claude/skills/run-issue/SKILL.md:162`
+- [ ] (suggestion) Caveat that background re-invocation depends on the host-runtime completion callback (mirror the Agent-tool caveat at :48-51) — `.claude/skills/run-issue/SKILL.md:61`
+- [ ] (suggestion) Round-1 findings addressed in `529d390` but checkboxes remain unchecked and no `## Implementation` entry recorded — timeline misrepresents resolution state — `.agent/work-plans/issue-531/progress.md:19`

--- a/.agent/work-plans/issue-531/progress.md
+++ b/.agent/work-plans/issue-531/progress.md
@@ -16,12 +16,12 @@ issue: 531
 **Must-fix**: 1 | **Suggestions**: 4
 
 ### Findings
-- [ ] (must-fix) Inaccurate rationale: `--type "Local Review (Pre-Push)"` does NOT surface `## Local Review` per `progress_read.py` `_matches_type`; drop the false claim — `.claude/skills/address-findings/SKILL.md:74`
-- [ ] (suggestion) Note that pre-push *suggestions* are auto-actioned (address-findings acts on all unchecked findings, unlike post-PR triage) — `.claude/skills/address-findings/SKILL.md:28`
-- [ ] (suggestion) Add a max-rounds/escalation note to the automated changes-requested → address-findings → review-code loop — `.claude/skills/run-issue/SKILL.md:147`
-- [ ] (suggestion) Document where the dispatcher FAILED report surfaces on the background re-invocation path — `.claude/skills/run-issue/SKILL.md:57`
-- [ ] (suggestion) Note that "single latest entry" relies on progress.md append order — `.claude/skills/address-findings/SKILL.md:75`
-- [ ] (consequence) Update `review-code/SKILL.md` Next-step to document the pre-push changes-requested → address-findings branch (file not in this diff) — `.claude/skills/review-code/SKILL.md:918`
+- [x] (must-fix) Inaccurate rationale: `--type "Local Review (Pre-Push)"` does NOT surface `## Local Review` per `progress_read.py` `_matches_type`; drop the false claim — `.claude/skills/address-findings/SKILL.md:74`
+- [x] (suggestion) Note that pre-push *suggestions* are auto-actioned (address-findings acts on all unchecked findings, unlike post-PR triage) — `.claude/skills/address-findings/SKILL.md:28`
+- [x] (suggestion) Add a max-rounds/escalation note to the automated changes-requested → address-findings → review-code loop — `.claude/skills/run-issue/SKILL.md:147`
+- [x] (suggestion) Document where the dispatcher FAILED report surfaces on the background re-invocation path — `.claude/skills/run-issue/SKILL.md:57`
+- [x] (suggestion) Note that "single latest entry" relies on progress.md append order — `.claude/skills/address-findings/SKILL.md:75`
+- [x] (consequence) Update `review-code/SKILL.md` Next-step to document the pre-push changes-requested → address-findings branch (file not in this diff) — `.claude/skills/review-code/SKILL.md:918`
 
 ## Local Review (Pre-Push)
 **Status**: complete
@@ -35,8 +35,19 @@ issue: 531
 **Must-fix**: 1 | **Suggestions**: 4
 
 ### Findings
-- [ ] (must-fix) Decision-table row not generalized: `## Implementation` preceded by `## Local Review (Pre-Push)` (the new pre-push address-findings state) matches no table row, contradicting the prose at :137 — add "or `## Local Review (Pre-Push)`" — `.claude/skills/run-issue/SKILL.md:119`
-- [ ] (suggestion) Background path: instruct gating on the dispatch exit/FAILED report before routing on the timeline, so a no-entry failure isn't silently re-tried — `.claude/skills/run-issue/SKILL.md:67`
-- [ ] (suggestion) Give the host a durable round counter for the address-findings⇄review-code loop (count `## Local Review (Pre-Push)` entries) — `.claude/skills/run-issue/SKILL.md:162`
-- [ ] (suggestion) Caveat that background re-invocation depends on the host-runtime completion callback (mirror the Agent-tool caveat at :48-51) — `.claude/skills/run-issue/SKILL.md:61`
-- [ ] (suggestion) Round-1 findings addressed in `529d390` but checkboxes remain unchecked and no `## Implementation` entry recorded — timeline misrepresents resolution state — `.agent/work-plans/issue-531/progress.md:19`
+- [x] (must-fix) Decision-table row not generalized: `## Implementation` preceded by `## Local Review (Pre-Push)` (the new pre-push address-findings state) matches no table row, contradicting the prose at :137 — add "or `## Local Review (Pre-Push)`" — `.claude/skills/run-issue/SKILL.md:119`
+- [x] (suggestion) Background path: instruct gating on the dispatch exit/FAILED report before routing on the timeline, so a no-entry failure isn't silently re-tried — `.claude/skills/run-issue/SKILL.md:67`
+- [x] (suggestion) Give the host a durable round counter for the address-findings⇄review-code loop (count `## Local Review (Pre-Push)` entries) — `.claude/skills/run-issue/SKILL.md:162`
+- [x] (suggestion) Caveat that background re-invocation depends on the host-runtime completion callback (mirror the Agent-tool caveat at :48-51) — `.claude/skills/run-issue/SKILL.md:61`
+- [x] (suggestion) Round-1 findings addressed in `529d390` but checkboxes remain unchecked and no `## Implementation` entry recorded — timeline misrepresents resolution state — `.agent/work-plans/issue-531/progress.md:19`
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-20 16:36 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8) [host-inline — not address-findings]
+**Branch**: feature/issue-531 at `dcd9ce5`
+**Addressed**: Local Review (Pre-Push) rounds 1 + 2
+
+### Actions
+- [x] Round 1: parser-claim must-fix + 4 suggestions + review-code Next-step consequence
+- [x] Round 2: decision-table-row must-fix (generalized predecessor) + background gating/callback caveats + round-counter note + this timeline bookkeeping

--- a/.claude/skills/address-findings/SKILL.md
+++ b/.claude/skills/address-findings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: address-findings
-description: Work through the open action items from the latest ## Integrated Review entry in progress.md — make each fix, commit atomically with pre-commit hooks, check the box, and record a ## Implementation entry. The close-the-loop phase between triage-reviews and a re-review.
+description: Work through the open action items from the latest review entry in progress.md — a ## Integrated Review (post-PR) or a ## Local Review (Pre-Push) (pre-push) — make each fix, commit atomically with pre-commit hooks, check the box, and record a ## Implementation entry. The close-the-loop phase between a review and its re-review.
 ---
 
 # Address Findings
@@ -12,23 +12,28 @@ description: Work through the open action items from the latest ## Integrated Re
 ```
 
 Run from the issue's worktree (or pass `--issue <N>`). Operates on the
-**latest** `## Integrated Review` entry in that issue's
+**latest review entry** — a `## Integrated Review` (post-PR triage) or a
+`## Local Review (Pre-Push)` (pre-push `review-code`) — in that issue's
 `.agent/work-plans/issue-<N>/progress.md`.
 
 ## Overview
 
-**Lifecycle position**: triage-reviews → **address-findings** → review-code (re-review)
+**Lifecycle position**:
+- post-PR: triage-reviews → **address-findings** → review-code (re-review)
+- pre-push: review-code (changes-requested) → **address-findings** → review-code (re-review)
 
-`triage-reviews` produces a `## Integrated Review` entry: a fix plan of
-`- [ ]` checkbox actions (must-fix, cross-confirmed, and single-source
-findings), plus plain-bullet false positives that are *dismissals, not
-actions*. This skill consumes that entry — it works each open action,
-commits the fix atomically, checks the box, and writes one closing
+A review phase produces the *source review entry* — `triage-reviews` a
+`## Integrated Review` (post-PR), or pre-push `review-code` a `## Local Review
+(Pre-Push)` (changes-requested). Either is a fix plan of `- [ ]` checkbox
+actions (must-fix and suggestions), plus plain-bullet false positives that are
+*dismissals, not actions*. This skill consumes that entry — it works each open
+action, commits the fix atomically, checks the box, and writes one closing
 `## Implementation` entry so the timeline shows what was addressed.
 
-It is deliberately **thin**: it does not re-classify findings (that was
-`triage-reviews`' job) and does not re-review its own work (that is the
-next `review-code` pass). It only *acts on an agreed fix plan*.
+It is deliberately **thin**: it does not re-classify findings (that was the
+review's job — `triage-reviews` post-PR, `review-code` pre-push) and does not
+re-review its own work (that is the next `review-code` pass). It only *acts on
+an agreed fix plan*.
 
 **Entry type** — writes `## Implementation` (an existing ADR-0013 type;
 no new type is minted). The orchestrator (`/run-issue`, #492) reads the
@@ -38,8 +43,9 @@ last entry: `## Implementation` → dispatch a re-review.
 > future `implement` skill write it — so the orchestrator can't route on
 > entry type alone (a fresh implement pass and a post-triage fix pass both
 > land as `## Implementation`). It should disambiguate by what *precedes*
-> the entry (a `## Integrated Review` immediately before ⇒ this was an
-> address-findings pass ⇒ next is re-review). Flagged here for #492's design.
+> the entry (a `## Integrated Review` **or `## Local Review (Pre-Push)`**
+> immediately before ⇒ this was an address-findings pass ⇒ next is re-review).
+> Flagged here for #492's design.
 
 ## Steps
 
@@ -49,32 +55,39 @@ Resolve `<N>` from `--issue` or `$WORKTREE_ISSUE`. The file is
 `.agent/work-plans/issue-<N>/progress.md` in the issue's worktree. If it
 doesn't exist, stop with an error — there's no triage to address.
 
-### 2. Read the latest Integrated Review
+### 2. Read the latest review entry
 
-Use the shared parser rather than re-parsing markdown:
+This skill addresses whichever review came last — a `## Integrated Review`
+(post-PR, from `triage-reviews`) **or** a `## Local Review (Pre-Push)`
+(pre-push, from `review-code`). Use the shared parser rather than re-parsing
+markdown (`--type` is repeatable):
 
 ```bash
 python3 .agent/scripts/progress_read.py \
-    .agent/work-plans/issue-<N>/progress.md --type "Integrated Review"
+    .agent/work-plans/issue-<N>/progress.md \
+    --type "Integrated Review" --type "Local Review (Pre-Push)"
 ```
 
-`progress_read.py` emits JSON. **Filter on `base_type == "Integrated
-Review"`**, not the raw `--type` match: `--type "Integrated Review"`
-also returns legacy `## External Review` entries (its recognized
-predecessor), which this skill must not act on. Then:
+`progress_read.py` emits JSON. Consider only entries whose `base_type` is
+**`Integrated Review`** or **`Local Review (Pre-Push)`** — *not* the raw
+`--type` match, which also surfaces legacy `## External Review` (Integrated
+Review's recognized predecessor) and the post-PR `## Local Review`, neither of
+which this skill acts on. Take the **single latest** such entry — the *source
+review entry* — and act only on it; never merge findings across entries or fall
+back to an older one (so a stale pre-push review is ignored once a later
+Integrated Review exists, and vice-versa). Then:
 
-- **No `Integrated Review` entry at all** (no entry whose `base_type` is
-  `Integrated Review` — the file exists but `triage-reviews` never ran,
-  or only earlier phases / a legacy `External Review` are present):
-  report "no Integrated Review to address — run `triage-reviews` first"
-  and exit without a commit. Do **not** fall back to other entry types.
-- Otherwise take the **last** such entry's `findings[]` array. Each finding is `{section, checked, source_hint, text}`. The
-  action items are the entries with `checked == false`. (False positives
-  are plain bullets, so they never appear in `findings[]` — no special
-  handling needed.)
-- **No unchecked findings** in that entry: report "nothing to address —
-  the latest Integrated Review has no open actions" and exit without a
-  commit.
+- **No qualifying entry at all** (the file exists but no `Integrated Review` /
+  `Local Review (Pre-Push)` is present — no review has run yet): report "no
+  review entry to address — run `review-code` (pre-push) or `triage-reviews`
+  (post-PR) first" and exit without a commit. Do **not** fall back to other
+  entry types.
+- Otherwise take the source review entry's `findings[]` array. Each finding is
+  `{section, checked, source_hint, text}`. The action items are the entries with
+  `checked == false`. (False positives are plain bullets, so they never appear
+  in `findings[]` — no special handling needed.)
+- **No unchecked findings** in the source review entry: report "nothing to
+  address — the latest review has no open actions" and exit without a commit.
 
 ### 3. Address each open finding
 
@@ -86,13 +99,13 @@ For each unchecked finding, in listed order (cross-confirmed first):
    an earlier round already touched the area).
 2. If, on inspection, the finding is **not** actionable (already fixed,
    or a genuine false negative on re-read), do **not** fake a change.
-   Record it as a **deferred** item: check its box in the `## Integrated
-   Review` entry with a `(deferred: <reason>)` annotation and list it in
+   Record it as a **deferred** item: check its box in the source review
+   entry with a `(deferred: <reason>)` annotation and list it in
    the `## Implementation` deferred actions (step 5). Checking it (rather
    than leaving it open) is deliberate: a finding's checkbox should reflect
    whether it still needs attention, and a deferred one does not. It also
    keeps the skill idempotent — if `address-findings` is ever re-run against
-   the same `## Integrated Review` entry, it acts only on `checked == false`
+   the same source review entry, it acts only on `checked == false`
    items and so won't re-attempt a deferral. "Checked" here means
    *consciously handled*, not *code changed*; the `(deferred: …)` annotation
    records which.
@@ -105,10 +118,10 @@ For each unchecked finding, in listed order (cross-confirmed first):
        commit -m "<area>: <what was fixed> (#<N>)"
    ```
 
-   Never `--no-verify`. One logical fix per commit. The `## Integrated
-   Review` box-check (next step) is the one permitted addition to a
+   Never `--no-verify`. One logical fix per commit. The source review
+   entry's box-check (next step) is the one permitted addition to a
    finding's commit beyond the finding's own files.
-4. Check the box for that finding in the `## Integrated Review` entry
+4. Check the box for that finding in the source review entry
    (`- [ ]` → `- [x]`) so the timeline tracks resolution — in the same
    commit as the fix, or a trailing progress commit.
 
@@ -134,7 +147,7 @@ entry's `correlation` as `null`:
 **By**: <agent name> (<model>)
 
 **Branch**: <branch-name> at `<short-sha>`   <!-- or **PR**: #<N> at `<sha>` if a PR exists -->
-**Addressed**: <the ## Integrated Review entry's When/SHA it consumed>
+**Addressed**: <the source review entry's type + When/SHA it consumed>
 **Commits**: <short-shas of the fix commits>
 
 ### Actions
@@ -154,7 +167,7 @@ pushes; AGENTS.md § Agent Commit Identity). Run from the issue worktree:
 ```bash
 git add .agent/work-plans/issue-<N>/progress.md
 git -c user.name="$AGENT_NAME" -c user.email="$AGENT_EMAIL" \
-    commit -m "progress: addressed integrated-review findings for #<N>"
+    commit -m "progress: addressed review findings for #<N>"
 ```
 
 ### Next step
@@ -173,9 +186,10 @@ user checkpoints. This step only emits this prompt and its `progress.md` entry.
 
 ## Guidelines
 
-- **Act on the agreed plan, don't re-litigate it** — `triage-reviews` already
-  classified each finding. If you disagree with a finding on inspection, defer
-  it with a reason; don't silently drop it or argue it in the commit.
+- **Act on the agreed plan, don't re-litigate it** — the review
+  (`triage-reviews` post-PR, or `review-code` pre-push) already classified each
+  finding. If you disagree with a finding on inspection, defer it with a reason;
+  don't silently drop it or argue it in the commit.
 - **Never fake resolution** — a checked box on an *actioned* finding must
   correspond to a real commit. A finding you consciously **defer** is also
   checked, but annotated `(deferred: <reason>)` so it reads as "handled, not

--- a/.claude/skills/address-findings/SKILL.md
+++ b/.claude/skills/address-findings/SKILL.md
@@ -70,9 +70,11 @@ python3 .agent/scripts/progress_read.py \
 
 `progress_read.py` emits JSON. Consider only entries whose `base_type` is
 **`Integrated Review`** or **`Local Review (Pre-Push)`** — *not* the raw
-`--type` match, which also surfaces legacy `## External Review` (Integrated
-Review's recognized predecessor) and the post-PR `## Local Review`, neither of
-which this skill acts on. Take the **single latest** such entry — the *source
+`--type` match, which for `"Integrated Review"` also surfaces legacy
+`## External Review` (its recognized predecessor), which this skill must not
+act on. (`--type "Local Review (Pre-Push)"` matches only that exact heading —
+it does **not** also return the post-PR `## Local Review`, which `run-issue`
+never produces here anyway.) Take the **single latest** such entry — the *source
 review entry* — and act only on it; never merge findings across entries or fall
 back to an older one (so a stale pre-push review is ignored once a later
 Integrated Review exists, and vice-versa). Then:
@@ -88,6 +90,17 @@ Integrated Review exists, and vice-versa). Then:
   in `findings[]` — no special handling needed.)
 - **No unchecked findings** in the source review entry: report "nothing to
   address — the latest review has no open actions" and exit without a commit.
+
+> **"Latest" is progress.md append order** — entries are appended chronologically,
+> so the last qualifying entry in file order is the most recent review. (The
+> `run-issue` loop never reorders the file.)
+>
+> **Pre-push actions *all* unchecked findings — including suggestions.** Post-PR
+> `triage-reviews` curates which findings become `- [ ]` actions; pre-push
+> `review-code` writes both must-fix *and* suggestions as unchecked checkboxes,
+> so address-findings will action the suggestions too. That's intended (suggestions
+> on your own pre-push diff are cheap to apply) — defer any you disagree with via
+> the Step 3.2 `(deferred: …)` path rather than skipping them.
 
 ### 3. Address each open finding
 

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -917,6 +917,12 @@ Key points:
 
 Lifecycle: **Local Review** → push / open PR → **triage-reviews**
 
+That path is for an **approved** pre-push review. If the verdict is
+**changes-requested**, the host (`/run-issue`) instead dispatches
+**`address-findings`** to work the open findings from this
+`## Local Review (Pre-Push)` entry, then re-dispatches `review-code` — the diff
+is not pushed until a pre-push review comes back **approved**.
+
 Once findings are addressed and the branch is pushed (or a PR opened), hand off
 to the next phase in a **fresh-context sub-agent** — independence between
 lifecycle steps is what makes the timeline trustworthy. Use the dispatcher:

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -64,6 +64,9 @@ decision table from the completion notification. **Don't poll** a
 harness-tracked background dispatch (the completion signal is automatic) — only
 poll genuinely external state. In-process (`Agent`-tool) phases already return
 control to the host's turn, so this applies specifically to the container path.
+When backgrounded, the dispatcher's `FAILED` / exit-contract report arrives
+**with the completion notification** (and in the task's captured output) — read
+it there and stop-and-surface, exactly as for a foreground dispatch.
 
 The dispatcher already verifies the sub-agent wrote the expected entry type
 (PRE/POST entry-count delta — `dispatch_subagent.sh:216-282`); treat a `FAILED`
@@ -155,6 +158,13 @@ warranted only when a fix needs operator ground truth the sub-agent can't have
 (a convention learned from live operations, say); then make the edits, commit,
 and re-dispatch `review-code` directly. (To convey ground truth *to*
 `address-findings` instead, leave it as a note in the review entry it reads.)
+
+The `address-findings` ⇄ `review-code` loop has **no built-in round cap yet** —
+a convergence / ship-recommendation signal is tracked in
+[#537](https://github.com/rolker/ros2_agent_workspace/issues/537). Until it
+lands, after ~2–3 rounds the host should **surface the loop state to the
+operator** (remaining-finding severity, ship-vs-continue) rather than spinning —
+especially for guidance-doc diffs, where review can demand precision indefinitely.
 
 ## Checkpoints
 

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -66,7 +66,13 @@ poll genuinely external state. In-process (`Agent`-tool) phases already return
 control to the host's turn, so this applies specifically to the container path.
 When backgrounded, the dispatcher's `FAILED` / exit-contract report arrives
 **with the completion notification** (and in the task's captured output) — read
-it there and stop-and-surface, exactly as for a foreground dispatch.
+it there and stop-and-surface, exactly as for a foreground dispatch. **Gate on
+that report before routing on the timeline**: a FAILED dispatch may have written
+no entry (or a stale one), so acting on `progress.md` without first checking the
+dispatch outcome risks routing on the wrong state. Background re-invocation
+relies on the host runtime delivering a completion callback; a runtime without
+one must drive phases foreground / manually (the same caveat as the `Agent` tool
+above).
 
 The dispatcher already verifies the sub-agent wrote the expected entry type
 (PRE/POST entry-count delta — `dispatch_subagent.sh:216-282`); treat a `FAILED`
@@ -116,7 +122,7 @@ Read the **last** progress.md entry; act per its type + verdict:
 | (PR published) | review comments landed | dispatch `triage-reviews` | **yes** (async wait) |
 | `## Integrated Review` | open findings remain | dispatch `address-findings` | **yes** (non-trivial findings) |
 | `## Integrated Review` | none | merge | **yes** (before merge) |
-| `## Implementation` **preceded by** `## Integrated Review` | — | dispatch `review-code` (re-review) | — |
+| `## Implementation` **preceded by** `## Integrated Review` or `## Local Review (Pre-Push)` | — | dispatch `review-code` (re-review) | — |
 
 **`## Local Review (Pre-Push)` is the exact heading** every pre-push
 `review-code` writes, and **the orchestrator only ever dispatches `review-code`
@@ -164,7 +170,9 @@ a convergence / ship-recommendation signal is tracked in
 [#537](https://github.com/rolker/ros2_agent_workspace/issues/537). Until it
 lands, after ~2–3 rounds the host should **surface the loop state to the
 operator** (remaining-finding severity, ship-vs-continue) rather than spinning —
-especially for guidance-doc diffs, where review can demand precision indefinitely.
+especially for guidance-doc diffs, where review can demand precision
+indefinitely. The round number is just the count of `## Local Review (Pre-Push)`
+entries in `progress.md` — a cheap durable counter the host can read at any time.
 
 ## Checkpoints
 

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -54,6 +54,17 @@ Each phase runs in a **fresh-context sub-agent** via the dispatcher:
   specialist fan-out, or implementation that benefits from a clean OS). Container
   mode is headless and self-contained, so it needs no host `Agent` tool.
 
+**Dispatch container phases in the *background* so the host stays available.**
+A synchronous (foreground) container dispatch blocks the host's turn for the
+entire phase — a review-issue / review-code / implement run is minutes — leaving
+the operator unable to chat or redirect the whole time. Launch the container
+dispatch as a **background task**; the host runtime re-invokes the orchestrator
+on completion, so the host stays responsive between phases and resumes the
+decision table from the completion notification. **Don't poll** a
+harness-tracked background dispatch (the completion signal is automatic) — only
+poll genuinely external state. In-process (`Agent`-tool) phases already return
+control to the host's turn, so this applies specifically to the container path.
+
 The dispatcher already verifies the sub-agent wrote the expected entry type
 (PRE/POST entry-count delta — `dispatch_subagent.sh:216-282`); treat a `FAILED`
 report as a stop-and-surface, not a silent retry. After each dispatch, read the
@@ -98,7 +109,7 @@ Read the **last** progress.md entry; act per its type + verdict:
 | `## Plan Authored` | — | dispatch `review-plan` | — |
 | `## Plan Review` | any verdict | run implementation, then `review-code` | **always** |
 | `## Local Review (Pre-Push)` | `approved` | push → open PR (or field-push) | **yes** (before publish) |
-| `## Local Review (Pre-Push)` | `changes-requested` | address inline, re-dispatch `review-code` | maybe |
+| `## Local Review (Pre-Push)` | `changes-requested` | dispatch `address-findings`, then re-dispatch `review-code` | maybe |
 | (PR published) | review comments landed | dispatch `triage-reviews` | **yes** (async wait) |
 | `## Integrated Review` | open findings remain | dispatch `address-findings` | **yes** (non-trivial findings) |
 | `## Integrated Review` | none | merge | **yes** (before merge) |
@@ -120,8 +131,9 @@ none ⇒ merge checkpoint).
 
 **Shared `## Implementation` routing key**: `## Implementation` is written by
 both `address-findings` and a future `implement` skill. Disambiguate by the
-**preceding** entry — a `## Integrated Review` immediately before means this was
-an address-findings pass, so the next action is a re-review.
+**preceding** entry — a `## Integrated Review` **or `## Local Review (Pre-Push)`**
+immediately before means this was an address-findings pass (post-PR or pre-push
+respectively), so the next action is a re-review.
 
 **Implementation phase**: there is no `implement` skill yet. After
 `## Plan Review`, the host runs implementation **inline** (edits, commits,
@@ -131,6 +143,18 @@ swap the inline step for a dispatch — **and add a table row** for a bare
 implementation pass ⇒ dispatch `review-code`). That state is unreachable today
 (inline implementation writes no such entry before the host itself runs
 `review-code`), so the table has no row for it yet.
+
+**The changes-requested fix pass uses `address-findings`, not host-inline
+editing.** When pre-push `review-code` returns `changes-requested`, dispatch
+`address-findings` — it reads the open findings straight from the latest
+`## Local Review (Pre-Push)` entry, applies them, and writes `## Implementation`
+— then re-dispatch `review-code`. Prefer this over hand-authoring a per-round
+fix prompt: the findings are already structured in `progress.md`, so re-encoding
+them by hand is wasted host effort. **Host-inline editing is the exception**,
+warranted only when a fix needs operator ground truth the sub-agent can't have
+(a convention learned from live operations, say); then make the edits, commit,
+and re-dispatch `review-code` directly. (To convey ground truth *to*
+`address-findings` instead, leave it as a note in the review entry it reads.)
 
 ## Checkpoints
 


### PR DESCRIPTION
## run-issue fix-pass loop: background dispatch + address-findings routing

First of the run-issue refinement batch (the #530 dogfood retro).

- **#531** — `run-issue/SKILL.md`: dispatch container phases in the **background** so the host stays available to the operator; resume on the completion notification, gate on the FAILED report before routing, don't poll a harness-tracked dispatch.
- **#538** — `run-issue/SKILL.md`: changes-requested → dispatch **`address-findings`** (reads findings from `progress.md`) instead of host-authored fix prompts; decision-table + disambiguation generalized; host-inline kept as the ground-truth exception. **`address-findings/SKILL.md` generalized** from "Integrated Review only" to "the latest review entry of either type" (post-PR `Integrated Review` **or** pre-push `Local Review (Pre-Push)`) — preserving the post-PR path. `review-code/SKILL.md` Next-step documents the new pre-push branch.

### Review
Pre-push `review-code` ×2 (Standard): round 1 = 1 must-fix + 5, round 2 = 1 must-fix + 4 — all addressed. Shipped at round 2 per the **#537 convergence wisdom this PR itself adds** (a converging guidance-doc, not chased indefinitely). Timeline bookkeeping recorded in `progress.md`.

Closes #531. Closes #538.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
