### PR TITLE
fix: red main — stale dispatch tests after #526

### DIFF
--- a/.agent/scripts/test_dispatch_subagent.sh
+++ b/.agent/scripts/test_dispatch_subagent.sh
@@ -125,13 +125,20 @@ case "$out" in
     *) bad "honors AGENT_NAME/AGENT_EMAIL override" "override not reflected in handoff" ;;
 esac
 
-# --- ambiguous worktree match warns on stderr ---
+# --- ambiguous worktree match fails loud (#526) ---
+# Two worktrees (workspace FAKE_WT + layer FAKE_WT2) match the same bare issue
+# number. The dispatcher must refuse to guess and exit non-zero, telling the
+# operator to disambiguate with --repo-slug. (Was warn-and-proceed before #526.)
 mkdir -p "$FAKE_WT2/.agent/work-plans/issue-$TEST_ISSUE"
-err="$("$DISPATCH" --mode in-process --issue "$TEST_ISSUE" --skill review-code 2>&1 >/dev/null)"
-case "$err" in
-    *"worktrees matched issue #$TEST_ISSUE"*) ok "warns on ambiguous worktree match" ;;
-    *) bad "warns on ambiguous worktree match" "no warning emitted to stderr" ;;
-esac
+out="$("$DISPATCH" --mode in-process --issue "$TEST_ISSUE" --skill review-code 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ]; then
+    bad "fails loud on ambiguous worktree match" "expected non-zero exit, got 0"
+else
+    case "$out" in
+        *"worktrees match issue #$TEST_ISSUE"*"refusing to guess"*) ok "fails loud on ambiguous worktree match" ;;
+        *) bad "fails loud on ambiguous worktree match" "stderr missing the refuse-to-guess message" ;;
+    esac
+fi
 rm -rf "$FAKE_WT2"
 
 echo ""

--- a/.agent/scripts/tests/test_dispatch_worktree_resolution.sh
+++ b/.agent/scripts/tests/test_dispatch_worktree_resolution.sh
@@ -13,7 +13,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DISPATCH="$SCRIPT_DIR/../dispatch_subagent.sh"
 
 # Resolve ROOT_DIR exactly as dispatch_subagent.sh does (strip worktree prefix).
-ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# This test lives one dir deeper than dispatch_subagent.sh (tests/), so it walks
+# up THREE levels (tests -> scripts -> .agent -> root), not two. Getting this
+# wrong points the fake worktrees at .agent/layers/... while the script looks
+# under <root>/layers/... — a mismatch the worktree-prefix strip masks locally
+# (when run from inside a worktree) but CI exposes (#548).
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 case "$ROOT_DIR" in
     *"/.workspace-worktrees/"*) ROOT_DIR="${ROOT_DIR%%/.workspace-worktrees/*}" ;;
     *"/layers/worktrees/"*)     ROOT_DIR="${ROOT_DIR%%/layers/worktrees/*}" ;;


### PR DESCRIPTION
Fixes the red `main` left by #547 (issue #526). Both fixes are **test-only**.

## What broke

1. **`test_dispatch_worktree_resolution.sh` `ROOT_DIR` off-by-one** — the test lives in `.agent/scripts/tests/` (3 levels under the repo root) but computed `ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"` (2 levels → `.agent/`). It created fake worktrees under `.agent/layers/worktrees/` while `dispatch_subagent.sh` resolves `<root>/layers/worktrees/` → "no worktree found", 3/5 cases failed in CI. It passed *locally* only because the worktree-prefix strip masked the off-by-one when run from inside a worktree. Fixed: `../..` → `../../..` (parity with `dispatch_subagent.sh:30`).

2. **`test_dispatch_subagent.sh:128` stale assertion** — its ambiguous-match case asserted the pre-#526 warn-and-proceed wording (`worktrees matched issue #N`). #526 made resolution **fail-loud** (`N worktrees match issue #N — refusing to guess`, exit 1). Updated to assert exit-1 + the refuse-to-guess message and renamed the label.

## Verification

- `test_dispatch_subagent.sh`: 29 passed, 0 failed
- `test_dispatch_worktree_resolution.sh`: 5 passed, 0 failed
- Full `run_script_tests.sh` (CI's invocation): all shell suites pass + pytest 51 passed

The `Lint (pre-commit)` failure on #547 was an unrelated CI infra flake ("Failed to determine ROS apt source version from GitHub API" in the bootstrap step), not addressed here.

Follow-up to #526 / #547.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
