### PR TITLE
fix(merge_pr): resolve src/ project repo, not colcon install/build artifacts (#514)

### DIFF
--- a/.agent/scripts/merge_pr.sh
+++ b/.agent/scripts/merge_pr.sh
@@ -148,10 +148,24 @@ if [[ -n "$ARG_PR" ]]; then
         REPO_PATH="$ROOT_DIR"
         REPO_SLUG=""
     else
-        REPO_PATH=$(find "$ROOT_DIR/layers/main" -maxdepth 3 -type d -name "$ARG_REPO_SLUG" -print -quit 2>/dev/null || true)
+        # Anchor on '*_ws/src/*' so a `colcon build` artifact at
+        # <layer>_ws/install/<pkg> or <layer>_ws/build/<pkg> (same depth+name as
+        # the source) can't be picked before the real source repo (issue #514).
+        # Anchored on the layer-workspace structure (not a bare '*/src/*'): a
+        # workspace checked out under a path containing a /src/ segment would
+        # still match install/build dirs with the bare form.
+        REPO_PATH=$(find "$ROOT_DIR/layers/main" -maxdepth 3 -type d -path '*_ws/src/*' -name "$ARG_REPO_SLUG" -print -quit 2>/dev/null || true)
         if [[ -z "$REPO_PATH" ]]; then
             echo "ERROR: --repo-slug '$ARG_REPO_SLUG' not found under layers/main." >&2
             echo "  Check the spelling, or pass --repo-slug workspace for the workspace repo." >&2
+            exit 1
+        fi
+        # Belt-and-suspenders: the candidate must be a git repo root, not a stray
+        # dir that slipped past the path filter. Only error on found-but-not-a-
+        # git-root — an empty find already exited above.
+        if [[ "$(git -C "$REPO_PATH" rev-parse --show-toplevel 2>/dev/null)" != "$REPO_PATH" ]]; then
+            echo "ERROR: --repo-slug '$ARG_REPO_SLUG' resolved to '$REPO_PATH', which is not a git repo root." >&2
+            echo "  Expected a project repo under layers/main/<layer>_ws/src/." >&2
             exit 1
         fi
         REPO_SLUG="$ARG_REPO_SLUG"
@@ -218,7 +232,17 @@ fi
 if [[ -z "$REPO_SLUG" ]]; then
     BRANCH_REPO="$ROOT_DIR"
 else
-    BRANCH_REPO=$(find "$ROOT_DIR/layers/main" -maxdepth 3 -type d -name "$REPO_SLUG" -print -quit 2>/dev/null || true)
+    # Anchor on '*_ws/src/*' for the same reason as the --pr derivation above:
+    # exclude colcon install/build artifacts that share the source's depth+name
+    # (issue #514).
+    BRANCH_REPO=$(find "$ROOT_DIR/layers/main" -maxdepth 3 -type d -path '*_ws/src/*' -name "$REPO_SLUG" -print -quit 2>/dev/null || true)
+    # An EMPTY result is a legitimate signal — fall through to the REPO_PATH
+    # fallback below. Only error when a non-empty candidate isn't a git repo root.
+    if [[ -n "$BRANCH_REPO" && "$(git -C "$BRANCH_REPO" rev-parse --show-toplevel 2>/dev/null)" != "$BRANCH_REPO" ]]; then
+        echo "ERROR: repo-slug '$REPO_SLUG' resolved to '$BRANCH_REPO', which is not a git repo root." >&2
+        echo "  Expected a project repo under layers/main/<layer>_ws/src/." >&2
+        exit 1
+    fi
     [[ -z "$BRANCH_REPO" ]] && BRANCH_REPO="$REPO_PATH"
 fi
 

--- a/.agent/scripts/tests/test_merge_pr.sh
+++ b/.agent/scripts/tests/test_merge_pr.sh
@@ -134,6 +134,34 @@ out=$(cd "$fieldwt" && PATH="$ghstub:$PATH" "$MERGE_PR" 2>&1); rc=$?
     && ok "field-mode refused before any gh call" || bad "field-mode guard (rc=$rc, out: $(head -1 <<<"$out"))"
 rm -rf "$fieldwt" "$ghstub"
 
+# A `colcon build` creates artifact dirs at <layer>_ws/install/<pkg> and
+# <layer>_ws/build/<pkg> with the SAME depth+name as the source repo at
+# <layer>_ws/src/<pkg>. The slug `find` must resolve the source under src/, not
+# an artifact (issue #514). Contrast test (no reliance on filesystem ordering):
+# make install/testpkg a *github*-origin repo and src/testpkg a *gitcloud*
+# (field-mode) repo, then assert the field-mode guard FIRES — which can only
+# happen if src/testpkg was resolved. A regression to install/testpkg (github
+# origin) would proceed PAST the field-mode guard, a distinguishable outcome.
+echo "Test: --repo-slug resolves src/ project repo, not colcon install/ artifact (#514)"
+artwt="$ROOT_DIR/layers/main/testlayer_ws"
+mkdir -p "$artwt/build/testpkg"
+git -C "$ROOT_DIR" init -q "$artwt/install/testpkg"
+git -C "$artwt/install/testpkg" remote add origin "git@github.com:test/testpkg.git"
+git -C "$ROOT_DIR" init -q "$artwt/src/testpkg"
+git -C "$artwt/src/testpkg" remote add origin "git@gitcloud:field/testpkg.git"
+ghstub514=$(mktemp -d)
+cat >"$ghstub514/gh" <<'STUB'
+#!/bin/bash
+echo "GH_WAS_CALLED" >&2
+exit 99
+STUB
+chmod +x "$ghstub514/gh"
+out=$(cd "$ROOT_DIR" && PATH="$ghstub514:$PATH" "$MERGE_PR" --pr 1 --repo-slug testpkg 2>&1); rc=$?
+{ [[ $rc -ne 0 ]] && grep -qF "is a field-mode repo" <<<"$out" && ! grep -qF "GH_WAS_CALLED" <<<"$out"; } \
+    && ok "src/ repo resolved (field-mode guard fired), not install/ artifact" \
+    || bad "src/ vs install/ resolution (#514) (rc=$rc, out: $(head -1 <<<"$out"))"
+rm -rf "$artwt" "$ghstub514"
+
 echo "Test: --issue and --pr together → mutually-exclusive usage error (exit 2)"
 out=$("$MERGE_PR" --issue 5 --pr 5 --repo-slug workspace 2>&1); rc=$?
 { [[ $rc -eq 2 ]] && grep -qF "mutually exclusive" <<<"$out"; } \

--- a/.agent/work-plans/issue-514/plan.md
+++ b/.agent/work-plans/issue-514/plan.md
@@ -1,0 +1,85 @@
+# Plan: merge_pr.sh resolves install/ or build/ artifacts instead of src/ project repo
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/514
+
+## Context
+
+`merge_pr.sh` uses `find ... -maxdepth 3 -type d -name "$slug"` in two places
+to locate a project repo under `layers/main/`. After a `colcon build`, colcon
+creates artifact directories at `<layer>_ws/install/<pkg>` and
+`<layer>_ws/build/<pkg>` — same depth and name as the source at
+`<layer>_ws/src/<pkg>`. Since `-quit` returns the first match, colcon artifacts
+are found before the source repo (filesystem order, install/ typically first).
+
+This causes `git remote get-url origin` to walk up to the workspace root,
+resolving `GH_REPO` to the workspace repo instead of the package's own repo,
+and the subsequent `gh pr view` call fails with "no PR found."
+
+Both find invocations are affected:
+- **Line 151** (`--pr` escape hatch): `REPO_PATH` derivation
+- **Line 221** (`BRANCH_REPO` derivation): used by all resolution modes when
+  `REPO_SLUG` is non-empty
+
+## Approach
+
+1. **Scope both `find` calls to `*/src/*`** — colcon artifacts always live
+   under `*/install/*` or `*/build/*`, never under `*/src/*`. Adding
+   `-path '*/src/*'` to both find calls excludes artifacts entirely.
+
+2. **Add git-repo verification after each `find` (belt-and-suspenders)** —
+   after finding a candidate path, verify it is a git repo root via
+   `git -C "$path" rev-parse --show-toplevel 2>/dev/null`. If the result
+   does not equal `$path`, emit a clear error (not a silent wrong-path
+   fallback). This defends against future layout changes that `-path`
+   alone can't catch.
+
+3. **Add a regression test to `test_merge_pr.sh`** — fabricate a fake
+   `layers/main/testlayer_ws/{install,build,src}/testpkg` structure where
+   `src/testpkg` is a git repo with a gitcloud (field-mode) origin. Invoke
+   `merge_pr.sh --pr 1 --repo-slug testpkg` and assert the field-mode guard
+   fires (proving `src/testpkg` was resolved), not any other error
+   (which would indicate `install/testpkg` or `build/testpkg` was found first).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/merge_pr.sh` | Add `-path '*/src/*'` to the two `find` calls on lines 151 and 221; add git-repo verification after each |
+| `.agent/scripts/tests/test_merge_pr.sh` | Add regression test: fake artifact dirs + src git repo, assert field-mode guard fires (src resolved) |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | Regression test ships in same PR; AGENTS.md script reference table needs no update (interface unchanged) |
+| Test what breaks | Test exercises the exact failure mode from the issue (artifact dir found before src/) |
+| Human control and transparency | Fix makes script behave as documented; error messages remain clear |
+| Enforcement over documentation | Fix is code-level (path filter + git verify), not a warning comment |
+| Only what's needed | Two targeted find changes + one test; no refactor beyond the bug |
+| Improve incrementally | Single focused PR; no scope creep |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0007 (Retain Make with dependency tracking) | No | `make merge-pr` delegates to `merge_pr.sh`; Makefile target interface unchanged |
+| ADR-0001 (Adopt ADRs) | No | Bug fix, not a new design decision; no ADR needed |
+| ADR-0013 (progress.md vocabulary) | Yes | Plan Authored entry written to `progress.md` per spec |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Both `find` calls in `merge_pr.sh` | Regression test in `test_merge_pr.sh` | Yes |
+| `merge_pr.sh` behavior | AGENTS.md script reference table | No — interface unchanged, no update needed |
+| `merge_pr.sh` behavior | `.agent/WORKTREE_GUIDE.md` | No — script behavior fix, not workflow change |
+
+## Open Questions
+
+- [ ] No open questions — plan is review-plan-ready.
+
+## Estimated Scope
+
+Single PR — two targeted `find` fixes + one regression test in an existing test file.

--- a/.agent/work-plans/issue-514/plan.md
+++ b/.agent/work-plans/issue-514/plan.md
@@ -24,30 +24,40 @@ Both find invocations are affected:
 
 ## Approach
 
-1. **Scope both `find` calls to `*/src/*`** — colcon artifacts always live
-   under `*/install/*` or `*/build/*`, never under `*/src/*`. Adding
-   `-path '*/src/*'` to both find calls excludes artifacts entirely.
+1. **Scope both `find` calls to the layer-workspace `src/` with an *anchored*
+   path: `-path '*_ws/src/*'`** — colcon artifacts live under
+   `<layer>_ws/install/*` / `<layer>_ws/build/*`, the source under
+   `<layer>_ws/src/*`. **Not** a bare `-path '*/src/*'`: if the whole workspace
+   is checked out under a path that itself contains a `/src/` segment (e.g.
+   `~/src/project11/…`), then `…/install/<pkg>` *also* matches `*/src/*` and the
+   artifact dir is not excluded (review-plan finding). Anchoring on `_ws/src/`
+   keys on the layer-workspace structure, which the artifact paths never share.
 
 2. **Add git-repo verification after each `find` (belt-and-suspenders)** —
    after finding a candidate path, verify it is a git repo root via
-   `git -C "$path" rev-parse --show-toplevel 2>/dev/null`. If the result
-   does not equal `$path`, emit a clear error (not a silent wrong-path
-   fallback). This defends against future layout changes that `-path`
-   alone can't catch.
+   `git -C "$path" rev-parse --show-toplevel 2>/dev/null`. **Scope the new error
+   to the *found-but-not-a-git-root* case only** — an empty `find` result is a
+   legitimate signal that must keep flowing to the existing `REPO_PATH` fallback
+   at `merge_pr.sh:222` (do not convert an empty result into a hard error, or the
+   escape-hatch path regresses). Emit the clear error only when a non-empty
+   candidate fails the git-root check.
 
 3. **Add a regression test to `test_merge_pr.sh`** — fabricate a fake
-   `layers/main/testlayer_ws/{install,build,src}/testpkg` structure where
-   `src/testpkg` is a git repo with a gitcloud (field-mode) origin. Invoke
-   `merge_pr.sh --pr 1 --repo-slug testpkg` and assert the field-mode guard
-   fires (proving `src/testpkg` was resolved), not any other error
-   (which would indicate `install/testpkg` or `build/testpkg` was found first).
+   `layers/main/testlayer_ws/{install,build,src}/testpkg` structure. Make
+   **`install/testpkg` a *github*-origin git repo** and **`src/testpkg` a
+   *gitcloud* (field-mode) git repo**, so buggy vs fixed resolution produces a
+   **positive/positive contrast** rather than relying on filesystem ordering or
+   an error: invoke `merge_pr.sh --pr 1 --repo-slug testpkg` and assert the
+   **field-mode guard fires** (proving `src/testpkg` was resolved). If resolution
+   regressed to `install/testpkg`, the github-origin path would instead proceed
+   past the field-mode guard — a clearly distinguishable outcome.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `.agent/scripts/merge_pr.sh` | Add `-path '*/src/*'` to the two `find` calls on lines 151 and 221; add git-repo verification after each |
-| `.agent/scripts/tests/test_merge_pr.sh` | Add regression test: fake artifact dirs + src git repo, assert field-mode guard fires (src resolved) |
+| `.agent/scripts/merge_pr.sh` | Add anchored `-path '*_ws/src/*'` to the two `find` calls (L151, L221); add git-repo verification scoped to the found-but-not-git-root case (preserve the empty→`REPO_PATH` fallback at L222) |
+| `.agent/scripts/tests/test_merge_pr.sh` | Add regression test: github-origin `install/testpkg` + gitcloud-origin `src/testpkg`, assert the field-mode guard fires (positive/positive contrast, no filesystem-order reliance) |
 
 ## Principles Self-Check
 
@@ -78,7 +88,9 @@ Both find invocations are affected:
 
 ## Open Questions
 
-- [ ] No open questions — plan is review-plan-ready.
+- [x] None. Review-plan's 3 suggestions folded in: anchored `*_ws/src/*` (not
+  bare `*/src/*`); git-verify error scoped to found-but-not-git-root (empty
+  fallback preserved); contrast-based test (github `install/` vs gitcloud `src/`).
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-514/progress.md
+++ b/.agent/work-plans/issue-514/progress.md
@@ -57,3 +57,15 @@ Fits in a single PR. The issue lives in the workspace repo (infra script).
 - [ ] Scope both `find` calls in `merge_pr.sh` to `*/src/*` and/or verify result is a git repo root.
 - [ ] Include a regression test: build a layer package, then assert `merge_pr.sh` resolves `src/<pkg>` (not `install/<pkg>`).
 - [ ] Verify the `--pr <N> --repo-slug <slug>` escape-hatch `REPO_PATH` derivation also uses the scoped `find`.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-21 10:30 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-514/plan.md` at `5f4a41c`
+**Branch**: feature/issue-514 at `5f4a41c`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-514/progress.md
+++ b/.agent/work-plans/issue-514/progress.md
@@ -69,3 +69,17 @@ Fits in a single PR. The issue lives in the workspace repo (infra script).
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-21 14:57 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-514/plan.md` at `5f4a41c`
+**PR**: PR-less (container dispatch, no GitHub auth)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) `-path '*/src/*'` is defeated by a checkout path containing a `/src/` segment (e.g. `~/src/...`) — the install/ artifact path then still matches; degrades to a false hard error via git-verify, not a wrong merge. Use anchored `-path '*_ws/src/*'`. — `plan.md:28`
+- [ ] (suggestion) Scope the new git-verify error to found-but-not-git-root; preserve the legit empty→`REPO_PATH` fallback at `merge_pr.sh:222`. — `plan.md:32`
+- [ ] (suggestion) Stronger test discriminator: make `install/testpkg` a github-origin git repo so buggy vs fixed resolution gives a positive/positive contrast (no reliance on filesystem ordering). — `plan.md:39`

--- a/.agent/work-plans/issue-514/progress.md
+++ b/.agent/work-plans/issue-514/progress.md
@@ -1,0 +1,59 @@
+---
+issue: 514
+---
+
+# Issue #514 — merge_pr.sh resolves install/ or build/ artifacts instead of src/ project repo
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-21 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #514
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Scope Assessment
+
+The issue identifies a concrete, reproducible bug in `.agent/scripts/merge_pr.sh`:
+two `find` calls use `-maxdepth 3 -type d -name "$slug"` without path-scoping,
+so a built layer package's `install/<pkg>` or `build/<pkg>` artifact directory
+is found before `src/<pkg>`. The fix is narrow (two locations in one script),
+the root cause is clear, and the suggested approaches are ready to implement.
+Fits in a single PR. The issue lives in the workspace repo (infra script).
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| A change includes its consequences | Action needed | Issue requests a regression test (build a layer pkg, assert `merge_pr.sh` resolves `src/<pkg>`). Test must ship in the same PR. |
+| Test what breaks | Action needed | No test currently guards this `find` scoping. The regression test described in the issue is concrete and achievable. |
+| Human control and transparency | OK | Fix makes script behave as documented; no hidden side effects. |
+| Enforcement over documentation | OK | The fix is a code-level guard, not just a warning comment. |
+| Only what's needed | OK | Belt-and-suspenders option (path scope + `git rev-parse` verify) is appropriate given the bug severity; not over-engineering. |
+| Improve incrementally | OK | Single focused bug fix; no scope creep. |
+| Workspace vs. project separation | OK | Change is in workspace infra script, correct home. |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| ADR-0007 (Retain Make with dependency tracking) | Watch | `make merge-pr` delegates to `merge_pr.sh`; fix is in the underlying script, Makefile target unchanged. No ADR action needed. |
+| ADR-0001 (Adopt ADRs) | OK | Bug fix doesn't introduce a new design decision requiring an ADR. |
+
+### Consequences
+
+- **AGENTS.md script reference table**: `merge_pr.sh` is listed; behavior fix doesn't change the interface, no update needed.
+- **Regression test**: the issue explicitly calls for one — this must be included in the PR, not left as follow-up.
+- No `.agent/WORKTREE_GUIDE.md` update needed (script behavior fix, not workflow change).
+
+### Recommendations
+
+- Use the belt-and-suspenders approach: scope `find` to `*/src/*` (option 1) AND verify the result is a git repo root via `git -C <dir> rev-parse --show-toplevel` (option 2). Both are cheap; either alone is fragile if the layout changes.
+- Consider also checking `--pr <N> --repo-slug <slug>` escape-hatch path — the issue notes it hits the same `find` for `REPO_PATH`.
+- Regression test: create a minimal fixture (or use an existing built layer) to assert the resolved path ends in `src/<pkg>`, not `install/<pkg>` or `build/<pkg>`.
+
+### Actions
+- [ ] Scope both `find` calls in `merge_pr.sh` to `*/src/*` and/or verify result is a git repo root.
+- [ ] Include a regression test: build a layer package, then assert `merge_pr.sh` resolves `src/<pkg>` (not `install/<pkg>`).
+- [ ] Verify the `--pr <N> --repo-slug <slug>` escape-hatch `REPO_PATH` derivation also uses the scoped `find`.

--- a/.agent/work-plans/issue-514/progress.md
+++ b/.agent/work-plans/issue-514/progress.md
@@ -128,3 +128,25 @@ Fits in a single PR. The issue lives in the workspace repo (infra script).
 - [x] Scope both `find` calls (anchored `*_ws/src/*`) + git-repo-root verify.
 - [x] Regression test (github `install/` vs gitcloud `src/`, field-mode-guard assertion).
 - [x] `--pr` escape-hatch `REPO_PATH` derivation uses the scoped `find`.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 15:28 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-514 at `f30034d`
+**Mode**: pre-push
+**Depth**: Deep (reason: destructive tool that shells out with user input; 283-line diff)
+**Must-fix**: 0 | **Suggestions**: 0
+**Round**: 1 | **Ship**: recommended — fix correct, empirically verified in main tree, 16/16 tests pass, no Must-fix.
+
+### Findings
+- [ ] No issues found. LGTM. Both adversarial passes (Lens A logic, Lens B
+  systemic/safety) independently confirmed the anchored `-path '*_ws/src/*'`
+  excludes colcon artifacts and the git-root verify fails closed before any
+  merge/delete. Verified end-to-end in the real main tree: `find` resolves
+  `site_ws/src/ccomjhc_project11` and `git rev-parse --show-toplevel` matches.
+  Lens A's theoretical symlink/realpath mismatch does not apply (`$ROOT_DIR/layers/main`
+  is a real dir; were it symlinked, the failure mode is fail-closed, not a wrong merge).
+  No plan drift; consequences addressed (regression test ships in same commit).

--- a/.agent/work-plans/issue-514/progress.md
+++ b/.agent/work-plans/issue-514/progress.md
@@ -83,3 +83,48 @@ Fits in a single PR. The issue lives in the workspace repo (infra script).
 - [ ] (suggestion) `-path '*/src/*'` is defeated by a checkout path containing a `/src/` segment (e.g. `~/src/...`) — the install/ artifact path then still matches; degrades to a false hard error via git-verify, not a wrong merge. Use anchored `-path '*_ws/src/*'`. — `plan.md:28`
 - [ ] (suggestion) Scope the new git-verify error to found-but-not-git-root; preserve the legit empty→`REPO_PATH` fallback at `merge_pr.sh:222`. — `plan.md:32`
 - [ ] (suggestion) Stronger test discriminator: make `install/testpkg` a github-origin git repo so buggy vs fixed resolution gives a positive/positive contrast (no reliance on filesystem ordering). — `plan.md:39`
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-21 00:00 +00:00
+**By**: Claude Opus
+
+**Branch**: feature/issue-514 at `e0e1477`
+**Commit**: `e0e1477` (fix + regression test, atomic)
+
+### Changes
+- `.agent/scripts/merge_pr.sh` — both slug-resolution `find` calls now anchor on
+  `-path '*_ws/src/*'` (the `--pr` escape-hatch `REPO_PATH` derivation, and the
+  `BRANCH_REPO` derivation), excluding colcon `install/<pkg>` and `build/<pkg>`
+  artifacts that share the source's depth+name. Anchored on the layer-workspace
+  structure rather than a bare `*/src/*`, per the review-plan finding (a workspace
+  under a `/src/` parent dir would defeat the bare form).
+- Added git-repo-root verification after each `find`
+  (`git -C "$cand" rev-parse --show-toplevel` must equal the candidate). Scoped
+  to the **found-but-not-git-root** case only: the `--pr` path errors after its
+  own non-empty `find`; the `BRANCH_REPO` path guards the check behind
+  `[[ -n "$BRANCH_REPO" && ... ]]` so an EMPTY result still flows to the existing
+  `REPO_PATH` fallback (no regression of the escape-hatch path).
+- `.agent/scripts/tests/test_merge_pr.sh` — new regression test: fabricates
+  `layers/main/testlayer_ws/{install,build,src}/testpkg`, makes `install/testpkg`
+  a github-origin repo and `src/testpkg` a gitcloud (field-mode) repo, invokes
+  `merge_pr.sh --pr 1 --repo-slug testpkg`, and asserts the field-mode guard
+  fires (proving `src/` resolved). Positive/positive contrast — a regression to
+  `install/testpkg` (github origin) would proceed past the guard. `gh` is stubbed
+  to a loud failure to prove no GitHub call escapes.
+
+### Verification
+- `bash .agent/scripts/tests/test_merge_pr.sh` → **16 passed, 0 failed** (incl. the new #514 case).
+- `PYTHON=python3 ./.agent/scripts/tests/run_script_tests.sh` → `test_merge_pr.sh` green; all
+  pytest (51) green. One pre-existing unrelated failure in
+  `test_check_commit_identity.sh` ("no propagation rejection"), an `$AGENT_NAME`/git-config
+  env-gate test that touches neither changed file (confirmed pre-existing).
+- `bash -n .agent/scripts/merge_pr.sh` → clean.
+- `shellcheck .agent/scripts/merge_pr.sh` → only pre-existing info/style notes
+  (SC2317/SC1091/SC2001/SC2015), none in the edited regions; passes the pre-commit
+  shellcheck hook.
+
+### Actions
+- [x] Scope both `find` calls (anchored `*_ws/src/*`) + git-repo-root verify.
+- [x] Regression test (github `install/` vs gitcloud `src/`, field-mode-guard assertion).
+- [x] `--pr` escape-hatch `REPO_PATH` derivation uses the scoped `find`.


### PR DESCRIPTION
Closes #514.

## Problem

`merge_pr.sh` located a project repo with `find … -name "$slug"` under `layers/main/`. After a `colcon build`, colcon creates `<layer>_ws/install/<pkg>` and `<layer>_ws/build/<pkg>` at the same depth/name as `<layer>_ws/src/<pkg>`. Since `-print -quit` returns the first match, an **artifact dir was resolved before `src/<pkg>`** — `git remote get-url origin` then walked up to the workspace root, mis-resolving the repo and failing `gh pr view`.

## Fix (`.agent/scripts/merge_pr.sh`)

- **Anchored path scope** on the vulnerable `--pr`-escape-hatch find: `-path '*_ws/src/*'`. Colcon artifacts live under `<layer>_ws/install/*` / `build/*`, never `*_ws/src/*`. Deliberately **anchored on `_ws/src/`** rather than a bare `*/src/*` — the latter would still match `install/<pkg>` if the whole workspace is checked out under a path containing a `/src/` segment (e.g. `~/src/…`).
- **Git-root verification** after the find: a non-empty candidate must satisfy `git -C "$path" rev-parse --show-toplevel == "$path"`, else a clear error — **fail closed**, never a silent wrong-path merge/delete. Scoped to *found-but-not-a-git-root*; an empty result still flows to the normal fallback.
- The other resolution path (`repo_path_in_worktree`) finds `.git` dirs, which colcon artifacts don't have — inherently safe, left unchanged (no over-anchoring).

## Test (`.agent/scripts/tests/test_merge_pr.sh`)

Regression test with a **positive/positive contrast** (no filesystem-order reliance): a fabricated `testlayer_ws/{install,build,src}/testpkg` where `install/testpkg` is a **github-origin** repo and `src/testpkg` is a **gitcloud (field-mode)** repo. `merge_pr.sh --pr 1 --repo-slug testpkg` must trip the **field-mode guard** (proving `src/` resolved); a regression to `install/` would instead proceed past it (github origin). Suite: **16/0**.

## Provenance

`/run-issue`, all phases container-dispatched (review-issue/plan-task via the new `--context-file` flow from #552): review-issue → plan → review-plan (3 refinements: anchored path, scoped git-verify, contrast test) → plan revised → implement (Opus) → review-code R1 **approved, 0 must-fix, Deep depth** (both adversarial passes verified end-to-end in the main tree).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
