### PR TITLE
fix(review-issue): persist progress.md before best-effort GitHub post (#466)

### DIFF
--- a/.agent/work-plans/issue-466/plan.md
+++ b/.agent/work-plans/issue-466/plan.md
@@ -1,0 +1,132 @@
+---
+issue: 466
+skill: plan-task
+---
+
+# Work Plan — Issue #466: Local-First Posting for review-issue
+
+**Issue**: #466 — Persist review-issue and review-plan output to progress.md
+**Scope**: POST-SIDE ONLY — skill-side posting behavior in `review-issue` SKILL.md.
+**Out of scope** (tracked in #552): host injecting read-context; false-FAILED on
+re-dispatch replacing a typed entry (count 1→1).
+
+## Context
+
+The persistence half of issue #466 is already shipped: both `review-issue` and
+`review-plan` write typed `## Issue Review` / `## Plan Review` entries to
+`progress.md` (observed driving #550). What remains is a posting-order and
+reporting bug in `review-issue`:
+
+1. **Wrong order**: step 7 (GitHub comment) runs before step 8 (progress.md
+   commit). If posting fails, progress.md may not yet have been written.
+2. **Wrong status**: when posting fails due to missing gh auth (the normal
+   container case), the skill self-marks `**Status**: partial`, even though it
+   produced a complete progress.md entry. `dispatch_subagent.sh` maps
+   `partial → exit 1`, so a fully-successful container phase pages the host as
+   "FAILED".
+
+`review-plan` has no posting step at all — no change needed there.
+
+`dispatch_subagent.sh` already maps `complete → exit 0` (lines 481–482, 492–493).
+No code change is needed in that script; the fix is entirely in `review-issue`
+SKILL.md.
+
+## Changes
+
+### 1. Reorder steps in `review-issue` SKILL.md
+
+**File**: `.claude/skills/review-issue/SKILL.md`
+
+Current order:
+- Step 7 — Post findings as a GitHub comment
+- Step 8 — Persist to progress.md + commit
+
+New order (swap):
+- Step 7 — Persist to progress.md + commit (**canonical record — always runs**)
+- Step 8 — Post findings as a GitHub comment (**best-effort / optional**)
+
+The commit in step 7 becomes the primary record. Step 8 is a publication
+convenience that may be skipped without affecting the lifecycle state.
+
+### 2. Gate the posting step on gh auth
+
+In the new step 8, add a pre-flight check before calling `gh issue comment`:
+
+```bash
+# Best-effort only — skip silently if gh auth is absent
+if gh auth status --active 2>/dev/null; then
+    gh issue comment <N> --body-file "$BODY_FILE"
+else
+    echo "[review-issue] No GitHub auth — skipping comment post (progress.md is the record)."
+fi
+```
+
+Do not set `**Status**: partial` based on this branch. The status is `complete`
+regardless of whether the post succeeded.
+
+### 3. Update `**Comment**:` field in the progress.md template
+
+The `**Comment**:` line in the `## Issue Review` entry currently expects a
+GitHub comment URL. With best-effort posting it may not have one. Use:
+
+- When posting succeeded: `**Comment**: <URL>`
+- When posting was skipped: `**Comment**: (not posted — no GitHub auth)`
+
+This is already the pattern used by the review performed while driving #550
+(see the existing `## Issue Review` entry in this file).
+
+### 4. Document the decision in SKILL.md
+
+Add a "Posting behavior" note to the `## Overview` section of
+`review-issue/SKILL.md` making the best-effort contract explicit:
+
+> **GitHub posting is best-effort.** The `progress.md` entry (step 7) is the
+> canonical record. Step 8 posts a comment for human visibility on GitHub, but
+> skips silently when no gh auth is present (e.g., container dispatch per
+> #532). A skipped post does **not** change the phase status — the skill
+> reports `complete` as long as the progress.md entry was committed.
+
+### 5. Verify dispatch_subagent.sh (no code change expected)
+
+Confirm that `dispatch_subagent.sh` maps `complete → exit 0` (already true at
+lines 481–482, 492–493 in the current file). If confirmation finds a gap,
+add a clarifying comment — but do not change the mapping logic. Update
+AGENTS.md script table only if `dispatch_subagent.sh` is actually modified.
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `.claude/skills/review-issue/SKILL.md` | Reorder steps 7↔8; add gh-auth gate; document best-effort decision in Overview |
+| `.agent/scripts/dispatch_subagent.sh` | Read-only verification; comment only if modified |
+| `AGENTS.md` | Only if `dispatch_subagent.sh` changes (not expected) |
+
+## Acceptance Criteria (from issue)
+
+- [ ] `review-issue` reports `**Status**: complete` when the only unmet step is
+  the optional GitHub post
+- [ ] No gh auth ⇒ skip the post silently; `progress.md` entry is committed
+  before the posting attempt
+- [ ] `dispatch_subagent.sh` does not surface a locally-complete phase as FAILED
+  / exit 1 because the optional GitHub post was skipped
+- [ ] Skill docs updated with the best-effort-posting decision
+
+## Step Sequence
+
+1. Edit `review-issue/SKILL.md`: swap steps 7 and 8, add gh-auth gate, add
+   Overview note on best-effort posting, update `**Comment**:` field template.
+2. Read `dispatch_subagent.sh` to confirm `complete → exit 0` mapping; add
+   comment if helpful (no logic change).
+3. Run pre-commit, commit changes with agent identity.
+4. Run `/review-code` pre-push against the diff.
+5. Address any review findings; re-commit if needed.
+
+## Consequences
+
+- All container-dispatched `review-issue` phases (and future peers using the
+  same pattern) will now correctly report `complete` when the optional post is
+  skipped.
+- The `## Issue Review` entry is always present in `progress.md` before any
+  posting attempt — the timeline is correct even if posting fails mid-way.
+- No change to the human-facing review content or the governance evaluation
+  logic.

--- a/.agent/work-plans/issue-466/plan.md
+++ b/.agent/work-plans/issue-466/plan.md
@@ -14,16 +14,23 @@ re-dispatch replacing a typed entry (count 1→1).
 
 The persistence half of issue #466 is already shipped: both `review-issue` and
 `review-plan` write typed `## Issue Review` / `## Plan Review` entries to
-`progress.md` (observed driving #550). What remains is a posting-order and
-reporting bug in `review-issue`:
+`progress.md` (observed driving #550). What remains is a **posting-order** bug in
+`review-issue`:
 
-1. **Wrong order**: step 7 (GitHub comment) runs before step 8 (progress.md
-   commit). If posting fails, progress.md may not yet have been written.
-2. **Wrong status**: when posting fails due to missing gh auth (the normal
-   container case), the skill self-marks `**Status**: partial`, even though it
-   produced a complete progress.md entry. `dispatch_subagent.sh` maps
-   `partial → exit 1`, so a fully-successful container phase pages the host as
-   "FAILED".
+1. **Wrong order is the root cause**: SKILL.md posts the GitHub comment (step 7)
+   *before* persisting + committing the `## Issue Review` entry (step 8). When
+   gh auth is absent (the normal container case), the agent has no way to
+   complete step 7 and aborts there — *before* reaching step 8's persist — so
+   either nothing is written, or it records a non-`complete` status. Observed
+   live: commit `a38b523` wrote `**Status**: failed`; the #550 run wrote
+   `partial`. `dispatch_subagent.sh` maps both `partial` and `failed` to a
+   non-zero exit, so a phase whose only real gap is the optional post pages the
+   host as "FAILED".
+2. **Note on framing**: the current SKILL.md does *not* literally instruct the
+   skill to self-mark `partial` — step 8 hardcodes `complete`. The bad status
+   comes from the agent improvising when it can't complete the earlier posting
+   step. Persisting **first** removes the ability of the optional post to block
+   (or downgrade) the canonical record, which is the actual fix.
 
 `review-plan` has no posting step at all — no change needed there.
 
@@ -64,16 +71,33 @@ fi
 Do not set `**Status**: partial` based on this branch. The status is `complete`
 regardless of whether the post succeeded.
 
-### 3. Update `**Comment**:` field in the progress.md template
+### 3. Update `**Comment**:` field in the progress.md template (no inline URL)
 
-The `**Comment**:` line in the `## Issue Review` entry currently expects a
-GitHub comment URL. With best-effort posting it may not have one. Use:
+Because the entry is now written + committed in step 7 **before** any posting
+attempt (step 8), the **comment URL is not known at write time** — so the
+template must not depend on it. Drop the on-success-URL case entirely; the
+`**Comment**:` line records posting *intent*, not a resulting URL:
 
-- When posting succeeded: `**Comment**: <URL>`
-- When posting was skipped: `**Comment**: (not posted — no GitHub auth)`
+- `**Comment**: (best-effort post follows this entry; not recorded inline)`
 
-This is already the pattern used by the review performed while driving #550
-(see the existing `## Issue Review` entry in this file).
+If a posted comment's URL is ever wanted, it lives on the GitHub issue thread —
+do **not** round-trip back to amend+recommit the entry just to capture it (that
+churn is out of proportion to the value, and re-committing the same entry would
+also trip the #552 replace-vs-append count edge). Keep the `## Issue Review`
+entry single-write.
+
+### 3b. Fix stale internal cross-references in SKILL.md
+
+Swapping steps 7↔8 leaves dangling references that assume posting precedes
+persistence. Fix them so the doc is internally consistent:
+
+- `SKILL.md:161` — "After posting the comment, append…" → reword to "After
+  committing the progress.md entry, (best-effort) post…" (persistence now first).
+- `SKILL.md:305` — `**Comment**: <URL … from step 7>` → align with change #3
+  (no inline URL; the persist step is the new step 7).
+
+Grep the file for any other "step 7"/"step 8" or "after posting" phrasing and
+reconcile all of it with the new order.
 
 ### 4. Document the decision in SKILL.md
 
@@ -97,7 +121,7 @@ AGENTS.md script table only if `dispatch_subagent.sh` is actually modified.
 
 | File | Change |
 |------|--------|
-| `.claude/skills/review-issue/SKILL.md` | Reorder steps 7↔8; add gh-auth gate; document best-effort decision in Overview |
+| `.claude/skills/review-issue/SKILL.md` | Reorder steps 7↔8; add gh-auth gate; drop inline-URL `**Comment**:` case; fix stale cross-refs (`:161`, `:305`, + any other "after posting"/"step 7/8" phrasing); document best-effort decision in Overview |
 | `.agent/scripts/dispatch_subagent.sh` | Read-only verification; comment only if modified |
 | `AGENTS.md` | Only if `dispatch_subagent.sh` changes (not expected) |
 

--- a/.agent/work-plans/issue-466/progress.md
+++ b/.agent/work-plans/issue-466/progress.md
@@ -148,4 +148,4 @@ Implemented the approved revised plan (commit 87ac99e), post-side only.
 - [x] (must-fix) Step rename `8a.x`→`7a.x` left 4 dangling cross-refs in sibling skill — `.claude/skills/review-plan/SKILL.md:269,291,310,320` (→ 7a.1/7a.2/7a.3/7a.5)
 - [x] (must-fix) gh-auth gate handles only no-token; read-only container `GH_TOKEN` makes `gh auth status --active` pass, then unguarded `gh issue comment` fails loudly (403) — reintroduces bad status in the #532 target env — `.claude/skills/review-issue/SKILL.md:359`
 - [x] (suggestion) `description:`/Overview still flatly say "Posts findings as a comment"; posting is now best-effort — `.claude/skills/review-issue/SKILL.md:3`
-- [ ] (suggestion) Read path (step 1 `gh issue view`, 7a.1 probe) remains ungated auth dependency; "persist-first complete" guarantee only holds with a read token — `.claude/skills/review-issue/SKILL.md:26`
+- [x] (suggestion) Read path (step 1 `gh issue view`, 7a.1 probe) remains ungated auth dependency; "persist-first complete" guarantee only holds with a read token — `.claude/skills/review-issue/SKILL.md:26`

--- a/.agent/work-plans/issue-466/progress.md
+++ b/.agent/work-plans/issue-466/progress.md
@@ -64,3 +64,14 @@ Per the consequences map:
 - [ ] Verify `dispatch_subagent.sh`: confirm that a `complete` progress.md entry from the skill results in exit 0 (no code change likely needed — the current logic already maps `complete → exit 0`; add a comment if helpful)
 - [ ] If `dispatch_subagent.sh` is changed, update AGENTS.md script reference table entry for `dispatch_subagent.sh`
 - [ ] Skill docs updated per acceptance criteria
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-21 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-466/plan.md`
+**Scope**: Post-side only — `review-issue` SKILL.md posting behavior; `review-plan` has no posting step (no change needed); `dispatch_subagent.sh` already maps `complete → exit 0` (no code change needed).
+
+### Findings
+- [ ] Plan looks solid. Ready for implementation.

--- a/.agent/work-plans/issue-466/progress.md
+++ b/.agent/work-plans/issue-466/progress.md
@@ -2,36 +2,65 @@
 issue: 466
 ---
 
-# Issue #466 — (title unknown — see below)
+# Issue #466 — Persist review-issue and review-plan output to progress.md
 
 ## Issue Review
-**Status**: failed
-**When**: 2026-06-21 00:00 +00:00
+**Status**: complete
+**When**: 2026-06-21 05:08 +00:00
 **By**: Claude Code Agent (Claude Sonnet)
 
 **Issue**: #466
-**Comment**: (not posted — GitHub auth unavailable)
-**Scope verdict**: (not determined)
+**Comment**: (not posted — GitHub posting is optional/best-effort per local-first contract #532)
+**Scope verdict**: well-scoped
 
-### Failure reason
+### Scope Assessment
 
-`gh auth status` reports no authenticated GitHub hosts. Neither `GH_TOKEN`,
-`GITHUB_TOKEN`, `AGENT_GH_TOKEN`, nor `~/.config/ros2-agent/gh-readonly-token`
-are present in this in-process dispatch context. Without GitHub auth, steps 1
-(read issue body) and 7 (post review comment) of the review-issue SKILL.md
-procedure cannot be completed.
+**Well-scoped?** Yes — the persistence half is already shipped (both `review-issue` and
+`review-plan` write typed `progress.md` entries). The remaining work is narrowly defined:
+(1) make `review-issue` report `complete` (not `partial`) when the only unmet step is the
+optional GitHub post, and (2) verify `dispatch_subagent.sh` does not surface a locally-
+complete phase as FAILED solely because the post was skipped. Both fit a single PR.
 
-git-bug was checked (`git-bug bug list`); only 10 closed bugs are cached and
-none correspond to issue #466. Workspace commit history and grep searches
-also turned up no cached copy of the issue body.
+**Right repo?** Yes — workspace repo. Changes are to `.claude/skills/review-issue/SKILL.md`
+and `.agent/scripts/dispatch_subagent.sh` (verification/documentation; may not need a code
+change). No project-repo changes required.
 
-### What was attempted
+**Dependencies**: The issue body confirms the persistence half is shipped (observed driving #550).
+No blocking open issues identified. Issue #532 (local-first posting contract) is referenced
+as context, not a blocker.
 
-- `gh issue view 466` → `gh auth login` required
-- `git-bug bug list` → no #466 entry
-- Searched `.agent/work-plans/`, git log, and all markdown files for issue #466 body
-- Confirmed no GH token environment variables or token files present
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | Silently skipping an optional post and recording the skip in `progress.md` keeps the record honest; no hidden state change |
+| Enforcement over documentation | OK | Skill instructions are the appropriate enforcement layer here; behavior fix in SKILL.md is sufficient |
+| Capture decisions, not just implementations | Watch | The "posting is best-effort/optional" decision should be explicit in SKILL.md — not just implied by the fix. Issue text calls for skill docs update, which covers this. |
+| A change includes its consequences | Action needed | SKILL.md must be updated; `dispatch_subagent.sh` behavior should be verified and documented; AGENTS.md/CLAUDE.md need no change (issue text confirms they don't reference per-skill persistence detail) |
+| Only what's needed | OK | Minimal change: update the complete/partial/failed logic in the skill and SKILL.md; no scope creep needed |
+| Improve incrementally | OK | Persistence half already shipped; this is a clean targeted follow-up |
+| Workspace vs. project separation | OK | Workspace skills and scripts only |
+| Workspace improvements cascade to projects | OK | All container-dispatched phases benefit from the corrected posting behavior |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| ADR-0002 — Worktree isolation | Yes | Work proceeds in the existing `issue-workspace-466` worktree |
+| ADR-0004 — Enforcement hierarchy | Watch | The optional-posting rule lives only in skill instructions; no hook/CI enforcement possible for skill behavior, so docs-only is acceptable here |
+| ADR-0006 — Shared AGENTS.md | No | Issue text explicitly confirms AGENTS.md/CLAUDE.md references are unchanged |
+| ADR-0013 — progress.md vocabulary | Yes | Entry type `## Issue Review` with `complete` status is per ADR-0013. The fix must ensure the entry is committed *before* the optional posting attempt, so the timeline is correct even if posting is skipped |
+
+### Consequences
+
+Per the consequences map:
+- Changing a framework skill → framework adapter file may need updating if it references posting behavior; issue text says no AGENTS.md/CLAUDE.md change needed
+- If `dispatch_subagent.sh` changes → update AGENTS.md script reference table (§ Script Reference)
+- The posting-as-optional change must be recorded in SKILL.md so the intent survives future reads
 
 ### Actions
-- [ ] Host: re-dispatch review-issue with GitHub auth available (GH_TOKEN env var
-  or `~/.config/ros2-agent/gh-readonly-token` populated) so steps 1 and 7 can run
+- [ ] Update `review-issue` SKILL.md: document GitHub posting as best-effort/optional; when no gh auth, skip silently and report `complete`
+- [ ] Ensure the `progress.md` write + commit happens *before* the optional posting attempt (so entry is always present regardless of posting outcome)
+- [ ] Verify `dispatch_subagent.sh`: confirm that a `complete` progress.md entry from the skill results in exit 0 (no code change likely needed — the current logic already maps `complete → exit 0`; add a comment if helpful)
+- [ ] If `dispatch_subagent.sh` is changed, update AGENTS.md script reference table entry for `dispatch_subagent.sh`
+- [ ] Skill docs updated per acceptance criteria

--- a/.agent/work-plans/issue-466/progress.md
+++ b/.agent/work-plans/issue-466/progress.md
@@ -1,0 +1,37 @@
+---
+issue: 466
+---
+
+# Issue #466 — (title unknown — see below)
+
+## Issue Review
+**Status**: failed
+**When**: 2026-06-21 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #466
+**Comment**: (not posted — GitHub auth unavailable)
+**Scope verdict**: (not determined)
+
+### Failure reason
+
+`gh auth status` reports no authenticated GitHub hosts. Neither `GH_TOKEN`,
+`GITHUB_TOKEN`, `AGENT_GH_TOKEN`, nor `~/.config/ros2-agent/gh-readonly-token`
+are present in this in-process dispatch context. Without GitHub auth, steps 1
+(read issue body) and 7 (post review comment) of the review-issue SKILL.md
+procedure cannot be completed.
+
+git-bug was checked (`git-bug bug list`); only 10 closed bugs are cached and
+none correspond to issue #466. Workspace commit history and grep searches
+also turned up no cached copy of the issue body.
+
+### What was attempted
+
+- `gh issue view 466` → `gh auth login` required
+- `git-bug bug list` → no #466 entry
+- Searched `.agent/work-plans/`, git log, and all markdown files for issue #466 body
+- Confirmed no GH token environment variables or token files present
+
+### Actions
+- [ ] Host: re-dispatch review-issue with GitHub auth available (GH_TOKEN env var
+  or `~/.config/ros2-agent/gh-readonly-token` populated) so steps 1 and 7 can run

--- a/.agent/work-plans/issue-466/progress.md
+++ b/.agent/work-plans/issue-466/progress.md
@@ -75,3 +75,17 @@ Per the consequences map:
 
 ### Findings
 - [ ] Plan looks solid. Ready for implementation.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-21 05:25 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-466/plan.md` at `abfc8bc`
+**PR**: PR-less (`--issue` mode; no gh auth in container)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (must-fix) Reorder makes persistence run first, so the GitHub comment URL is unknown when the `## Issue Review` entry is written — change #3's "When posting succeeded: `**Comment**: <URL>`" is unobtainable at write time. Specify placeholder-then-amend+recommit, or drop the on-success-URL case. — `plan.md:70`
+- [ ] (suggestion) "Swap steps 7↔8" must also fix stale internal cross-refs that assume posting precedes persistence: "After posting the comment, append…" (`SKILL.md:161`) and `**Comment**: <URL … from step 7>` (`SKILL.md:305`). — `plan.md:36`
+- [ ] (suggestion) Bug-#2 framing: current SKILL.md never instructs self-marking `partial`; step 8 hardcodes `complete`. Real failure mode is abort-at-step-7-before-persist (see commit `a38b523`). Align wording with the actual mechanism. — `plan.md:23`

--- a/.agent/work-plans/issue-466/progress.md
+++ b/.agent/work-plans/issue-466/progress.md
@@ -146,6 +146,6 @@ Implemented the approved revised plan (commit 87ac99e), post-side only.
 
 ### Findings
 - [x] (must-fix) Step rename `8a.x`→`7a.x` left 4 dangling cross-refs in sibling skill — `.claude/skills/review-plan/SKILL.md:269,291,310,320` (→ 7a.1/7a.2/7a.3/7a.5)
-- [ ] (must-fix) gh-auth gate handles only no-token; read-only container `GH_TOKEN` makes `gh auth status --active` pass, then unguarded `gh issue comment` fails loudly (403) — reintroduces bad status in the #532 target env — `.claude/skills/review-issue/SKILL.md:359`
+- [x] (must-fix) gh-auth gate handles only no-token; read-only container `GH_TOKEN` makes `gh auth status --active` pass, then unguarded `gh issue comment` fails loudly (403) — reintroduces bad status in the #532 target env — `.claude/skills/review-issue/SKILL.md:359`
 - [ ] (suggestion) `description:`/Overview still flatly say "Posts findings as a comment"; posting is now best-effort — `.claude/skills/review-issue/SKILL.md:3`
 - [ ] (suggestion) Read path (step 1 `gh issue view`, 7a.1 probe) remains ungated auth dependency; "persist-first complete" guarantee only holds with a read token — `.claude/skills/review-issue/SKILL.md:26`

--- a/.agent/work-plans/issue-466/progress.md
+++ b/.agent/work-plans/issue-466/progress.md
@@ -131,3 +131,21 @@ Implemented the approved revised plan (commit 87ac99e), post-side only.
 ### Out of scope (not touched)
 - Read-side host-injected context and false-FAILED-on-redispatch (count 1→1)
   — tracked in #552.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 05:48 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-466 at `d430610`
+**Mode**: pre-push
+**Depth**: Standard (reason: governance-touching skill doc; lifecycle-procedure change)
+**Must-fix**: 2 | **Suggestions**: 2
+**Round**: 1 | **Ship**: continue — two must-fix, one a genuine correctness concern in the gh-auth gate
+
+### Findings
+- [ ] (must-fix) Step rename `8a.x`→`7a.x` left 4 dangling cross-refs in sibling skill — `.claude/skills/review-plan/SKILL.md:269,291,310,320` (→ 7a.1/7a.2/7a.3/7a.5)
+- [ ] (must-fix) gh-auth gate handles only no-token; read-only container `GH_TOKEN` makes `gh auth status --active` pass, then unguarded `gh issue comment` fails loudly (403) — reintroduces bad status in the #532 target env — `.claude/skills/review-issue/SKILL.md:359`
+- [ ] (suggestion) `description:`/Overview still flatly say "Posts findings as a comment"; posting is now best-effort — `.claude/skills/review-issue/SKILL.md:3`
+- [ ] (suggestion) Read path (step 1 `gh issue view`, 7a.1 probe) remains ungated auth dependency; "persist-first complete" guarantee only holds with a read token — `.claude/skills/review-issue/SKILL.md:26`

--- a/.agent/work-plans/issue-466/progress.md
+++ b/.agent/work-plans/issue-466/progress.md
@@ -149,3 +149,22 @@ Implemented the approved revised plan (commit 87ac99e), post-side only.
 - [x] (must-fix) gh-auth gate handles only no-token; read-only container `GH_TOKEN` makes `gh auth status --active` pass, then unguarded `gh issue comment` fails loudly (403) — reintroduces bad status in the #532 target env — `.claude/skills/review-issue/SKILL.md:359`
 - [x] (suggestion) `description:`/Overview still flatly say "Posts findings as a comment"; posting is now best-effort — `.claude/skills/review-issue/SKILL.md:3`
 - [x] (suggestion) Read path (step 1 `gh issue view`, 7a.1 probe) remains ungated auth dependency; "persist-first complete" guarantee only holds with a read token — `.claude/skills/review-issue/SKILL.md:26`
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-21 05:55 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-466 at `4ca424f`
+**Addressed**: ## Local Review (Pre-Push) (When 2026-06-21 05:48 +00:00, branch feature/issue-466 at `d430610`)
+**Commits**: 2c0fe36, c0401b4, ba48532, 4ca424f
+
+Addressed all 4 open findings (2 must-fix, 2 suggestions) from the pre-push
+review. Doc-only changes to two sibling skills; pre-commit passed on every
+commit (no `--no-verify`).
+
+### Actions
+- [x] (must-fix) Fixed 4 dangling `8a.x`→`7a.x` cross-refs in sibling skill after the review-issue step renumber — `.claude/skills/review-plan/SKILL.md:269,291,310,320` (commit 2c0fe36)
+- [x] (must-fix) gh-auth gate only handled no-token; wrapped `gh issue comment` so a read-only-token 403 is caught and the phase still completes — `.claude/skills/review-issue/SKILL.md` posting block (commit c0401b4)
+- [x] (suggestion) Reframed `description:` and Overview to state posting is best-effort, not unconditional — `.claude/skills/review-issue/SKILL.md:3,17` (commit ba48532)
+- [x] (suggestion) Documented that the read path (step 1 `gh issue view`, step 7a.1 probe) remains an auth dependency, so the persist-first `complete` guarantee holds only with a read token — `.claude/skills/review-issue/SKILL.md` Posting behavior note (commit 4ca424f)

--- a/.agent/work-plans/issue-466/progress.md
+++ b/.agent/work-plans/issue-466/progress.md
@@ -89,3 +89,45 @@ Per the consequences map:
 - [ ] (must-fix) Reorder makes persistence run first, so the GitHub comment URL is unknown when the `## Issue Review` entry is written — change #3's "When posting succeeded: `**Comment**: <URL>`" is unobtainable at write time. Specify placeholder-then-amend+recommit, or drop the on-success-URL case. — `plan.md:70`
 - [ ] (suggestion) "Swap steps 7↔8" must also fix stale internal cross-refs that assume posting precedes persistence: "After posting the comment, append…" (`SKILL.md:161`) and `**Comment**: <URL … from step 7>` (`SKILL.md:305`). — `plan.md:36`
 - [ ] (suggestion) Bug-#2 framing: current SKILL.md never instructs self-marking `partial`; step 8 hardcodes `complete`. Real failure mode is abort-at-step-7-before-persist (see commit `a38b523`). Align wording with the actual mechanism. — `plan.md:23`
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-21 05:37 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Issue**: #466 (post-side only; read-side + exit-contract gaps tracked in #552)
+
+Implemented the approved revised plan (commit 87ac99e), post-side only.
+
+### What changed
+- `.claude/skills/review-issue/SKILL.md`:
+  - Reordered steps: **step 7 = Persist to progress.md** (canonical record,
+    written + committed first); **step 8 = Post findings as a comment**
+    (best-effort, last). Renumbered sub-steps `8a`/`8b` → `7a`/`7b`.
+  - Gated the post on `gh auth status --active`: skips silently with a
+    `[review-issue]` note when auth is absent; phase status stays `complete`
+    regardless of post outcome.
+  - Dropped the inline comment-URL case from `**Comment**:` (URL unknown at
+    write time now) → `(best-effort post follows this entry; not recorded
+    inline)`. Single-write entry, no amend+recommit.
+  - Reconciled all stale cross-refs with the new order: precondition para
+    ("Steps 1 and 8", "Step 7's owning-repo probe", "step 7a.1's probe"),
+    former `:161` ("After posting…" → persist-first intro), former `:305`
+    (no inline URL).
+  - Added a "Posting behavior" note to the Overview making the best-effort
+    contract explicit (plan change #4).
+- `.agent/scripts/dispatch_subagent.sh`: verified `complete → exit 0` —
+  `complete` falls through the status `case` with no `exit` (lines ~483/494),
+  while `failed`/`partial` map to `exit 1`. No code change (and none to
+  AGENTS.md, per plan).
+
+### Verification
+- Re-grepped SKILL.md for `step N` / `8a` / `8b` / "after posting" /
+  "from step 7" references — all reconciled; step numbering coherent 1–8
+  with 7a–7b sub-steps.
+- Pre-commit passed (no `--no-verify`). Committed as `3b70c73` with agent
+  identity.
+
+### Out of scope (not touched)
+- Read-side host-injected context and false-FAILED-on-redispatch (count 1→1)
+  — tracked in #552.

--- a/.agent/work-plans/issue-466/progress.md
+++ b/.agent/work-plans/issue-466/progress.md
@@ -145,7 +145,7 @@ Implemented the approved revised plan (commit 87ac99e), post-side only.
 **Round**: 1 | **Ship**: continue — two must-fix, one a genuine correctness concern in the gh-auth gate
 
 ### Findings
-- [ ] (must-fix) Step rename `8a.x`→`7a.x` left 4 dangling cross-refs in sibling skill — `.claude/skills/review-plan/SKILL.md:269,291,310,320` (→ 7a.1/7a.2/7a.3/7a.5)
+- [x] (must-fix) Step rename `8a.x`→`7a.x` left 4 dangling cross-refs in sibling skill — `.claude/skills/review-plan/SKILL.md:269,291,310,320` (→ 7a.1/7a.2/7a.3/7a.5)
 - [ ] (must-fix) gh-auth gate handles only no-token; read-only container `GH_TOKEN` makes `gh auth status --active` pass, then unguarded `gh issue comment` fails loudly (403) — reintroduces bad status in the #532 target env — `.claude/skills/review-issue/SKILL.md:359`
 - [ ] (suggestion) `description:`/Overview still flatly say "Posts findings as a comment"; posting is now best-effort — `.claude/skills/review-issue/SKILL.md:3`
 - [ ] (suggestion) Read path (step 1 `gh issue view`, 7a.1 probe) remains ungated auth dependency; "persist-first complete" guarantee only holds with a read token — `.claude/skills/review-issue/SKILL.md:26`

--- a/.agent/work-plans/issue-466/progress.md
+++ b/.agent/work-plans/issue-466/progress.md
@@ -168,3 +168,18 @@ commit (no `--no-verify`).
 - [x] (must-fix) gh-auth gate only handled no-token; wrapped `gh issue comment` so a read-only-token 403 is caught and the phase still completes — `.claude/skills/review-issue/SKILL.md` posting block (commit c0401b4)
 - [x] (suggestion) Reframed `description:` and Overview to state posting is best-effort, not unconditional — `.claude/skills/review-issue/SKILL.md:3,17` (commit ba48532)
 - [x] (suggestion) Documented that the read path (step 1 `gh issue view`, step 7a.1 probe) remains an auth dependency, so the persist-first `complete` guarantee holds only with a read token — `.claude/skills/review-issue/SKILL.md` Posting behavior note (commit 4ca424f)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 06:09 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-466 at `fbff467`
+**Mode**: pre-push
+**Depth**: Standard (reason: governance-touching skill doc; lifecycle-procedure change)
+**Must-fix**: 0 | **Suggestions**: 1
+**Round**: 2 | **Ship**: recommended — no must-fix; all Round-1 findings addressed, only one cosmetic suggestion remains
+
+### Findings
+- [ ] (suggestion) Prose says comment is wrapped `|| { … }` but code uses `|| echo "…"`; align for internal consistency — `.claude/skills/review-issue/SKILL.md:365`

--- a/.agent/work-plans/issue-466/progress.md
+++ b/.agent/work-plans/issue-466/progress.md
@@ -147,5 +147,5 @@ Implemented the approved revised plan (commit 87ac99e), post-side only.
 ### Findings
 - [x] (must-fix) Step rename `8a.x`→`7a.x` left 4 dangling cross-refs in sibling skill — `.claude/skills/review-plan/SKILL.md:269,291,310,320` (→ 7a.1/7a.2/7a.3/7a.5)
 - [x] (must-fix) gh-auth gate handles only no-token; read-only container `GH_TOKEN` makes `gh auth status --active` pass, then unguarded `gh issue comment` fails loudly (403) — reintroduces bad status in the #532 target env — `.claude/skills/review-issue/SKILL.md:359`
-- [ ] (suggestion) `description:`/Overview still flatly say "Posts findings as a comment"; posting is now best-effort — `.claude/skills/review-issue/SKILL.md:3`
+- [x] (suggestion) `description:`/Overview still flatly say "Posts findings as a comment"; posting is now best-effort — `.claude/skills/review-issue/SKILL.md:3`
 - [ ] (suggestion) Read path (step 1 `gh issue view`, 7a.1 probe) remains ungated auth dependency; "persist-first complete" guarantee only holds with a read token — `.claude/skills/review-issue/SKILL.md:26`

--- a/.claude/skills/review-issue/SKILL.md
+++ b/.claude/skills/review-issue/SKILL.md
@@ -23,18 +23,26 @@ the issue — does not modify the issue body.
 repo? conflicting with ADRs?). For evaluating an implementation plan, use
 `plan-task`. For evaluating a completed PR, use `review-code`.
 
+**Posting behavior**: GitHub posting is best-effort. The `progress.md`
+entry (step 7) is the canonical record, written and committed first. Step 8
+posts a comment for human visibility on GitHub, but skips silently when no
+gh auth is present (e.g., container dispatch per
+[#532](https://github.com/rolker/ros2_agent_workspace/issues/532)). A skipped
+post does **not** change the phase status — the skill reports `complete` as
+long as the progress.md entry was committed.
+
 **Precondition: invoke from the owning repo's cwd.** Issue numbers are
 scoped per-repo (`rolker/ros2_agent_workspace#42` and
-`rolker/unh_marine_autonomy#42` are different issues). Steps 1 and 7
+`rolker/unh_marine_autonomy#42` are different issues). Steps 1 and 8
 (`gh issue view <N>` and `gh issue comment <N>`) resolve the repo via
 the current directory's origin — so `cd` into the repo that owns the
 issue before invoking `/review-issue <N>`. From the wrong cwd the
 skill will either fail loudly (`NotFound`) or silently query/comment
-on a colliding-number issue in the wrong repo. Step 8's
+on a colliding-number issue in the wrong repo. Step 7's
 owning-repo probe creates the right worktree for progress.md even if
-cwd is mismatched, but the comment-and-view steps will already have
-hit the wrong repo by then. If you don't know which repo owns `<N>`,
-use step 8a.1's probe pattern up front (probe workspace, then project
+cwd is mismatched, but the view step (and any best-effort comment in
+step 8) will already have hit the wrong repo by then. If you don't know
+which repo owns `<N>`, use step 7a.1's probe pattern up front (probe workspace, then project
 repos under `layers/main/*/src/*`) and `cd` to the match before
 invoking. Cwd-independent owning-repo resolution is tracked as
 [#478](https://github.com/rolker/ros2_agent_workspace/issues/478) —
@@ -107,68 +115,22 @@ Using the consequences map: if this issue changes something in the "If you
 change..." column, note the corresponding "Also update..." items. These
 should be part of the issue scope or flagged as follow-up work.
 
-### 7. Post findings as a comment
+### 7. Persist to progress.md
 
-Post the review as a comment on the issue. **Do not modify the issue body.**
-
-```markdown
-## Review
-
-### Scope Assessment
-
-**Well-scoped?** Yes/No — [explanation]
-**Right repo?** Yes/No — [explanation]
-**Dependencies**: [list or "none identified"]
-
-### Principle Alignment
-
-| Principle | Status | Notes |
-|---|---|---|
-| ... | ... | ... |
-
-### ADR Applicability
-
-| ADR | Triggered | Notes |
-|---|---|---|
-| ... | ... | ... |
-
-### Consequences
-
-- [items that should be updated as part of this work]
-
-### Recommendations
-
-- [specific suggestions, if any]
-
----
-**Authored-By**: `$AGENT_NAME`
-**Model**: `$AGENT_MODEL`
-```
-
-Use `--body-file` for the comment (not `--body`):
-
-```bash
-BODY_FILE=$(mktemp /tmp/gh_body.XXXXXX.md)
-cat << 'COMMENT_EOF' > "$BODY_FILE"
-[review content]
-COMMENT_EOF
-gh issue comment <N> --body-file "$BODY_FILE"
-rm "$BODY_FILE"
-```
-
-### 8. Persist to progress.md
-
-After posting the comment, append a `## Issue Review` entry to
+Append a `## Issue Review` entry to
 `.agent/work-plans/issue-<N>/progress.md` so the timeline reflects
 that the issue has been governance-reviewed before plan-task starts.
 Per [ADR-0013](../../../docs/decisions/0013-progress-md-entry-type-vocabulary.md).
+This is the **canonical record** — it is written and committed here,
+*before* the best-effort GitHub post (step 8), so the phase status
+never depends on whether the post succeeds.
 
-**8a. Locate-or-create the owning worktree.** `review-issue` is
+**7a. Locate-or-create the owning worktree.** `review-issue` is
 typically the *first* skill in the lifecycle, so a worktree may not
 exist yet. Since progress.md commits cannot land on a protected
 default branch, this step creates a worktree on demand:
 
-**8a.1.** **Resolve the owning repo first.** Issue numbers can collide
+**7a.1.** **Resolve the owning repo first.** Issue numbers can collide
 across the workspace repo and project repos (e.g., workspace `#42` is
 a different issue from `unh_echoboats_project11#42`), so the issue
 number alone is not enough to identify a worktree.
@@ -190,11 +152,11 @@ value we're trying to determine). Probe in order:
 This mirrors `plan-task` step 4's cwd-based `gh issue view <N>`
 pattern.
 
-**8a.2.** Check `$WORKTREE_ISSUE` and the worktree's repo slug. If
+**7a.2.** Check `$WORKTREE_ISSUE` and the worktree's repo slug. If
 `$WORKTREE_ISSUE` matches `<N>` *and* the worktree's repo slug
 matches the owning repo's short slug, you're already in the right
-worktree — skip to step 8b. If only the number matches, treat it as a
-miss and continue to step 8a.3 (you're in the wrong-repo worktree for
+worktree — skip to step 7b. If only the number matches, treat it as a
+miss and continue to step 7a.3 (you're in the wrong-repo worktree for
 a colliding number).
 
 `worktree_enter.sh` exports `$WORKTREE_ROOT`, `$WORKTREE_TYPE`, and
@@ -202,7 +164,7 @@ a colliding number).
 `$WORKTREE_ROOT`'s basename:
 ```bash
 if [ -z "${WORKTREE_ROOT:-}" ]; then
-    # Not in a worktree (or worktree_enter.sh never ran) — fall through to 8a.3
+    # Not in a worktree (or worktree_enter.sh never ran) — fall through to 7a.3
     WORKTREE_SLUG=""
 else
     WT_BASENAME=$(basename "$WORKTREE_ROOT")
@@ -214,16 +176,16 @@ else
 fi
 ```
 
-Compare `$WORKTREE_SLUG` against the owning repo. Step 8a.1 returned
+Compare `$WORKTREE_SLUG` against the owning repo. Step 7a.1 returned
 `owner/repo` form; the slug-relevant comparison depends on type:
-- **Workspace issue** — the `owner/repo` from step 8a.1 matches the
+- **Workspace issue** — the `owner/repo` from step 7a.1 matches the
   workspace repo's `nameWithOwner` (e.g., `rolker/ros2_agent_workspace`).
   Match iff `WORKTREE_SLUG == "workspace"`.
-- **Project-repo issue** — the `owner/repo` from step 8a.1 matches a
+- **Project-repo issue** — the `owner/repo` from step 7a.1 matches a
   project repo (e.g., `rolker/unh_marine_autonomy`). Match iff
   `WORKTREE_SLUG` equals the repo-name portion (`unh_marine_autonomy`).
 
-**8a.3.** If not, check whether a worktree for the issue already
+**7a.3.** If not, check whether a worktree for the issue already
 exists. Use an anchored, repo-aware pattern so neighbouring issue
 numbers (e.g. `4700` for `<N>=470`) and unrelated repo worktrees don't
 match:
@@ -239,7 +201,7 @@ Or grep `worktree_list.sh` output with a numeric boundary:
   | grep -E "issue-(workspace|<repo-slug>)-<N>($|[^0-9])"
 ```
 
-**8a.4.** If a worktree exists, source it to enter:
+**7a.4.** If a worktree exists, source it to enter:
 ```bash
 source .agent/scripts/worktree_enter.sh --issue <N> [--repo-slug <slug>]
 ```
@@ -247,17 +209,17 @@ source .agent/scripts/worktree_enter.sh --issue <N> [--repo-slug <slug>]
 issue number collides across repos, pass `--repo-slug <slug>` to
 disambiguate (see `WORKTREE_GUIDE.md`).
 
-**8a.5.** If neither: determine worktree type from the owning repo
+**7a.5.** If neither: determine worktree type from the owning repo
 (workspace for issues in the workspace repo, layer for project-repo
 issues — same logic as `plan-task` step 4). Create the worktree:
 
-- **Workspace issue** (`owner/repo` from step 8a.1 matches the
+- **Workspace issue** (`owner/repo` from step 7a.1 matches the
   workspace repo's `nameWithOwner`):
   ```bash
   .agent/scripts/worktree_create.sh --issue <N> --type workspace
   ```
 - **Project-repo issue**: derive `<layer>` and `<project_repo>` from
-  the local path the step 8a.1 probe matched (under
+  the local path the step 7a.1 probe matched (under
   `layers/main/<layer>_ws/src/<project_repo>/`). Parse `<layer>` as
   the directory name before `_ws/src/` and `<project_repo>` as the
   leaf directory. This mirrors `plan-task` step 4 and `review-plan`
@@ -274,7 +236,7 @@ commits the plan to the branch but, by default, does **not** open a PR
 `--draft-pr` (or the worktree was created with `--plan-file`); otherwise
 the `/run-issue` orchestrator opens the real PR at the end.
 
-**8b. Append the entry.** Create the parent directory if needed
+**7b. Append the entry.** Create the parent directory if needed
 (`review-issue` typically runs *before* `plan-task`, so
 `.agent/work-plans/issue-<N>/` may not exist yet):
 
@@ -302,7 +264,7 @@ Append:
 **By**: <agent name> (<model>)
 
 **Issue**: #<N>
-**Comment**: <URL of the posted issue comment from step 7>
+**Comment**: (best-effort post follows this entry; not recorded inline)
 **Scope verdict**: <well-scoped | needs-splitting | needs-more-detail>
 
 ### Actions
@@ -340,6 +302,67 @@ The branch (`feature/issue-<N>`) now exists with one commit. If the
 user decides not to proceed (and so plan-task never runs), they can
 remove the worktree + branch via
 `.agent/scripts/worktree_remove.sh --issue <N>`.
+
+### 8. Post findings as a comment (best-effort)
+
+With the canonical record committed (step 7), post the review as a
+comment on the issue for human visibility. **Do not modify the issue
+body.** This step is **best-effort**: it skips silently when no gh auth
+is present (e.g., container dispatch per
+[#532](https://github.com/rolker/ros2_agent_workspace/issues/532)), and a
+skipped or failed post does **not** change the phase status — it stays
+`complete` as long as step 7 committed the entry.
+
+```markdown
+## Review
+
+### Scope Assessment
+
+**Well-scoped?** Yes/No — [explanation]
+**Right repo?** Yes/No — [explanation]
+**Dependencies**: [list or "none identified"]
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| ... | ... | ... |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| ... | ... | ... |
+
+### Consequences
+
+- [items that should be updated as part of this work]
+
+### Recommendations
+
+- [specific suggestions, if any]
+
+---
+**Authored-By**: `$AGENT_NAME`
+**Model**: `$AGENT_MODEL`
+```
+
+Use `--body-file` for the comment (not `--body`), and gate the post on
+gh auth so it skips cleanly when none is present:
+
+```bash
+BODY_FILE=$(mktemp /tmp/gh_body.XXXXXX.md)
+cat << 'COMMENT_EOF' > "$BODY_FILE"
+[review content]
+COMMENT_EOF
+# Best-effort only — skip silently if gh auth is absent
+if gh auth status --active 2>/dev/null; then
+    gh issue comment <N> --body-file "$BODY_FILE"
+else
+    echo "[review-issue] No GitHub auth — skipping comment post (progress.md is the record)."
+fi
+rm "$BODY_FILE"
+```
 
 ### Next step
 

--- a/.claude/skills/review-issue/SKILL.md
+++ b/.claude/skills/review-issue/SKILL.md
@@ -362,7 +362,7 @@ gate it on gh auth so it skips cleanly when none is present, **and** treat a
 failed post itself as non-fatal. The auth gate is necessary but not
 sufficient — a read-only token (e.g. the container's `GH_TOKEN`) makes
 `gh auth status --active` pass, yet `gh issue comment` then fails with a 403.
-Because the comment is wrapped (`|| { … }`) the phase still completes; the
+Because the comment is wrapped (`|| echo …`) the phase still completes; the
 progress.md entry written in step 7 is the record regardless of post outcome.
 
 ```bash

--- a/.claude/skills/review-issue/SKILL.md
+++ b/.claude/skills/review-issue/SKILL.md
@@ -347,17 +347,26 @@ skipped or failed post does **not** change the phase status — it stays
 **Model**: `$AGENT_MODEL`
 ```
 
-Use `--body-file` for the comment (not `--body`), and gate the post on
-gh auth so it skips cleanly when none is present:
+Use `--body-file` for the comment (not `--body`). The post is best-effort:
+gate it on gh auth so it skips cleanly when none is present, **and** treat a
+failed post itself as non-fatal. The auth gate is necessary but not
+sufficient — a read-only token (e.g. the container's `GH_TOKEN`) makes
+`gh auth status --active` pass, yet `gh issue comment` then fails with a 403.
+Because the comment is wrapped (`|| { … }`) the phase still completes; the
+progress.md entry written in step 7 is the record regardless of post outcome.
 
 ```bash
 BODY_FILE=$(mktemp /tmp/gh_body.XXXXXX.md)
 cat << 'COMMENT_EOF' > "$BODY_FILE"
 [review content]
 COMMENT_EOF
-# Best-effort only — skip silently if gh auth is absent
+# Best-effort only — never fail the phase on a post problem.
+# Two distinct failure modes, both tolerated:
+#   1. no auth at all          → gh auth status --active fails → skip
+#   2. read-only/insufficient  → auth passes but `gh issue comment` 403s → catch
 if gh auth status --active 2>/dev/null; then
-    gh issue comment <N> --body-file "$BODY_FILE"
+    gh issue comment <N> --body-file "$BODY_FILE" \
+        || echo "[review-issue] Comment post failed (e.g. read-only token / 403) — continuing; progress.md is the record."
 else
     echo "[review-issue] No GitHub auth — skipping comment post (progress.md is the record)."
 fi

--- a/.claude/skills/review-issue/SKILL.md
+++ b/.claude/skills/review-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-issue
-description: Evaluate a GitHub issue against workspace principles and ADRs before work begins. Posts findings as a comment on the issue.
+description: Evaluate a GitHub issue against workspace principles and ADRs before work begins. Records findings in progress.md and best-effort posts them as a comment on the issue.
 ---
 
 # Review Issue
@@ -14,8 +14,9 @@ description: Evaluate a GitHub issue against workspace principles and ADRs befor
 ## Overview
 
 Evaluate an issue before work begins. Checks scope, principle alignment, ADR
-relevance, repo placement, and dependencies. Posts findings as a comment on
-the issue — does not modify the issue body.
+relevance, repo placement, and dependencies. Records findings in progress.md
+(the canonical record) and best-effort posts them as a comment on the issue —
+does not modify the issue body. See **Posting behavior** below.
 
 **Lifecycle position**: **review-issue** → plan-task → review-plan → implement → review-code
 

--- a/.claude/skills/review-issue/SKILL.md
+++ b/.claude/skills/review-issue/SKILL.md
@@ -32,6 +32,15 @@ gh auth is present (e.g., container dispatch per
 post does **not** change the phase status — the skill reports `complete` as
 long as the progress.md entry was committed.
 
+The best-effort guarantee covers the *write* path only. The **read** path
+remains an auth dependency: step 1's `gh issue view <N>` (and the step 7a.1
+owning-repo probe) need at least a read token to fetch the issue body the
+review is built from. With no read auth those calls fail before any
+progress.md entry can be written, so the "persist-first ⇒ always `complete`"
+guarantee holds only when a read token is present. A read-only token (the
+common container case) satisfies the read path while still tripping the
+write-path 403 the post handles above.
+
 **Precondition: invoke from the owning repo's cwd.** Issue numbers are
 scoped per-repo (`rolker/ros2_agent_workspace#42` and
 `rolker/unh_marine_autonomy#42` are different issues). Steps 1 and 8

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -266,7 +266,7 @@ appending, resolve the right place to write:
      — already in hand, no extra lookup needed.
    - **`--issue` or file-path mode**: no PR metadata available. Don't
      pass `--repo <owner/repo>` — that's the value we're resolving.
-     Probe in order (matches `review-issue` step 8a.1):
+     Probe in order (matches `review-issue` step 7a.1):
 
      1. **Workspace root first** — from the workspace root,
         `gh issue view <N> --json repository --jq '.repository.nameWithOwner'`
@@ -288,7 +288,7 @@ appending, resolve the right place to write:
    `worktree_enter.sh` exports `$WORKTREE_ROOT`, `$WORKTREE_TYPE`,
    and `$WORKTREE_ISSUE` — but not the repo slug. Derive it from
    `$WORKTREE_ROOT`'s basename (same pattern as `review-issue` step
-   8a.2):
+   7a.2):
    ```bash
    if [ -z "${WORKTREE_ROOT:-}" ]; then
        # Not in a worktree — fall through to sub-step 3 (find or create)
@@ -307,7 +307,7 @@ appending, resolve the right place to write:
    iff `WORKTREE_SLUG == "workspace"`; project-repo issue matches iff
    `WORKTREE_SLUG` equals the repo-name portion of `owner/repo`.
 3. **Find an existing worktree** with an anchored, repo-aware match —
-   same pattern as `review-issue` step 8a.3:
+   same pattern as `review-issue` step 7a.3:
    ```bash
    .agent/scripts/worktree_list.sh \
      | grep -E "issue-(workspace|<repo-slug>)-<N>($|[^0-9])"
@@ -317,7 +317,7 @@ appending, resolve the right place to write:
    repos, pass `--repo-slug <slug>` if entering via
    `worktree_enter.sh`.
 4. **Otherwise create one on demand**, mirroring `review-issue` step
-   8a.5:
+   7a.5:
    - **Workspace issues**: `.agent/scripts/worktree_create.sh --issue <N> --type workspace`.
    - **Project-repo issues**: derive `<layer>` and `<project_repo>`
      from the project repo's path. Step 1 returned the owning


### PR DESCRIPTION
Closes #466.

## What this does (post-side scope)

The persistence half of #466 was already shipped (both `review-issue` and `review-plan` write typed `progress.md` entries). This PR fixes the **posting behavior** so a container-dispatched `review-issue` — which has no GitHub write auth by design (#532) — reports `complete` instead of failing.

**Root cause was ordering:** `review-issue/SKILL.md` posted the GitHub comment *before* persisting + committing the `## Issue Review` entry. With no gh auth the agent aborted at the posting step before ever persisting, recording a `failed`/`partial` status (which `dispatch_subagent.sh` maps to a non-zero exit) — so a fully-successful review paged the host as FAILED.

## Changes (all in skill docs)

- **Reorder**: persist + commit `progress.md` **first** (now step 7), post the comment **last** (step 8, best-effort). The committed entry is the canonical record; the post can be skipped without changing lifecycle state.
- **Failure-tolerant post**: the post is gated on `gh auth status` *and* wrapped so a failed post (e.g. a read-only token that passes auth-status but 403s on `gh issue comment`) is non-fatal — `… || echo "continuing; progress.md is the record"`.
- **Drop the inline-URL `**Comment**:` case** — the comment URL isn't known when the entry is written first; the entry is single-write (no amend+recommit, which would also trip the #552 replace-vs-append edge).
- **Reconcile cross-refs**: fixed stale `step 7/8` ordering references in `review-issue/SKILL.md` and 4 dangling `8a→7a` cross-refs in the sibling `review-plan/SKILL.md`.
- **Document** the best-effort contract in the Overview/`description`.

`dispatch_subagent.sh` is unchanged — it already maps `complete → exit 0`; the fix is entirely skill-side.

## Out of scope (tracked in #552)

The **read-side** gap (container can't `gh issue view` without auth → host should inject issue/PR context) and the **exit-contract false-FAILED on entry replace** (re-dispatch overwriting a typed entry → count 1→1) are dispatcher-contract concerns split to #552.

## Provenance

Driven via `/run-issue`, all phases container-dispatched: review-issue (had to inject the body by hand — the #552 read-side gap) → plan-task → review-plan (caught the comment-URL-unobtainable-after-reorder must-fix) → plan revised → implement (Opus) → review-code R1 (changes-requested: sibling-skill cross-refs + read-only-token 403) → address-findings → review-code R2 (approved).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
