### PR TITLE
start-deployment: issue-less start + offer-and-confirm + background propagation (#533)

### DIFF
--- a/.agent/knowledge/deployment_mode.md
+++ b/.agent/knowledge/deployment_mode.md
@@ -225,9 +225,17 @@ on-disk artifacts that already exist:
 
 | State | Evidence | Skill action |
 |---|---|---|
-| **Create new** | No open `deployment`-labeled issue (per `issue_sync`) | Offer to create; operator approves scope; templated issue body. |
-| **Activate first time** | Open issue exists, but no local worktree (dev) / no host log (field) | Rename issue title to `Deployment YYYY-MM-DD: <scope>` if not already in that format; ensure `## Logs` section present in body; create worktree (dev) or prepare main-tree (field); initialize host log; run `issue_sync.dev_push` so field hosts see the changes. |
+| **Create new** | No usable open issue (none found, or the operator declined the offered one) | Dev: offer scope + `gh issue create` + templated body. Field: take the **issue-less start** (#533) instead — no `gh`. |
+| **Activate first time** | Open issue exists, but no local worktree (dev) / no host log (field) | **Offer the found issue for confirmation first** (#533 — never silent-attach); then rename title to `Deployment YYYY-MM-DD: <scope>` if needed; ensure `## Logs`; create worktree (dev) or prepare main-tree (field); initialize host log; `issue_sync.dev_push` (**background-by-default**, #533) so field hosts see the changes. |
 | **Resume ongoing** | Open issue + worktree+log (dev) / log file (field) | Re-attach: load the urgency contract into context, summarize state from the deployment issue body and the last ~20 entries of the current host's log. No artifacts created. |
+
+**Issue-less field start + reconciliation (#533).** Where the git-bug *lookup*
+is the slow, window-eating step, the **field side** can start **issue-less** —
+anchored to the per-host log's date (`issue: pending` header), skipping all
+`gh` / `issue_sync` calls. The **dev side** then **backfills**: on a later
+`/start-deployment`, scan `<log_dir>` for logs marked `pending`, create + link
+their issues (dated from the log filename), and clear the marker — so
+`/wrap-up-deployment` (which discovers via `gh issue list`) can find them.
 
 "Ensure essentials" on the deployment issue body is limited to:
 

--- a/.agent/knowledge/deployment_mode.md
+++ b/.agent/knowledge/deployment_mode.md
@@ -231,9 +231,10 @@ on-disk artifacts that already exist:
 
 **Issue-less field start + reconciliation (#533).** Where the git-bug *lookup*
 is the slow, window-eating step, the **field side** can start **issue-less** —
-anchored to the per-host log's date (`issue: pending` header), skipping all
-`gh` / `issue_sync` calls. The **dev side** then **backfills**: on a later
-`/start-deployment`, scan `<log_dir>` for logs marked `pending`, create + link
+anchored to the per-host log's date (canonical `Deployment issue: pending`
+header), skipping all `gh` / `issue_sync` calls. The **dev side** then
+**backfills**: on a later `/start-deployment`, scan `<log_dir>` for logs whose
+header line is `Deployment issue: pending`, create + link
 their issues (dated from the log filename), and clear the marker — so
 `/wrap-up-deployment` (which discovers via `gh issue list`) can find them.
 

--- a/.agent/work-plans/issue-533/progress.md
+++ b/.agent/work-plans/issue-533/progress.md
@@ -1,0 +1,23 @@
+---
+issue: 533
+---
+
+# Issue #533 — start-deployment: issue-less start + offer-and-confirm + background propagation
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 00:02 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-533 at `a9f0634`
+**Mode**: pre-push
+**Depth**: Standard (reason: `.claude/skills/*/SKILL.md` is a Governance override-trigger file)
+**Must-fix**: 1 | **Suggestions**: 3
+**Round**: 1 | **Ship**: continue — lone must-fix is a genuine design gap (reconciliation mechanism asserted but unimplemented); re-read after it's addressed
+
+### Findings
+- [ ] (must-fix) Issue-less reconciliation asserted but unimplemented — wrap-up discovers only by `gh issue list`, bails on no issue; nothing scans logs for `pending`. Issue-less deployment can be silently never tracked/closed. Add backfill step or flag as manual + follow-up issue — `.claude/skills/start-deployment/SKILL.md:241,322-326`
+- [ ] (suggestion) Issue-less path re-enters "4b's field branch" whose first step reads the issue body (`issue_sync.field_show`) — no issue exists; clarify entry at log-init, skip body/title/Logs checks — `.claude/skills/start-deployment/SKILL.md:239-241`
+- [ ] (suggestion) Background `dev_push` ("report when it finishes") drops the original "On failure, print `issue_sync.failure_hint`" obligation; carry failure-surfacing into the background branch — `.claude/skills/start-deployment/SKILL.md:401-410`
+- [ ] (suggestion) `deployment_mode.md` three-state table not updated for issue-less / offer-and-confirm / background dev_push (consequences map) — `.agent/knowledge/deployment_mode.md:221-230`

--- a/.agent/work-plans/issue-533/progress.md
+++ b/.agent/work-plans/issue-533/progress.md
@@ -21,3 +21,21 @@ issue: 533
 - [ ] (suggestion) Issue-less path re-enters "4b's field branch" whose first step reads the issue body (`issue_sync.field_show`) — no issue exists; clarify entry at log-init, skip body/title/Logs checks — `.claude/skills/start-deployment/SKILL.md:239-241`
 - [ ] (suggestion) Background `dev_push` ("report when it finishes") drops the original "On failure, print `issue_sync.failure_hint`" obligation; carry failure-surfacing into the background branch — `.claude/skills/start-deployment/SKILL.md:401-410`
 - [ ] (suggestion) `deployment_mode.md` three-state table not updated for issue-less / offer-and-confirm / background dev_push (consequences map) — `.agent/knowledge/deployment_mode.md:221-230`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 00:51 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-533 at `d879913`
+**Mode**: pre-push
+**Depth**: Standard (reason: `.claude/skills/*/SKILL.md` is a Governance override-trigger file)
+**Must-fix**: 1 | **Suggestions**: 3
+**Round**: 2 | **Ship**: recommended — round-1 findings all resolved; lone must-fix is a mechanical one-string fix (pin canonical `pending` marker), not a design question
+
+### Findings
+- [ ] (must-fix) Reconciliation marker mismatch: seeded `Deployment issue: _pending — ...` but backfill scans for literal `issue: pending` (not a substring of `issue: _pending`) — verbatim match finds zero issue-less logs, silently skipping backfill (the "forever untracked" failure at 250-253). Pin one canonical grep-safe string across all 5 sites — `.claude/skills/start-deployment/SKILL.md:233,246,264,336` + `.agent/knowledge/deployment_mode.md:234,236`
+- [ ] (suggestion) Wrap-up never scans logs for `pending`; loop-closure is human-memory-dependent — note orphaned-`pending`-log discovery in wrap-up — `.claude/skills/wrap-up-deployment/SKILL.md` (consequence of this change)
+- [ ] (suggestion) Issue-less "continuing a prior deployment" branch overlaps Resume (4c) when a matching local log exists — add pointer to 4c to avoid a duplicate log — `.claude/skills/start-deployment/SKILL.md:234-237`
+- [ ] (suggestion) Log-init title template shows `#<N>` first; issue-less alt title is 8 lines later — risk of stamping empty `#` under pressure; co-locate the variant — `.claude/skills/start-deployment/SKILL.md:326,334-335`

--- a/.claude/skills/start-deployment/SKILL.md
+++ b/.claude/skills/start-deployment/SKILL.md
@@ -236,9 +236,21 @@ So before running it, ask: **"Look for an existing deployment issue? (y/n)"**
       `<log_dir>/<YYYY>/<date>_<label>_logs.md` on this host; if none, **ask
       the operator**) — the multi-day convention keeps the original date.
       *Other situation?* → ask, then proceed once the start date is settled.
-  - Then go straight to the log-init + urgency-contract steps (4b's field
-    branch), **skipping every `gh` / `issue_sync` call**. A dev host
-    reconciles the `pending` link later — it finds the log by date.
+  - Then go straight to the **log-init** (the per-host-log creation in 4b)
+    and the **urgency contract** — *not* 4b's issue read / title / body /
+    `## Logs` steps, which all require an issue that doesn't exist. Skip
+    every `gh` / `issue_sync` call.
+
+**Dev-side backfill of issue-less starts (#533) — the reconciliation mechanism.**
+On the **dev side**, after the issue lookup, **also scan `<log_dir>/<YYYY>/`
+for per-host logs whose header reads `issue: pending`** (an issue-less field
+start with no link yet). For each, **offer to create + link its deployment
+issue**: derive the scope from the log's first entries, `gh issue create` it
+(dated from the log's filename — the multi-day anchor), stamp the number / URL
+back into the log header (clearing `pending`), then `dev_push`. Without this
+step an issue-less deployment is *never* tracked or closed — `/wrap-up-deployment`
+discovers deployments via `gh issue list`, so the issue must exist by then. (If
+the operator declines, leave the marker for a later run, and note it.)
 
 #### 4a. Create new
 
@@ -402,7 +414,9 @@ not a producer). On failure, print `issue_sync.failure_hint`.
 `bridge pull` + `push gitcloud`) is the slow, window-eating step on the dev
 side. When the operator is starting a *live* deployment, **run it in the
 background** (so logging + the urgency contract are active in seconds) and
-report when it finishes — **unless the operator asks to run it now** (e.g.
+report when it finishes — and on a **background failure, surface
+`issue_sync.failure_hint`** (don't let a deferred push fail silently) —
+**unless the operator asks to run it now** (e.g.
 a field host is waiting on it this minute). The choice is situational; offer
 it: "Propagate the issue to gitcloud now, or in the background?" Default
 background. The deployment is fully usable before it completes — the issue

--- a/.claude/skills/start-deployment/SKILL.md
+++ b/.claude/skills/start-deployment/SKILL.md
@@ -230,12 +230,15 @@ So before running it, ask: **"Look for an existing deployment issue? (y/n)"**
 - **n** → start **issue-less**, anchored to the per-host log's date:
   - Ask **"Is this deployment for the current day? (y/n)."**
     - **y** → use **today's date** for the log filename (step 3) and seed the
-      header `Deployment issue: _pending — backfill from a dev host_`.
+      **canonical marker** (one exact, grep-safe string — see the log-header
+      note in 4b): `Deployment issue: pending (backfill from a dev host)`.
     - **n** → **clarify**: *continuing a prior deployment?* → use that
       deployment's **start date** (read it from an existing local
       `<log_dir>/<YYYY>/<date>_<label>_logs.md` on this host; if none, **ask
       the operator**) — the multi-day convention keeps the original date.
-      *Other situation?* → ask, then proceed once the start date is settled.
+      **But if that local log already exists, this is the Resume state (4c)
+      — re-attach to it, don't start a duplicate.** *Other situation?* → ask,
+      then proceed once the start date is settled.
   - Then go straight to the **log-init** (the per-host-log creation in 4b)
     and the **urgency contract** — *not* 4b's issue read / title / body /
     `## Logs` steps, which all require an issue that doesn't exist. Skip
@@ -243,8 +246,10 @@ So before running it, ask: **"Look for an existing deployment issue? (y/n)"**
 
 **Dev-side backfill of issue-less starts (#533) — the reconciliation mechanism.**
 On the **dev side**, after the issue lookup, **also scan `<log_dir>/<YYYY>/`
-for per-host logs whose header reads `issue: pending`** (an issue-less field
-start with no link yet). For each, **offer to create + link its deployment
+for per-host logs whose header line is the canonical marker
+`Deployment issue: pending`** (`grep -l '^Deployment issue: pending'`; the
+exact string the issue-less seed writes) — an issue-less field start with no
+link yet. For each, **offer to create + link its deployment
 issue**: derive the scope from the log's first entries, `gh issue create` it
 (dated from the log's filename — the multi-day anchor), stamp the number / URL
 back into the log header (clearing `pending`), then `dev_push`. Without this
@@ -261,7 +266,7 @@ the operator declines, leave the marker for a later run, and note it.)
   > create + label it), then `issue_sync.dev_push` so this field host sees it
   > on the next `field_pull`.
 - Otherwise take the **issue-less field start** (step 4's field-side branch):
-  start logging against the date *now*, header `issue: pending`; a dev host
+  start logging against the date *now*, header `Deployment issue: pending`; a dev host
   backfills the issue link later. This is the fast path when there's no time
   to prep an issue before launch.
 
@@ -324,6 +329,7 @@ next) exists by the time any warnings need to land in it.
 
 ```markdown
 # <YYYY-MM-DD> — <label> log (<platform> deployment #<N>)
+<!-- issue-less field start (#533): no #<N> / URL yet — use the variant below -->
 
 Deployment issue: <issue URL>
 Host: <hostname>
@@ -332,8 +338,9 @@ Started: <YYYY-MM-DD HH:MM ±HH:MM>
 ```
 
 For an **issue-less field start (#533)** there is no `#<N>` or URL yet:
-title the log `… (<platform> deployment — issue pending)` and seed
-`Deployment issue: _pending — backfill from a dev host_`. The date in the
+title the log `… (<platform> deployment — issue pending)` and seed the
+**canonical marker** — one exact, grep-safe string the dev-side backfill scans
+for: `Deployment issue: pending (backfill from a dev host)`. The date in the
 filename + header is the reconciliation anchor; a dev host fills in the
 number/URL later (it finds this log by date) and clears the marker.
 

--- a/.claude/skills/start-deployment/SKILL.md
+++ b/.claude/skills/start-deployment/SKILL.md
@@ -216,17 +216,42 @@ Then branch on state:
 | **Activate first time** | Issue exists, no local worktree (dev) / no host log (field) | Step 4b |
 | **Resume ongoing** | Issue exists + worktree+log (dev) / log file (field) | Step 4c |
 
-If multiple open deployment issues are found, list them and ask the
-operator which one this session is joining.
+**Offer, don't assume (#533).** Whether one *or* several open deployment
+issues are found, **present them and have the operator confirm** before
+first-activating — "Use #N — <title>? (y/n)" (or "which one?" for several).
+On **no / none suitable**, fall through to *Create new* (4a, dev) or the
+*issue-less field start* (below). Never silently attach to a found issue.
+
+**Field-side issue-less start (#533).** On the **field side** the git-bug
+*lookup* (`field_pull` + `field_list_open`) is the slow, window-eating step.
+So before running it, ask: **"Look for an existing deployment issue? (y/n)"**
+
+- **y** → run the lookup as above; offer-and-confirm any match.
+- **n** → start **issue-less**, anchored to the per-host log's date:
+  - Ask **"Is this deployment for the current day? (y/n)."**
+    - **y** → use **today's date** for the log filename (step 3) and seed the
+      header `Deployment issue: _pending — backfill from a dev host_`.
+    - **n** → **clarify**: *continuing a prior deployment?* → use that
+      deployment's **start date** (read it from an existing local
+      `<log_dir>/<YYYY>/<date>_<label>_logs.md` on this host; if none, **ask
+      the operator**) — the multi-day convention keeps the original date.
+      *Other situation?* → ask, then proceed once the start date is settled.
+  - Then go straight to the log-init + urgency-contract steps (4b's field
+    branch), **skipping every `gh` / `issue_sync` call**. A dev host
+    reconciles the `pending` link later — it finds the log by date.
 
 #### 4a. Create new
 
-**Field side**: cannot create the issue (no GitHub access). Stop with:
+**Field side**: cannot create the issue (no GitHub access). Two paths (#533):
 
-> No open deployment issue found via `issue_sync`. Start the deployment
-> from a dev host first (where `gh` can create the issue and configure
-> labels), then run `issue_sync.dev_push` so this field host sees it on
-> the next `issue_sync.field_pull`.
+- If the operator wants the deployment **tracked from the start**, stop with:
+  > No deployment issue yet. Create it from a dev host first (where `gh` can
+  > create + label it), then `issue_sync.dev_push` so this field host sees it
+  > on the next `field_pull`.
+- Otherwise take the **issue-less field start** (step 4's field-side branch):
+  start logging against the date *now*, header `issue: pending`; a dev host
+  backfills the issue link later. This is the fast path when there's no time
+  to prep an issue before launch.
 
 **Dev side**: ask the operator for the scope of this deployment (one or
 two sentences; this becomes the issue title's `<scope>` portion and the
@@ -293,6 +318,12 @@ Host: <hostname>
 Side: <dev|field>
 Started: <YYYY-MM-DD HH:MM ±HH:MM>
 ```
+
+For an **issue-less field start (#533)** there is no `#<N>` or URL yet:
+title the log `… (<platform> deployment — issue pending)` and seed
+`Deployment issue: _pending — backfill from a dev host_`. The date in the
+filename + header is the reconciliation anchor; a dev host fills in the
+number/URL later (it finds this log by date) and clears the marker.
 
 Any title / body / log-stamp warnings emitted below append to this
 file. It is the canonical sink for field-side drift warnings; dev side
@@ -366,6 +397,17 @@ branch on side:
 propagate the title / body changes to the field-visible source. Skip
 silently on field side (the field host is the consumer of the share,
 not a producer). On failure, print `issue_sync.failure_hint`.
+
+**Background-by-default for a live start (#533).** `dev_push` (git-bug
+`bridge pull` + `push gitcloud`) is the slow, window-eating step on the dev
+side. When the operator is starting a *live* deployment, **run it in the
+background** (so logging + the urgency contract are active in seconds) and
+report when it finishes — **unless the operator asks to run it now** (e.g.
+a field host is waiting on it this minute). The choice is situational; offer
+it: "Propagate the issue to gitcloud now, or in the background?" Default
+background. The deployment is fully usable before it completes — the issue
+already exists for the worktree; propagation only affects when *other* hosts
+see it.
 
 Proceed to step 5 (dev pre-flight) if dev side; otherwise the skill is
 done.

--- a/.claude/skills/wrap-up-deployment/SKILL.md
+++ b/.claude/skills/wrap-up-deployment/SKILL.md
@@ -113,8 +113,14 @@ gh issue list --label deployment --state open --json number,title,createdAt,body
 Run from inside the project repo (or with `-R <owner/repo>` if not). `gh`
 auto-detects the remote from `origin`.
 
-- **No open deployment issue**: nothing to wrap up; confirm with the operator
-  whether this was intentional.
+- **No open deployment issue**: before concluding there's nothing to wrap up,
+  **scan `<log_dir>` for an issue-less field start (#533)** — a per-host log
+  whose header line is the canonical `Deployment issue: pending`
+  (`grep -rl '^Deployment issue: pending' <log_dir>`). If found, that
+  deployment was started issue-less and never backfilled: **create + link its
+  issue now** (dated from the log filename), clear the `pending` marker, then
+  proceed to wrap it up. Otherwise confirm with the operator whether the
+  no-issue state was intentional.
 - **Exactly one**: proceed.
 - **Multiple**: list them and ask the operator which deployment this wrap-up is for.
 


### PR DESCRIPTION
## start-deployment: issue-less start (defer the slow step, per side)

Final item of the run-issue/deployment refinement batch — start a deployment without burning the live window on issue ceremony. Dev/field-asymmetric because **the slow step differs by side**.

- **Detection:** a found issue is **offered for confirmation** (never silent-attach); on no/none → create-new (dev) or issue-less field start.
- **Field side** (slow step = git-bug *lookup*): "look for an issue? (y/n)" → no → **issue-less**, anchored to the per-host log date (today / continuing→Resume / clarify), all `gh`/`issue_sync` skipped, canonical `Deployment issue: pending` header.
- **Dev side** (slow step = git-bug *propagation*): issue still created (the worktree needs it), but `dev_push` is **background-by-default** with an immediate option (failure still surfaced).
- **Reconciliation:** dev-side `/start-deployment` **and** `/wrap-up-deployment` scan `<log_dir>` for `Deployment issue: pending` logs and backfill the issue (dated from the filename), clearing the marker. Knowledge-doc three-state table updated.

### Review
Pre-push `review-code` ×2 — **first run under #537's guidance-doc calibration + convergence signal** (just merged). Round 1: 1 must-fix (`Ship: continue` — real design gap: reconciliation asserted-not-implemented). Round 2: 1 must-fix (`Ship: recommended` — mechanical marker-string mismatch) + suggestions, all addressed. The signal behaved exactly as designed.

Closes #533.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
