### PR TITLE
dispatch: entry-type model default (#539) + model-stamp (#540) + auth preflight (#532)

### DIFF
--- a/.agent/scripts/dispatch_subagent.sh
+++ b/.agent/scripts/dispatch_subagent.sh
@@ -12,10 +12,12 @@
 #   dispatch_subagent.sh --mode in-process|container --issue <N> \
 #       (--skill <name> | --prompt-file <path>) \
 #       [--entry-type <type>] [--output-format <fmt>] [--model <id>]
+#   dispatch_subagent.sh --check    # container-auth preflight (#532), then exit
 #
-#   --model defaults per-skill (Opus for review/implement, Sonnet otherwise);
-#   pass an alias ('opus'/'sonnet') to override. Container mode forwards it;
-#   in-process mode only recommends it (the host picks the Agent's model).
+#   --model defaults per-skill (Opus for review/implement, Sonnet otherwise),
+#   or per --entry-type for a raw --prompt-file dispatch (#539); pass an alias
+#   ('opus'/'sonnet') to override. Container forwards it; in-process recommends
+#   it. --check verifies the container auth tokens and exits.
 #
 # Examples:
 #   dispatch_subagent.sh --mode in-process --issue 490 --skill review-code
@@ -41,6 +43,7 @@ PROMPT_FILE=""
 ENTRY_TYPE=""
 OUTPUT_FORMAT="stream-json"
 MODEL=""   # --model override; empty => derive from the skill (see skill_model)
+CHECK=""   # --check: run the container-auth preflight and exit (#532)
 
 # Identity literals embedded in the handoff (AGENTS.md § Agent Commit Identity).
 # Prefer the session's exported identity; fall back to the Claude default.
@@ -76,6 +79,73 @@ skill_model() {
     esac
 }
 
+# Entry-type -> model, for raw-prompt (--prompt-file) dispatches that carry no
+# --skill to map. Mirrors skill_model's tiers: reasoning-heavy review/implement
+# entries get Opus; lighter ones Sonnet. Without this a custom-prompt dispatch
+# silently defaulted to Sonnet even for an Implementation / review pass (#539).
+entry_type_model() {
+    case "$1" in
+        Implementation|"Local Review"|"Local Review (Pre-Push)"|"Integrated Review"|"Plan Review") echo "opus" ;;
+        "Issue Review"|"Plan Authored")          echo "sonnet" ;;
+        *)                                       echo "sonnet" ;;
+    esac
+}
+
+# Model alias -> version-less display name for the sub-agent's progress.md
+# `By:` line (#540). The alias resolves to the current release inside the
+# container, so a sub-agent must NOT invent a version (e.g. "Opus 4.6"); the
+# dispatcher hands it this exact string to stamp.
+model_display() {
+    case "$1" in
+        opus)   echo "Claude Opus" ;;
+        sonnet) echo "Claude Sonnet" ;;
+        haiku)  echo "Claude Haiku" ;;
+        *)      echo "$1" ;;
+    esac
+}
+
+# Canonical container-auth token paths (read by docker_run_agent.sh). Documented
+# here too so they're discoverable without grepping that script (#532).
+CLAUDE_TOKEN_FILE="$HOME/.config/ros2-agent/claude-oauth-token"
+GH_TOKEN_FILE="$HOME/.config/ros2-agent/gh-readonly-token"
+
+# Container-dispatch auth preflight (#532). Verifies the long-lived Claude
+# subscription token (env or file) and reports the optional read-only GH token.
+# Prints the canonical paths + a ready/not-ready verdict. Returns non-zero when
+# the Claude token is missing. In-process mode uses the host session and needs
+# neither token, so this is a container-mode concern.
+preflight_check() {
+    local ok=0
+    echo "Container-dispatch auth preflight (#532)"
+    echo "  Claude subscription token:"
+    if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+        echo "    ok  \$CLAUDE_CODE_OAUTH_TOKEN set in env"
+    elif [ -s "$CLAUDE_TOKEN_FILE" ]; then
+        echo "    ok  $CLAUDE_TOKEN_FILE"
+    elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+        echo "    ok  \$ANTHROPIC_API_KEY set (API billing, not subscription)"
+    else
+        echo "    MISSING — generate with 'claude setup-token', then save to:"
+        echo "             $CLAUDE_TOKEN_FILE   (chmod 600)"
+        ok=1
+    fi
+    echo "  GitHub token (optional — container reads only; the host publishes):"
+    if [ -n "${GH_TOKEN:-}" ]; then
+        echo "    ok  \$GH_TOKEN set in env"
+    elif [ -s "$GH_TOKEN_FILE" ]; then
+        echo "    ok  $GH_TOKEN_FILE"
+    else
+        echo "    none — container can't post to GitHub; that is expected (the host"
+        echo "          publishes review comments / PRs — local-first, see #532)."
+    fi
+    if [ "$ok" -eq 0 ]; then
+        echo "  => READY for container dispatch."
+    else
+        echo "  => NOT READY (Claude token missing)."
+    fi
+    return "$ok"
+}
+
 usage() {
     sed -n '2,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
@@ -91,10 +161,18 @@ while [[ $# -gt 0 ]]; do
         --entry-type)    ENTRY_TYPE="${2:-}"; shift 2 ;;
         --model)         MODEL="${2:-}"; shift 2 ;;
         --output-format) OUTPUT_FORMAT="${2:-}"; shift 2 ;;
