### PR TITLE
run-issue: container dispatch reduces permission prompts + lean toward it (#545)

### DIFF
--- a/.agent/work-plans/issue-545/progress.md
+++ b/.agent/work-plans/issue-545/progress.md
@@ -1,0 +1,21 @@
+---
+issue: 545
+---
+
+# Issue #545 — run-issue: container dispatch reduces permission prompts + lean toward it
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 01:41 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-545 at `49ecd2a`
+**Mode**: pre-push
+**Depth**: Standard (reason: `.claude/skills/*/SKILL.md` is a Governance override-trigger)
+**Must-fix**: 0 | **Suggestions**: 2
+**Round**: 1 | **Ship**: recommended — no must-fix; only prose-hardening suggestions on a guidance doc
+
+### Findings
+- [ ] (suggestion) Scope "prompt-free / out of the approval loop" framing to phase work vs. host-enforced publish/merge checkpoints — `.claude/skills/run-issue/SKILL.md:56-70`
+- [ ] (suggestion) Name the long-lived-token prompt-elimination as a safety tradeoff, not just a launch cost — `.claude/skills/run-issue/SKILL.md:67-70`

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -43,16 +43,31 @@ Each phase runs in a **fresh-context sub-agent** via the dispatcher:
 .agent/scripts/dispatch_subagent.sh --mode <in-process|container> --issue <N> --skill <phase>
 ```
 
-- **in-process** (default) for reviews and short phases — fast, same context
-  root. In-process dispatch spawns the phase via Claude Code's **`Agent` tool**,
-  which exists in the **host** session but **not** inside a headless container.
-  This is precisely why `run-issue` is a *host* orchestrator (see Scope E): run
-  it on the host, where it can fan phases out in-process; it is never itself
-  dispatched into a container. (Non-Claude host runtimes lack the `Agent` tool
-  too — there, drive the phases manually or use `--mode container`.)
-- **container** when isolation is wanted (e.g. running the full review-code
-  specialist fan-out, or implementation that benefits from a clean OS). Container
-  mode is headless and self-contained, so it needs no host `Agent` tool.
+- **in-process** for **quick / cheap phases** — fast, same context root. It
+  spawns the phase via Claude Code's **`Agent` tool**, which exists in the
+  **host** session but **not** inside a headless container. This is precisely
+  why `run-issue` is a *host* orchestrator (see Scope E): run it on the host,
+  where it can fan phases out in-process; it is never itself dispatched into a
+  container. (Non-Claude host runtimes lack the `Agent` tool too — there, drive
+  the phases manually or use `--mode container`.) **Caveat:** an in-process
+  `Agent` phase runs *in the host session*, so its tool calls (edits, commits,
+  `gh`, shell) are subject to the **host's permission policy and can prompt the
+  operator** — phase after phase, edit after edit.
+- **container** for **isolation *and* prompt-free dispatch**. It is headless and
+  self-contained (needs no host `Agent` tool), so its tool calls execute *inside
+  the sandbox* and **never reach the operator's permission prompt** — zero
+  approvals for the dispatched work. That prompt elimination is the biggest
+  practical reason to use it, beyond a clean OS for the review-code fan-out or
+  implementation.
+
+**Choosing a mode (#545).** **Lean toward `container`** for phases that do many
+tool calls (implement / address-findings / the review-code fan-out) or whenever
+keeping the operator **out of the approval loop** matters — combined with the
+background-dispatch guidance below, that gives a fully hands-off, prompt-free
+phase. Use **`in-process`** for quick/cheap phases where the prompt cost is
+already low and the lower overhead wins, or when container auth isn't set up
+(`dispatch_subagent.sh --check`, #532) — container needs the long-lived auth
+token and pays a launch cost, so it isn't free.
 
 **Dispatch container phases in the *background* so the host stays available.**
 A synchronous (foreground) container dispatch blocks the host's turn for the

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -58,7 +58,11 @@ Each phase runs in a **fresh-context sub-agent** via the dispatcher:
   the sandbox* and **never reach the operator's permission prompt** — zero
   approvals for the dispatched work. That prompt elimination is the biggest
   practical reason to use it, beyond a clean OS for the review-code fan-out or
-  implementation.
+  implementation. **Scope note:** this removes prompts for the *phase's own tool
+  calls* — `run-issue`'s **checkpoints** (publish, PR, merge) are host-enforced
+  operator confirmations and stay that way regardless of dispatch mode. "Out of
+  the approval loop" means the *busywork* approvals, not the deliberate human
+  gates.
 
 **Choosing a mode (#545).** **Lean toward `container`** for phases that do many
 tool calls (implement / address-findings / the review-code fan-out) or whenever
@@ -66,8 +70,13 @@ keeping the operator **out of the approval loop** matters — combined with the
 background-dispatch guidance below, that gives a fully hands-off, prompt-free
 phase. Use **`in-process`** for quick/cheap phases where the prompt cost is
 already low and the lower overhead wins, or when container auth isn't set up
-(`dispatch_subagent.sh --check`, #532) — container needs the long-lived auth
-token and pays a launch cost, so it isn't free.
+(`dispatch_subagent.sh --check`, #532). Container isn't free: it pays a launch
+cost, and the prompt elimination is itself a **safety tradeoff** — the
+dispatched agent runs with broad tool access under a long-lived token, so the
+**sandbox boundary (not per-call approval) is what contains it**. That's an
+acceptable trade for trusted first-party phases, but it *is* the safeguard you're
+relying on — keep it in mind before dispatching anything that processes
+untrusted input.
 
 **Dispatch container phases in the *background* so the host stays available.**
 A synchronous (foreground) container dispatch blocks the host's turn for the


### PR DESCRIPTION
## run-issue: state that container dispatch reduces permission prompts + lean toward it

run-issue defaulted to `in-process` and framed `container` as "for isolation" — never stating the biggest practical reason to use it: **a sandboxed phase's tool calls never reach the operator's permission prompt** (zero approvals), whereas in-process `Agent` phases run in the host session and *can* prompt, edit after edit. The whole run-issue refinement batch was driven prompt-free via background container dispatch — proving it — but the skill defaulted *away* from it.

- Add the **prompt-reduction** rationale to container dispatch; **lean toward container** for tool-call-heavy phases / staying out of the busywork-approval loop.
- Keep **in-process** for quick/cheap phases or when container auth isn't set up (`--check`, #532).
- Scope "prompt-free" to *phase work* — `run-issue` checkpoints (publish/PR/merge) stay host-enforced. Name the **safety tradeoff** (the sandbox boundary, not per-call approval, is the safeguard).

Review: approved, 0 must-fix + 2 suggestions (applied). Closes #545.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
