### PR TITLE
review-code: convergence/ship signal + guidance-doc severity calibration (#537)

### DIFF
--- a/.agent/work-plans/issue-537/progress.md
+++ b/.agent/work-plans/issue-537/progress.md
@@ -1,0 +1,22 @@
+---
+issue: 537
+---
+
+# Issue #537 — review-code: convergence/ship signal + guidance-doc severity calibration
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 22:51 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-537 at `d0d13c3`
+**Mode**: pre-push
+**Depth**: Standard (reason: `.claude/skills/*/SKILL.md` is a Governance override-trigger)
+**Must-fix**: 0 | **Suggestions**: 3
+**Round**: 1 | **Ship**: recommended — Round 1, zero Must-fix; diff is shippable, suggestions are cross-doc follow-ups
+
+### Findings
+- [ ] (suggestion) Refresh run-issue "until it lands" note to reference the now-emitted Round/Ship fields — `.claude/skills/run-issue/SKILL.md:168-175`
+- [ ] (suggestion) Add the Round/Ship header line to the Light-tier condensed report template — `.claude/skills/review-code/SKILL.md:812-839`
+- [ ] (suggestion) Give "low" a one-clause example threshold in the round-≥2 ship rule — `.claude/skills/review-code/SKILL.md:740-743`

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -707,9 +707,44 @@ Collect all findings from all dispatched specialists and filter:
      consequences
    - **Suggestion** — improvements worth the author's time
    - Drop anything below suggestion threshold.
+   - **Guidance-doc calibration (#537).** When the changed file is a
+     *guidance document* — prose an agent reads and *adapts* (a
+     `.claude/skills/**/SKILL.md`, a `.agent/knowledge/` doc, an ADR) rather
+     than code it *executes verbatim* — apply a lighter bar: a finding an agent
+     following the procedure would obviously catch or adapt on its own is a
+     **Suggestion, not a Must-fix**. Reserve Must-fix for guidance that would
+     actively mislead — a command that fails silently, a wrong path/flag, an
+     internal contradiction, a missing consequence. A SKILL.md is applied with
+     judgment, not executed literally; holding prose to executable-grade
+     precision is what makes a review loop fail to converge. (Genuinely
+     executable snippets *inside* a guidance doc — a copy-paste command block —
+     keep the code bar.)
 5. **Silence check** — if no findings survive the filter, report "No
    issues found." Don't invent feedback to fill the report. Target: ≥85%
    of reported findings should be actionable.
+
+**Convergence assessment (pre-push, #537).** Before writing the report, in
+pre-push mode, assess whether the review loop is converging — so the host
+(`/run-issue`) gets a ship-vs-continue signal instead of looping a guidance-doc
+review indefinitely:
+
+- **Round** = the count of prior `## Local Review (Pre-Push)` entries for this
+  branch in `progress.md`, plus 1 (this review). Round 1 has no prior entry.
+- **Ship verdict**:
+  - **recommended** when there are **no Must-fix** findings (only Suggestions,
+    or nothing) — the diff is shippable; remaining Suggestions can be applied or
+    tracked.
+  - **recommended** at **round ≥ 2** when the Must-fix count is **low and not
+    rising** versus the previous round and the remaining must-fixes are
+    mechanical/clear — recommend addressing them and shipping rather than
+    another full round (each round costs a container cycle for diminishing
+    return, especially on guidance docs after the calibration above).
+  - **continue** when Must-fix is **rising, high, or includes a genuine
+    design / correctness concern** that warrants another independent read.
+- Surface the round, verdict, and a one-line reason in the report header
+  (`Round`) and Summary, and in the `progress.md` entry (step 8), so the
+  orchestrator can route on it. The verdict is **advisory** — the operator/host
+  decides; this skill never blocks a ship.
 
 ### 7. Produce the report
 
@@ -722,6 +757,7 @@ Collect all findings from all dispatched specialists and filter:
 **Repo**: workspace | <project-repo>
 **Files changed**: <count> (+<additions> -<deletions>)
 **Review depth**: <Light|Standard|Deep> (reason: <primary signal>)
+**Round**: <N> (pre-push) — **Ship: <recommended | continue>** (see Convergence)
 **Static analysis**: <run | skipped (--skip-static)>
 **Claude Adversarial**: <1 pass (Lens A) | 2 passes (Lens A + Lens B)>
 **Copilot Adversarial**: <off (default) | run (--copilot) | skipped (<reason>, --copilot)>
@@ -880,6 +916,7 @@ timeline without one overwriting the other. Append only one header line
 **Mode**: <pre-push | post-PR>
 **Depth**: <tier> (reason: <signal>)
 **Must-fix**: <count> | **Suggestions**: <count>
+**Round**: <N> | **Ship**: <recommended | continue> — <one-line reason>  <!-- pre-push only; from the Convergence assessment (#537) -->
 
 ### Findings
 - [ ] (must-fix) <one-line summary> — `file:line`

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -736,9 +736,11 @@ review indefinitely:
     tracked.
   - **recommended** at **round ≥ 2** when the Must-fix count is **low and not
     rising** versus the previous round and the remaining must-fixes are
-    mechanical/clear — recommend addressing them and shipping rather than
-    another full round (each round costs a container cycle for diminishing
-    return, especially on guidance docs after the calibration above).
+    mechanical/clear (low ≈ **≤ 2** must-fixes, each a precise file:line fix with
+    an obvious correction — not a design question) — recommend addressing them
+    and shipping rather than another full round (each round costs a container
+    cycle for diminishing return, especially on guidance docs after the
+    calibration above).
   - **continue** when Must-fix is **rising, high, or includes a genuine
     design / correctness concern** that warrants another independent read.
 - Surface the round, verdict, and a one-line reason in the report header
@@ -814,6 +816,7 @@ Existing Review Comments sections. Use:
 
 **PR / Branch**: ...
 **Review depth**: Light (reason: <primary signal>)
+**Round**: <N> (pre-push) — **Ship: <recommended | continue>**   <!-- pre-push only; see Convergence assessment -->
 **Static analysis**: skipped (--skip-static)         <!-- include only when SKIP_STATIC=true -->
 **Claude Adversarial**: 1 pass (Lens A)
 **Copilot Adversarial**: <off (default) | run (--copilot) | skipped (<reason>, --copilot)>

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -165,14 +165,17 @@ warranted only when a fix needs operator ground truth the sub-agent can't have
 and re-dispatch `review-code` directly. (To convey ground truth *to*
 `address-findings` instead, leave it as a note in the review entry it reads.)
 
-The `address-findings` ⇄ `review-code` loop has **no built-in round cap yet** —
-a convergence / ship-recommendation signal is tracked in
-[#537](https://github.com/rolker/ros2_agent_workspace/issues/537). Until it
-lands, after ~2–3 rounds the host should **surface the loop state to the
-operator** (remaining-finding severity, ship-vs-continue) rather than spinning —
-especially for guidance-doc diffs, where review can demand precision
-indefinitely. The round number is just the count of `## Local Review (Pre-Push)`
-entries in `progress.md` — a cheap durable counter the host can read at any time.
+The `address-findings` ⇄ `review-code` loop has no hard round cap — instead,
+each pre-push `review-code` now emits a **`Round`** + a **`Ship: recommended |
+continue`** verdict in its `## Local Review (Pre-Push)` entry (the convergence
+signal, [#537](https://github.com/rolker/ros2_agent_workspace/issues/537)).
+**Route on it**: `Ship: recommended` means address any remaining must-fixes and
+publish rather than spin another full round; `Ship: continue` means another
+independent read is worth it. When the verdict is `recommended` (or after ~2–3
+rounds regardless), **surface the loop state to the operator** (remaining-finding
+severity, ship-vs-continue) rather than looping — especially for guidance-doc
+diffs, where review can demand precision indefinitely. (`Round` is the count of
+`## Local Review (Pre-Push)` entries in `progress.md` — a cheap durable counter.)
 
 ## Checkpoints
 


### PR DESCRIPTION
## review-code: convergence/ship signal + guidance-doc severity calibration

Last of the run-issue refinement batch — directly attacks the non-convergence we hit building #530 (3 review rounds on a doc).

- **Guidance-doc severity calibration** (step 6): for prose an agent *adapts* (`SKILL.md` / `.agent/knowledge/` / ADR) rather than code it executes verbatim, "an agent would catch/adapt this" downgrades **Must-fix → Suggestion**; Must-fix reserved for actively-misleading guidance (silent-fail command, wrong path/flag, contradiction, missing consequence).
- **Convergence/ship signal** (pre-push): each review computes its **Round** (count of prior `## Local Review (Pre-Push)` entries + 1) and a **Ship: recommended | continue** verdict, surfaced in the report header + Summary + the `progress.md` entry. `/run-issue` routes on it (advisory — never blocks a ship). Composes with the run-issue round-awareness from #531/#538.

### Review
Pre-push `review-code`: **approved, 0 must-fix + 3 suggestions** (all applied). The review *itself* emitted the new `Round: 1 | Ship: recommended` field — the signal is self-demonstrating.

Closes #537.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