+        --check)         CHECK=1; shift ;;
         -h|--help)       usage; exit 0 ;;
         *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
     esac
 done
+
+# ---------- Auth preflight (#532): `--check` runs standalone and exits ----------
+
+if [ -n "$CHECK" ]; then
+    preflight_check
+    exit $?
+fi
 
 # ---------- Validation ----------
 
@@ -125,11 +203,16 @@ if [ -z "$ENTRY_TYPE" ] && [ -n "$SKILL" ]; then
     ENTRY_TYPE="$(skill_entry_type "$SKILL")"
 fi
 
-# Resolve the model: explicit --model wins, else derive from the skill, else the
-# default ('sonnet'). For a raw prompt with no --model, the default applies.
+# Resolve the model: explicit --model wins; else derive from the skill; else,
+# for a raw --prompt-file dispatch (no skill), derive from the declared
+# --entry-type so an Implementation / review pass isn't silently downgraded to
+# Sonnet (#539); else the default ('sonnet').
 if [ -z "$MODEL" ]; then
-    if [ -n "$SKILL" ]; then MODEL="$(skill_model "$SKILL")"; else MODEL="sonnet"; fi
+    if [ -n "$SKILL" ]; then MODEL="$(skill_model "$SKILL")"
+    elif [ -n "$ENTRY_TYPE" ]; then MODEL="$(entry_type_model "$ENTRY_TYPE")"
+    else MODEL="sonnet"; fi
 fi
+MODEL_DISPLAY="$(model_display "$MODEL")"
 
 # ---------- Resolve the worktree + its progress.md ----------
 
