### PR TITLE
docs(run-issue): self-contained checkpoints — re-orientation header + embedded findings (#553)

### DIFF
--- a/.agent/work-plans/issue-553/plan.md
+++ b/.agent/work-plans/issue-553/plan.md
@@ -19,16 +19,20 @@ no changes to the decision table or the set of checkpoints.
 
 ## Approach
 
-1. **Read the current Checkpoints section** — confirm exact line range (lines 244-253
-   in run-issue/SKILL.md).
+1. **Read the current Checkpoints section** — confirm exact line range (~lines
+   242-256 in run-issue/SKILL.md; the Publish step begins ~258). Verify against
+   the live file since #552 shifted line numbers; do not trust a stale number.
 
 2. **Update the Checkpoints section** — replace the existing section with an expanded
    version that adds, after the introductory line and checkpoint list:
 
    - **Re-orientation header requirement**: every `AskUserQuestion` call must begin
-     with a one-line header in the question text:
+     with a one-line header **in the `question` field text** (NOT the `header`
+     field — that chip is capped at ~12 chars and can't hold this):
      `Issue #N: <title> — phase X of Y; <one-line state>`
      This reloads the operator's context when attention returns without scrollback.
+     The SKILL.md guidance must state the `question`-field-not-`header`-chip
+     placement explicitly so agents don't try to cram it into the chip.
 
    - **Finding-embedding requirement**: when a checkpoint is triggered by a review
      finding (`## Plan Review` / `## Local Review (Pre-Push)` / `## Integrated Review`),
@@ -76,7 +80,9 @@ no changes to the decision table or the set of checkpoints.
 
 ## Open Questions
 
-- [ ] No open questions — plan is review-plan-ready.
+- [x] None. Review-plan's 2 suggestions folded in: corrected the line ref
+  (~242-256, verify live post-#552); the re-orientation header goes in the
+  `question` field, not the 12-char `header` chip.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-553/plan.md
+++ b/.agent/work-plans/issue-553/plan.md
@@ -1,0 +1,83 @@
+# Plan: Self-contained checkpoints in run-issue
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/553
+
+## Context
+
+The `run-issue` orchestrator raises `AskUserQuestion` checkpoints at key lifecycle
+junctures. Currently the Checkpoints section of `.claude/skills/run-issue/SKILL.md`
+describes *when* to pause but says nothing about *what context* the dialog must carry.
+An operator returning to a checkpoint dialog sees the choice but not the triggering
+finding — the *why* lives only in prose above the dialog. During concurrent operation
+(e.g. #550 and #466 running together) the operator must scroll back to reconstruct
+context that should have been in the dialog itself.
+
+The fix is a targeted guidance update: two new requirements in the Checkpoints section,
+no changes to the decision table or the set of checkpoints.
+
+## Approach
+
+1. **Read the current Checkpoints section** — confirm exact line range (lines 244-253
+   in run-issue/SKILL.md).
+
+2. **Update the Checkpoints section** — replace the existing section with an expanded
+   version that adds, after the introductory line and checkpoint list:
+
+   - **Re-orientation header requirement**: every `AskUserQuestion` call must begin
+     with a one-line header in the question text:
+     `Issue #N: <title> — phase X of Y; <one-line state>`
+     This reloads the operator's context when attention returns without scrollback.
+
+   - **Finding-embedding requirement**: when a checkpoint is triggered by a review
+     finding (`## Plan Review` / `## Local Review (Pre-Push)` / `## Integrated Review`),
+     the finding's severity and condensed text must appear verbatim in the `question`
+     or option `description` fields — not only in surrounding prose. Option labels stay
+     short; the *why* rides in the `description`.
+
+   Both requirements apply to all four mandatory checkpoints. A short worked example
+   (or inline template) makes each requirement concrete enough to produce a
+   judgment-free dialog.
+
+3. **Verify no collateral change** — confirm the decision table, the checkpoint list
+   itself (4 items), the publish step, and all other sections are untouched.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.claude/skills/run-issue/SKILL.md` | Expand Checkpoints section with re-orientation header + finding-embedding requirements |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | This change directly strengthens it: operators can adjudicate checkpoints without scrollback |
+| Only what's needed | Single section update; no new mechanism, no new checkpoint, no schema change |
+| Improve incrementally | Minimal targeted edit; the decision table and checkpoint set are explicitly out of scope |
+| A change includes its consequences | Pure guidance doc; the acceptance criterion ("dialog readable in isolation") is human-observable — no automated test applies |
+| Enforcement over documentation | This is a doc refinement; enforcement is by human review of live run-issue traces |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0001 (Adopt ADRs) | No | Behavioral refinement to existing skill, not a new design decision |
+| ADR-0006 (Shared AGENTS.md) | No | The checkpoint-format change doesn't add/remove skills or change skill descriptions in adapter files |
+| ADR-0013 (progress.md vocabulary) | No | No new entry type; change is to checkpoint prose in SKILL.md |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Checkpoints section wording | Adapter files (AGENTS.md, copilot-instructions.md) | No — adapters reference run-issue only at a high level and don't describe checkpoint format |
+| Checkpoints section wording | Other sibling skills (#531, #537, #545) | No — scope is run-issue only per issue statement |
+
+## Open Questions
+
+- [ ] No open questions — plan is review-plan-ready.
+
+## Estimated Scope
+
+Single PR — one file, one section, ~20-30 lines added.

--- a/.agent/work-plans/issue-553/progress.md
+++ b/.agent/work-plans/issue-553/progress.md
@@ -57,3 +57,18 @@ issue: 553
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-21 16:04 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-553/plan.md` at `78f4c63`
+**PR**: PR-less (--issue mode)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) Stale line reference: Checkpoints section is at lines 242–256, not 244–253 (Publish step begins at 258) — `plan.md:22`
+- [ ] (suggestion) Carry into SKILL.md prose that the re-orientation header rides in the `AskUserQuestion` `question` field, not the 12-char `header` chip — `plan.md:30`
+
+<!-- Independence: Plan Authored by "Claude Code Agent (Claude Sonnet)"; this review is a fresh-context dispatch on Claude Opus, not an in-context author self-review. Agent-name match is a false positive of the generic shared name, so no self-review annotation applied. -->

--- a/.agent/work-plans/issue-553/progress.md
+++ b/.agent/work-plans/issue-553/progress.md
@@ -1,0 +1,47 @@
+---
+issue: 553
+---
+
+# Issue #553 — Self-contained checkpoints in run-issue
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-21 14:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #553
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | This change directly strengthens operator transparency — checkpoints become self-contained dialogs that don't require scrollback to adjudicate |
+| Only what's needed | OK | Single targeted edit to the Checkpoints section of run-issue/SKILL.md; no new mechanism, just improved guidance text |
+| Improve incrementally | OK | Small, focused doc change; constraint in the issue explicitly forbids scope creep into the decision table or checkpoint set |
+| A change includes its consequences | Watch | Pure guidance doc — no automated tests apply. The acceptance criteria ("dialog readable in isolation") is a human-observable property; verify with a live run-issue trace if available |
+| Enforcement over documentation | OK | This is a doc refinement, not a new rule requiring enforcement |
+| Capture decisions | OK | No new design decision warranting an ADR; the change refines existing behavior |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| ADR-0001 (Adopt ADRs) | No | Behavioral refinement to existing skill, not a new design decision |
+| ADR-0002 (Worktree isolation) | No | Already in worktree |
+| ADR-0006 (Shared AGENTS.md) | Watch | Consequences map: changing a framework skill → check adapter files. The checkpoint-format change doesn't add/remove skills or change the skill list, so no adapter update is needed; the other adapters don't describe checkpoint format. Still worth a quick scan. |
+| ADR-0013 (progress.md vocabulary) | No | No new entry type; change is to checkpoint prose in SKILL.md |
+
+### Consequences
+
+- **No cross-file updates required.** The Checkpoints section change is self-contained. The skill description in AGENTS.md and other adapter files reference `run-issue` only at a high level; they don't describe checkpoint format.
+- **Acceptance is self-verifying**: a host following the updated guidance produces a checkpoint dialog that reads correctly in isolation — no new tests to write.
+
+### Recommendations
+
+- The two concrete requirements (re-orientation header; finding embedded in the dialog) are clear enough that implementation can proceed directly — no further scoping needed.
+- The "no change to decision table or checkpoint set" constraint in the issue is a useful guardrail; plan-task should explicitly note it to prevent scope creep during implementation.
+
+### Actions
+- [ ] No actions — issue is plan-task-ready.

--- a/.agent/work-plans/issue-553/progress.md
+++ b/.agent/work-plans/issue-553/progress.md
@@ -101,3 +101,21 @@ Collateral-change check passed: `git diff` shows only a 33-line insertion within
 the Checkpoints section — the decision table, the 4-item checkpoint list, the
 Publish step, and all other sections are untouched. Pre-commit passed (no
 `--no-verify`). Committed as `c2973e1`. Per task scope: no push, no PR.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 16:15 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-553 at `5ec640c`
+**Mode**: pre-push
+**Depth**: Standard (reason: `.claude/skills/*/SKILL.md` is a Governance override-trigger file)
+**Must-fix**: 0 | **Suggestions**: 4
+**Round**: 1 | **Ship**: recommended — no must-fix; only adapt-on-read guidance suggestions
+
+### Findings
+- [ ] (suggestion) "both apply to all four checkpoints" vs conditional finding-embedding — resolved by inline wording, could add parenthetical — `.claude/skills/run-issue/SKILL.md:258`
+- [ ] (suggestion) `## Local Review (Pre-Push)` trigger maps to publish checkpoint implicitly; add a one-clause note — `.claude/skills/run-issue/SKILL.md:267`
+- [ ] (suggestion) "phase X of Y" numbering undefined; worked example "phase 6 of 7" denominator is fuzzy — `.claude/skills/run-issue/SKILL.md:261`
+- [ ] (suggestion) finding-embedding trigger list omits `## Issue Review` (checkpoint 1 open-questions) — `.claude/skills/run-issue/SKILL.md:267`

--- a/.agent/work-plans/issue-553/progress.md
+++ b/.agent/work-plans/issue-553/progress.md
@@ -72,3 +72,32 @@ issue: 553
 - [ ] (suggestion) Carry into SKILL.md prose that the re-orientation header rides in the `AskUserQuestion` `question` field, not the 12-char `header` chip — `plan.md:30`
 
 <!-- Independence: Plan Authored by "Claude Code Agent (Claude Sonnet)"; this review is a fresh-context dispatch on Claude Opus, not an in-context author self-review. Agent-name match is a false positive of the generic shared name, so no self-review annotation applied. -->
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-21 18:00 +00:00
+**By**: Claude Opus
+
+**Branch**: feature/issue-553 at `c2973e1`
+**Files**: `.claude/skills/run-issue/SKILL.md`
+
+Expanded the Checkpoints section of `run-issue/SKILL.md` (verified live at lines
+242–256, Publish step at 258 — matching the review-plan correction) with two new
+requirements, inserted after the intro line and the 4-item checkpoint list:
+
+- **Re-orientation header** — every `AskUserQuestion` opens its `question`-field
+  text with `Issue #N: <title> — phase X of Y; <one-line state>`. Guidance states
+  explicitly that this rides in the `question` field, **not** the ~12-char
+  `header` chip.
+- **Finding-embedding** — when a checkpoint is triggered by a `## Plan Review`,
+  `## Local Review (Pre-Push)`, or `## Integrated Review` finding, the finding's
+  severity + condensed text must appear verbatim in the `question` field or an
+  option `description`; labels stay short, the *why* rides in the description.
+
+Added a worked example (sample `question` string + two labelled options) making
+both concrete, and stated both apply to all four mandatory checkpoints.
+
+Collateral-change check passed: `git diff` shows only a 33-line insertion within
+the Checkpoints section — the decision table, the 4-item checkpoint list, the
+Publish step, and all other sections are untouched. Pre-commit passed (no
+`--no-verify`). Committed as `c2973e1`. Per task scope: no push, no PR.

--- a/.agent/work-plans/issue-553/progress.md
+++ b/.agent/work-plans/issue-553/progress.md
@@ -45,3 +45,15 @@ issue: 553
 
 ### Actions
 - [ ] No actions — issue is plan-task-ready.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-21 17:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-553/plan.md` at `78f4c63`
+**Branch**: feature/issue-553 at `78f4c63`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -252,6 +252,39 @@ Use `AskUserQuestion` — **never block silently**. Mandatory checkpoints:
 4. **Before any push, PR creation, or merge** — local-first: the user confirms
    that work publishes.
 
+**Every checkpoint dialog must stand on its own.** An operator returning to a
+checkpoint — possibly after attending to another issue running concurrently —
+should be able to adjudicate it from the dialog alone, without scrolling back
+for the context that triggered it. Two requirements make that true, and **both
+apply to all four checkpoints above**:
+
+- **Re-orientation header** — every `AskUserQuestion` call must open its
+  `question` text with a one-line header:
+  `Issue #N: <title> — phase X of Y; <one-line state>`. Put it in the
+  **`question` field, not the `header` field** — the `header` chip is capped at
+  ~12 chars and cannot hold it. This reloads the operator's context the moment
+  attention returns.
+- **Finding-embedding** — when a checkpoint is triggered by a review finding
+  (from `## Plan Review`, `## Local Review (Pre-Push)`, or
+  `## Integrated Review`), the finding's **severity and condensed text must
+  appear verbatim** in the `question` field or an option `description` — not
+  only in the prose above the dialog. Keep option **labels** short (the action);
+  the *why* rides in the `description`.
+
+Worked example — checkpoint 3, triggered by an `## Integrated Review` must-fix:
+
+```
+question: "Issue #466: Recover from GPS dropout — phase 6 of 7; Integrated
+           Review found 1 must-fix. [HIGH] stale fix published when RTK age
+           > 2s (nav_node.cpp:212). How should I proceed?"
+options:
+  - label:       "Fix via address-findings"
+    description: "Dispatch address-findings to gate publishing on RTK age —
+                  resolves the [HIGH] stale-fix finding above."
+  - label:       "Defer"
+    description: "Publish as-is; track the [HIGH] stale-fix finding separately."
+```
+
 Between checkpoints the orchestrator proceeds automatically, reporting each
 transition (entry read → next dispatch).
 

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -264,12 +264,14 @@ apply to all four checkpoints above**:
   **`question` field, not the `header` field** — the `header` chip is capped at
   ~12 chars and cannot hold it. This reloads the operator's context the moment
   attention returns.
-- **Finding-embedding** — when a checkpoint is triggered by a review finding
-  (from `## Plan Review`, `## Local Review (Pre-Push)`, or
-  `## Integrated Review`), the finding's **severity and condensed text must
-  appear verbatim** in the `question` field or an option `description` — not
-  only in the prose above the dialog. Keep option **labels** short (the action);
-  the *why* rides in the `description`.
+- **Finding-embedding** — when a checkpoint is triggered by a review entry's
+  findings or open questions (`## Issue Review` open-question actions → checkpoint
+  1; `## Plan Review` → checkpoint 2; `## Integrated Review` → checkpoint 3; and
+  `## Local Review (Pre-Push)`, whose `approved` verdict drives the checkpoint-4
+  publish gate), the finding's **severity and condensed text must appear
+  verbatim** in the `question` field or an option `description` — not only in the
+  prose above the dialog. Keep option **labels** short (the action); the *why*
+  rides in the `description`.
 
 Worked example — checkpoint 3, triggered by an `## Integrated Review` must-fix:
 


### PR DESCRIPTION
Closes #553.

Makes `run-issue`'s `AskUserQuestion` checkpoints **self-contained**, so an operator juggling concurrent issues can adjudicate a checkpoint from the dialog alone — no scrollback for the context that triggered it.

## Change (guidance only — `.claude/skills/run-issue/SKILL.md` Checkpoints section)

Two requirements added to the Checkpoints section (decision table, the 4-item checkpoint list, and Publish step all untouched — a single +36-line hunk):

1. **Re-orientation header** — every checkpoint dialog opens its `question` text with `Issue #N: <title> — phase X of Y; <one-line state>`. Explicitly in the **`question` field, not the 12-char `header` chip** (which can't hold it).
2. **Finding-embedding** — when a checkpoint is triggered by a review entry's findings/open-questions (`## Issue Review` open-questions → checkpoint 1; `## Plan Review` → 2; `## Integrated Review` → 3; `## Local Review (Pre-Push)` approved → publish gate), the finding's severity + condensed text appears **verbatim** in the `question` field or an option `description`, not only in surrounding prose. Labels stay short; the *why* rides in the `description`.

Includes a worked example dialog.

## Motivation

Reported live (operator, 2026-06-21) while running #550 and #466 concurrently: *"I'm asked to answer the question without the actual explanation from the review for why that question is asked … useful to have a brief summary of the issue being worked on when my attention returns."* Sibling to the run-issue refinements #531 / #537 / #545.

## Provenance

`/run-issue`, all phases container-dispatched via the #552 `--context-file` flow: review-issue → plan → review-plan (2 refinements: line ref, `question`-field-not-`header`-chip) → plan revised → implement (Opus) → review-code R1 **approved, 0 must-fix** (4 adapt-on-read suggestions; folded #2+#4, skipped the two prose-taste ones per the guidance-doc convergence principle — no extra round). This PR description itself follows the new format-context-richly spirit.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