@@ -182,6 +265,10 @@ literals (AGENTS.md § Agent Commit Identity):
 Never use \`--no-verify\`. Do **not** \`git push\` — the host performs pushes
 with its own credentials. Never write credentials/tokens (e.g.
 \`\$CLAUDE_CODE_OAUTH_TOKEN\`) into files, commits, or output.
+
+**Your runtime model** is **$MODEL_DISPLAY** (dispatched with \`--model $MODEL\`).
+Stamp exactly that string in the \`**By**:\` line of your progress.md entry — do
+NOT invent or guess a version number (e.g. never "Opus 4.6").
 
 **Exit contract** — before you finish, $ENTRY_CLAUSE:
 
@@ -243,6 +330,12 @@ PRE_COUNT="$(entry_count)"
 PROMPT_TMP="$(mktemp /tmp/dispatch_handoff.XXXXXX.md)"
 trap 'rm -f "$PROMPT_TMP"' EXIT
 printf '%s\n' "$HANDOFF" > "$PROMPT_TMP"
+
+# Soft auth preflight (#532): warn early and actionably if the Claude token is
+# absent, rather than failing opaquely deep inside docker_run_agent.sh.
+if ! preflight_check >/dev/null 2>&1; then
+    echo "⚠️  Container auth not ready — run '${BASH_SOURCE[0]} --check' for details." >&2
+fi
 
 echo "Dispatching issue #$ISSUE into a container (headless, model=$MODEL)…" >&2
 RC=0

--- a/.agent/scripts/dispatch_subagent.sh
+++ b/.agent/scripts/dispatch_subagent.sh
@@ -83,17 +83,22 @@ skill_model() {
 # --skill to map. Without this a custom-prompt dispatch silently defaulted to
 # Sonnet even for an Implementation / review pass (#539).
 #
-# KEEP THE TIERS IN SYNC WITH skill_model() — each entry type is written by a
-# skill, and the two must agree on its model: Local Review*(review-code),
-# Integrated Review(triage-reviews), Implementation(implement/address-findings),
-# Plan Review(review-plan) -> opus; Issue Review(review-issue),
-# Plan Authored(plan-task) -> sonnet. test_dispatch_model.sh asserts this parity.
+# The tier is NOT duplicated here: this maps the entry type to the skill that
+# writes it and defers to skill_model() — the single source of truth — so adding
+# an Opus tier in skill_model can't silently downgrade an entry type. Only the
+# entry-type -> skill map below is local; test_dispatch_model.sh asserts it.
 entry_type_model() {
+    local skill
     case "$1" in
-        Implementation|"Local Review"|"Local Review (Pre-Push)"|"Integrated Review"|"Plan Review") echo "opus" ;;
-        "Issue Review"|"Plan Authored")          echo "sonnet" ;;
-        *)                                       echo "sonnet" ;;
+        "Local Review"|"Local Review (Pre-Push)") skill="review-code" ;;
+        "Integrated Review")                       skill="triage-reviews" ;;
+        Implementation)                            skill="address-findings" ;;
+        "Plan Review")                             skill="review-plan" ;;
+        "Issue Review")                            skill="review-issue" ;;
+        "Plan Authored")                           skill="plan-task" ;;
+        *)                                         skill="" ;;  # unknown -> skill_model default (sonnet)
     esac
+    skill_model "$skill"
 }
 
 # Model alias -> version-less display name for the sub-agent's progress.md
@@ -129,6 +134,10 @@ preflight_check() {
         echo "    ok  $CLAUDE_TOKEN_FILE"
     elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
         echo "    ok  \$ANTHROPIC_API_KEY set (API billing, not subscription)"
+    elif [ -f "$HOME/.claude/.credentials.json" ]; then
+        echo "    ok  ~/.claude/.credentials.json (mounted OAuth — accepted by"
+        echo "        docker_run_agent.sh, but short-lived and can't refresh"
+        echo "        in-container; 'claude setup-token' is more robust)"
     else
         echo "    MISSING — generate with 'claude setup-token', then save to:"
         echo "             $CLAUDE_TOKEN_FILE   (chmod 600)"
@@ -152,7 +161,9 @@ preflight_check() {
 }
 
 usage() {
-    sed -n '2,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    # Keep the end line in sync with the header Usage block (currently ends at
+    # line 20 — the --model/--check note); a too-small range truncates --help.
+    sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 # ---------- Argument parsing ----------

--- a/.agent/scripts/dispatch_subagent.sh
+++ b/.agent/scripts/dispatch_subagent.sh
@@ -80,9 +80,14 @@ skill_model() {
 }
 
 # Entry-type -> model, for raw-prompt (--prompt-file) dispatches that carry no
-# --skill to map. Mirrors skill_model's tiers: reasoning-heavy review/implement
-# entries get Opus; lighter ones Sonnet. Without this a custom-prompt dispatch
-# silently defaulted to Sonnet even for an Implementation / review pass (#539).
+# --skill to map. Without this a custom-prompt dispatch silently defaulted to
+# Sonnet even for an Implementation / review pass (#539).
+#
+# KEEP THE TIERS IN SYNC WITH skill_model() — each entry type is written by a
+# skill, and the two must agree on its model: Local Review*(review-code),
+# Integrated Review(triage-reviews), Implementation(implement/address-findings),
+# Plan Review(review-plan) -> opus; Issue Review(review-issue),
+# Plan Authored(plan-task) -> sonnet. test_dispatch_model.sh asserts this parity.
 entry_type_model() {
     case "$1" in
         Implementation|"Local Review"|"Local Review (Pre-Push)"|"Integrated Review"|"Plan Review") echo "opus" ;;
@@ -130,8 +135,8 @@ preflight_check() {
         ok=1
     fi
     echo "  GitHub token (optional — container reads only; the host publishes):"
-    if [ -n "${GH_TOKEN:-}" ]; then
-        echo "    ok  \$GH_TOKEN set in env"
+    if [ -n "${AGENT_GH_TOKEN:-}" ]; then
+        echo "    ok  \$AGENT_GH_TOKEN set in env"
     elif [ -s "$GH_TOKEN_FILE" ]; then
         echo "    ok  $GH_TOKEN_FILE"
     else
@@ -170,8 +175,9 @@ done
 # ---------- Auth preflight (#532): `--check` runs standalone and exits ----------
 
 if [ -n "$CHECK" ]; then
-    preflight_check
-    exit $?
+    # Explicit if/else: under `set -e` a bare `preflight_check` returning
+    # non-zero would exit before `exit $?` ran (making it partly dead code).
+    if preflight_check; then exit 0; else exit 1; fi
 fi
 
 # ---------- Validation ----------
@@ -267,8 +273,9 @@ with its own credentials. Never write credentials/tokens (e.g.
 \`\$CLAUDE_CODE_OAUTH_TOKEN\`) into files, commits, or output.
 
 **Your runtime model** is **$MODEL_DISPLAY** (dispatched with \`--model $MODEL\`).
-Stamp exactly that string in the \`**By**:\` line of your progress.md entry — do
-NOT invent or guess a version number (e.g. never "Opus 4.6").
+Stamp **exactly that string** in the \`**By**:\` line of your progress.md entry —
+do not add to or embellish it (never expand "Claude Opus" into a guessed
+"Opus 4.6"; if a pinned model id was given, stamp it verbatim).
 
 **Exit contract** — before you finish, $ENTRY_CLAUSE:
 

--- a/.agent/scripts/tests/test_dispatch_model.sh
+++ b/.agent/scripts/tests/test_dispatch_model.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# .agent/scripts/tests/test_dispatch_model.sh
+# Unit-tests the pure model-mapping helpers in dispatch_subagent.sh:
+#   - entry_type_model (#539): a raw --prompt-file dispatch with no --skill must
+#     pick Opus for reasoning-heavy entry types, not silently default to Sonnet.
+#   - model_display (#540): alias -> version-less display name the dispatcher
+#     hands the sub-agent to stamp (so it never invents "Opus 4.6").
+# Extracts just those functions (no worktree / no dispatch) so it runs in CI.
+#
+# Run: bash .agent/scripts/tests/test_dispatch_model.sh
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISPATCH="$SCRIPT_DIR/../dispatch_subagent.sh"
+TEST_PASS=0
+TEST_FAIL=0
+
+# Pull the self-contained mapping functions out and define them here — each runs
+# from its `name() {` line to the next column-0 `}` (the case's inner braces are
+# indented, so `^}` only matches the function close).
+eval "$(sed -n '/^entry_type_model() {/,/^}/p; /^model_display() {/,/^}/p; /^skill_model() {/,/^}/p' "$DISPATCH")"
+
+check() { # check <desc> <expected> <actual>
+    if [ "$2" = "$3" ]; then echo "PASS: $1"; TEST_PASS=$((TEST_PASS + 1))
+    else echo "FAIL: $1 (expected '$2', got '$3')"; TEST_FAIL=$((TEST_FAIL + 1)); fi
+}
+
+# #539 — entry-type -> model
+check "Implementation -> opus"            opus   "$(entry_type_model 'Implementation')"
+check "Local Review (Pre-Push) -> opus"   opus   "$(entry_type_model 'Local Review (Pre-Push)')"
+check "Integrated Review -> opus"         opus   "$(entry_type_model 'Integrated Review')"
+check "Plan Review -> opus"               opus   "$(entry_type_model 'Plan Review')"
+check "Issue Review -> sonnet"            sonnet "$(entry_type_model 'Issue Review')"
+check "Plan Authored -> sonnet"           sonnet "$(entry_type_model 'Plan Authored')"
+check "unknown entry-type -> sonnet"      sonnet "$(entry_type_model 'Whatever')"
+
+# parity with skill_model: review/implement skills are Opus, lighter ones Sonnet
+check "skill review-code -> opus"         opus   "$(skill_model 'review-code')"
+check "skill review-issue -> sonnet"      sonnet "$(skill_model 'review-issue')"
+
+# #540 — version-less display names
+check "display opus"                      "Claude Opus"   "$(model_display opus)"
+check "display sonnet"                    "Claude Sonnet" "$(model_display sonnet)"
+check "display passthrough"               "custom-x"      "$(model_display 'custom-x')"
+
+echo
+echo "dispatch model-mapping tests: $TEST_PASS passed, $TEST_FAIL failed"
+[ "$TEST_FAIL" -eq 0 ]

--- a/.agent/scripts/tests/test_dispatch_model.sh
+++ b/.agent/scripts/tests/test_dispatch_model.sh
@@ -34,9 +34,15 @@ check "Issue Review -> sonnet"            sonnet "$(entry_type_model 'Issue Revi
 check "Plan Authored -> sonnet"           sonnet "$(entry_type_model 'Plan Authored')"
 check "unknown entry-type -> sonnet"      sonnet "$(entry_type_model 'Whatever')"
 
-# parity with skill_model: review/implement skills are Opus, lighter ones Sonnet
-check "skill review-code -> opus"         opus   "$(skill_model 'review-code')"
-check "skill review-issue -> sonnet"      sonnet "$(skill_model 'review-issue')"
+# Drift guard: each entry type's model MUST equal the model of the skill that
+# writes it (the two case statements must not diverge — see #539 / the
+# keep-in-sync comment on entry_type_model).
+check "parity Local Review (Pre-Push) == review-code"  "$(skill_model review-code)"     "$(entry_type_model 'Local Review (Pre-Push)')"
+check "parity Integrated Review == triage-reviews"     "$(skill_model triage-reviews)"  "$(entry_type_model 'Integrated Review')"
+check "parity Implementation == address-findings"      "$(skill_model address-findings)" "$(entry_type_model 'Implementation')"
+check "parity Plan Review == review-plan"              "$(skill_model review-plan)"     "$(entry_type_model 'Plan Review')"
+check "parity Issue Review == review-issue"            "$(skill_model review-issue)"    "$(entry_type_model 'Issue Review')"
+check "parity Plan Authored == plan-task"             "$(skill_model plan-task)"       "$(entry_type_model 'Plan Authored')"
 
 # #540 — version-less display names
 check "display opus"                      "Claude Opus"   "$(model_display opus)"

--- a/.agent/work-plans/issue-532/progress.md
+++ b/.agent/work-plans/issue-532/progress.md
@@ -1,0 +1,22 @@
+---
+issue: 532
+---
+
+# Issue #532 — container-auth token paths + `--check` preflight
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 21:29 +0000
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-532 at `2ac44d7`
+**Mode**: pre-push
+**Depth**: Deep (reason: auth/credential-token handling; AGENTS.md governance trigger)
+**Must-fix**: 1 | **Suggestions**: 3
+
+### Findings
+- [ ] (must-fix) Preflight GH-token env check keys on `$GH_TOKEN`, but `docker_run_agent.sh` consumes `$AGENT_GH_TOKEN` (GH_TOKEN is only the container-facing export) — false negative on documented override, false positive on `GH_TOKEN`; check `$AGENT_GH_TOKEN` instead — `.agent/scripts/dispatch_subagent.sh:133`
+- [ ] (suggestion) `entry_type_model` duplicates `skill_model` tiering with no shared source; test asserts parity for only 2 mappings — drift could pass CI — `.agent/scripts/dispatch_subagent.sh:86`
+- [ ] (suggestion) `model_display` passthrough lets a pinned `--model <id>` embed a version in the handoff, contradicting the "don't invent a version" instruction — `.agent/scripts/dispatch_subagent.sh:98`
+- [ ] (suggestion) `exit $?` after bare `preflight_check` is partially dead code under `set -e`; rewrite as explicit `if preflight_check` for clarity — `.agent/scripts/dispatch_subagent.sh:172`

--- a/.agent/work-plans/issue-532/progress.md
+++ b/.agent/work-plans/issue-532/progress.md
@@ -20,3 +20,25 @@ issue: 532
 - [ ] (suggestion) `entry_type_model` duplicates `skill_model` tiering with no shared source; test asserts parity for only 2 mappings — drift could pass CI — `.agent/scripts/dispatch_subagent.sh:86`
 - [ ] (suggestion) `model_display` passthrough lets a pinned `--model <id>` embed a version in the handoff, contradicting the "don't invent a version" instruction — `.agent/scripts/dispatch_subagent.sh:98`
 - [ ] (suggestion) `exit $?` after bare `preflight_check` is partially dead code under `set -e`; rewrite as explicit `if preflight_check` for clarity — `.agent/scripts/dispatch_subagent.sh:172`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 21:39 +0000
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-532 at `2e4a4a8`
+**Mode**: pre-push
+**Depth**: Deep (reason: auth/credential-token handling; AGENTS.md governance trigger)
+**Must-fix**: 1 | **Suggestions**: 2
+
+Re-review after `2e4a4a8` resolved all 4 prior-round findings (verified:
+GH-token check now keys on `$AGENT_GH_TOKEN`; parity test expanded 2→6;
+handoff text stamps pinned model id verbatim; `--check` uses explicit if/else).
+shellcheck clean; test_dispatch_model.sh 16/16. New finding below was introduced
+by this diff.
+
+### Findings
+- [ ] (must-fix) `usage()`'s `sed -n '2,18p'` range not widened when the header comment grew; `--help` truncates mid-paragraph at "…pass an alias", dropping the rest of the `--model`/`--check` explanation. Bump to `'2,19p'` — `.agent/scripts/dispatch_subagent.sh:155`
+- [ ] (suggestion) Preflight recognizes 3 Claude-auth sources but `docker_run_agent.sh:204` accepts a 4th (`~/.claude/.credentials.json`) → false `NOT READY` verdict when only mounted creds present; benign but note it — `.agent/scripts/dispatch_subagent.sh:126`
+- [ ] (suggestion) `entry_type_model` still duplicates `skill_model` tiering; parity test now covers all 6 current mappings but a future opus-tier addition could silently downgrade to sonnet — derive from `skill_model` to close it — `.agent/scripts/dispatch_subagent.sh:91`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,7 +467,7 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/field_mode.sh` | Detect field mode (non-GitHub origin) vs. dev mode **(source or exec)** |
 | `.agent/scripts/dlog.sh` | Prompt-free, `date`-stamped deployment log appender (`dlog.sh <logfile> <message>`); allowlist once for prompt-free + accurate live-ops logging (#515/#516) |
 | `.agent/scripts/agent start-task <N>` | High-level wrapper: create + enter worktree |
-| `.agent/scripts/dispatch_subagent.sh` | Dispatch a workflow skill into a fresh-context sub-agent (in-process or container); reads the progress.md exit contract |
+| `.agent/scripts/dispatch_subagent.sh` | Dispatch a workflow skill into a fresh-context sub-agent (in-process or container); reads the progress.md exit contract. `--check` runs the container-auth preflight; container auth tokens live at `~/.config/ros2-agent/claude-oauth-token` (Claude, from `claude setup-token`) + `~/.config/ros2-agent/gh-readonly-token` (optional GH read-only) |
 | `.agent/scripts/docker_run_agent.sh` | Launch the sandboxed agent container for a worktree; interactive or headless dispatch (`--prompt`/`--prompt-file`, `--model`), reads `CLAUDE_CODE_OAUTH_TOKEN`. `--build` also stages layer `package.xml` manifests into the image build context to bake their rosdep deps (#520) |
 | `.agent/scripts/stage_rosdep_manifests.sh` | Gather layer `package.xml` manifests (recursive) into the agent-image build context for the rosdep bake (#520); shared by `docker_run_agent.sh --build` and `make agent-build` |
 | `.agent/scripts/dashboard.sh` | Unified workspace status (supports `--quick`) |


### PR DESCRIPTION
## dispatch_subagent.sh: model defaults + model-stamp + auth preflight

Second of the run-issue refinement batch (the #530 dogfood retro).

- **#539** — `entry_type_model()`: a raw `--prompt-file` dispatch (no `--skill`) derives its model from the declared `--entry-type` instead of silently defaulting to Sonnet. Tier is **derived from `skill_model()`** (single source of truth — no duplication).
- **#540** — `model_display()` + the runtime model is injected into the sub-agent handoff, so it stamps the correct `By:` (no invented "Opus 4.6").
- **#532** — `--check` auth preflight (verifies the 4 Claude-auth sources + the read-only GH token, prints the canonical paths + ready/not-ready); soft pre-dispatch warning; token paths surfaced in AGENTS.md.

### Review
Pre-push `review-code` ×2 (Deep, auth-focused): round 1 = 1 must-fix + 3, round 2 = 1 must-fix + 2 — all addressed (`$AGENT_GH_TOKEN` env, `set -e` dead-code, `usage()` range, parity guard, derived tier). **16 unit tests pass**; `--check` verified; shellcheck clean. Shipped at round 2 per the #537 convergence wisdom.

Closes #532. Closes #539. Closes #540.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
