### PR TITLE
Runtime layer chaining: fix O(N²) sourcing + inverted overlay precedence (#559)

### DIFF
--- a/.agent/WORKTREE_GUIDE.md
+++ b/.agent/WORKTREE_GUIDE.md
@@ -47,6 +47,13 @@ point to `layers/main/`) are skipped to avoid polluting the shared workspace.
 | `<target_layer>_ws/test.sh` | Sources lower layers, runs `colcon test` + `colcon test-result --verbose` |
 | `<target_layer>_ws/colcon/defaults.yaml` | Default colcon flags (`--symlink-install`, compile commands); auto-discovered by colcon from `$PWD/colcon/defaults.yaml` |
 
+All generated layer sourcing uses each layer's `install/local_setup.bash`
+(runtime chaining in `layers.txt` order), **not** the baked chained
+`install/setup.bash` — see
+[ADR-0016](../docs/decisions/0016-runtime-vs-baked-layer-chaining.md).
+Worktrees created before that change keep their old (slower) generated
+scripts; recreate the worktree to pick up the fast versions.
+
 ### Usage
 
 ```bash

--- a/.agent/knowledge/ros2_development_patterns.md
+++ b/.agent/knowledge/ros2_development_patterns.md
@@ -150,11 +150,16 @@ This repository uses a layered workspace approach:
 
 ### Environment Sourcing Order
 ```bash
-source /opt/ros/<distro>/setup.bash  # ROS2 base
-source layers/main/underlay_ws/install/setup.bash
-source layers/main/core_ws/install/setup.bash
-# ... additional layers
+source /opt/ros/<distro>/setup.bash  # ROS2 base, once
+source layers/main/underlay_ws/install/local_setup.bash
+source layers/main/core_ws/install/local_setup.bash
+# ... additional layers, ascending layers.txt order (last sourced = highest precedence)
 ```
+
+Use each layer's `local_setup.bash` (this layer only), **not** the baked
+chained `setup.bash` — the chain re-sources every parent recorded at build
+time, which is O(N²) across layers and trusts stale build-time state. See
+[ADR-0016](../../docs/decisions/0016-runtime-vs-baked-layer-chaining.md).
 
 The `.agent/scripts/setup.bash` script handles this automatically.
 

--- a/.agent/scripts/build.sh
+++ b/.agent/scripts/build.sh
@@ -74,8 +74,39 @@ fi
     echo "|---|---|---|---|"
 } > "$REPORT_FILE"
 
-# Load Layer Definitions (this also sets LAYERS array)
-source "$SCRIPT_DIR/setup.bash" > /dev/null
+# Source ONLY the ROS 2 base before building. Sourcing the full workspace
+# environment here (the old `source setup.bash`) put every already-built layer
+# on COLCON_PREFIX_PATH before the first colcon build, so colcon baked ALL
+# other layers into each layer's parent chain — including layers ABOVE it
+# (e.g. underlay_ws recording ui_ws as a parent), inverting overlay precedence
+# for anyone sourcing the chained install/setup.bash. Layers below the one
+# being built are sourced progressively after each successful build, which is
+# the only pre-build environment a layer should see. See ADR-0016 / #559.
+if [ -f "/opt/ros/jazzy/setup.bash" ]; then
+    source /opt/ros/jazzy/setup.bash
+else
+    echo "❌ Error: /opt/ros/jazzy/setup.bash not found. Please install ROS 2 Jazzy."
+    exit 1
+fi
+
+# Load Layer Definitions from layers.txt (same resolution as setup.bash,
+# without sourcing the layer overlays)
+LAYERS_CONFIG="$ROOT_DIR/configs/manifest/layers.txt"
+if [ ! -f "$LAYERS_CONFIG" ] && [ -n "$WORKTREE_INFO" ]; then
+    if [ "$WORKTREE_INFO" = "workspace worktree" ]; then
+        # .workspace-worktrees/issue-N -> main root is two levels up
+        LAYERS_CONFIG="$(dirname "$(dirname "$ROOT_DIR")")/configs/manifest/layers.txt"
+    else
+        # layers/worktrees/issue-N -> main root is three levels up
+        LAYERS_CONFIG="$(dirname "$(dirname "$(dirname "$ROOT_DIR")")")/configs/manifest/layers.txt"
+    fi
+fi
+if [ -f "$LAYERS_CONFIG" ]; then
+    mapfile -t LAYERS < <(grep -v '^[[:space:]]*$' "$LAYERS_CONFIG" | grep -v '^#')
+else
+    echo "  ! Warning: Layer config not found at $LAYERS_CONFIG. Using defaults."
+    LAYERS=("underlay" "core" "platforms" "sensors" "simulation" "ui")
+fi
 
 echo "========================================"
 echo "Starting Build Sequence"
@@ -122,9 +153,10 @@ for layer in "${LAYERS[@]}"; do
 
     # Check result
     if [ $BUILD_RC -eq 0 ]; then
-        # Sourcing ensures the next layer can see this one
-        if [ -f "install/setup.bash" ]; then
-            source "install/setup.bash"
+        # Sourcing ensures the next layer can see this one. local_setup.bash
+        # adds only this layer (jazzy + lower layers are already in the env).
+        if [ -f "install/local_setup.bash" ]; then
+            source "install/local_setup.bash"
         fi
     else
         echo "!! Build Failed for layer: $layer"

--- a/.agent/scripts/build.sh
+++ b/.agent/scripts/build.sh
@@ -102,7 +102,9 @@ if [ ! -f "$LAYERS_CONFIG" ] && [ -n "$WORKTREE_INFO" ]; then
     fi
 fi
 if [ -f "$LAYERS_CONFIG" ]; then
-    mapfile -t LAYERS < <(grep -v '^[[:space:]]*$' "$LAYERS_CONFIG" | grep -v '^#')
+    # Strip trailing whitespace so a stray space in layers.txt can't produce a
+    # bad "<layer> _ws" path (matches setup.bash + test_layer_sourcing.sh).
+    mapfile -t LAYERS < <(grep -v '^[[:space:]]*$' "$LAYERS_CONFIG" | grep -v '^#' | sed 's/[[:space:]]*$//')
 else
     echo "  ! Warning: Layer config not found at $LAYERS_CONFIG. Using defaults."
     LAYERS=("underlay" "core" "platforms" "sensors" "simulation" "ui")

--- a/.agent/scripts/build.sh
+++ b/.agent/scripts/build.sh
@@ -82,6 +82,12 @@ fi
 # for anyone sourcing the chained install/setup.bash. Layers below the one
 # being built are sourced progressively after each successful build, which is
 # the only pre-build environment a layer should see. See ADR-0016 / #559.
+#
+# Scrub any inherited prefix paths first: the caller may run `make build` from
+# a shell that already sourced setup.bash, and sourcing jazzy PREPENDS rather
+# than resets — an inherited COLCON_PREFIX_PATH would re-bake higher layers
+# into lower chains (the exact pollution this section exists to prevent).
+unset COLCON_PREFIX_PATH AMENT_PREFIX_PATH CMAKE_PREFIX_PATH AMENT_CURRENT_PREFIX
 if [ -f "/opt/ros/jazzy/setup.bash" ]; then
     source /opt/ros/jazzy/setup.bash
 else
@@ -107,7 +113,7 @@ if [ -f "$LAYERS_CONFIG" ]; then
     mapfile -t LAYERS < <(grep -v '^[[:space:]]*$' "$LAYERS_CONFIG" | grep -v '^#' | sed 's/[[:space:]]*$//')
 else
     echo "  ! Warning: Layer config not found at $LAYERS_CONFIG. Using defaults."
-    LAYERS=("underlay" "core" "platforms" "sensors" "simulation" "ui")
+    LAYERS=("underlay" "core" "platforms" "site" "sensors" "simulation" "ui")
 fi
 
 echo "========================================"

--- a/.agent/scripts/setup.bash
+++ b/.agent/scripts/setup.bash
@@ -79,7 +79,7 @@ if [ -f "$LAYERS_CONFIG" ]; then
 else
     # Fallback/Bootstrap layers
     echo "  ! Warning: Layer config not found at $LAYERS_CONFIG. Using defaults."
-    LAYERS=("underlay" "core" "platforms" "sensors" "simulation" "ui")
+    LAYERS=("underlay" "core" "platforms" "site" "sensors" "simulation" "ui")
 fi
 
 echo "Sourcing ROS2 Agent Workspace layers..."

--- a/.agent/scripts/setup.bash
+++ b/.agent/scripts/setup.bash
@@ -82,15 +82,21 @@ fi
 
 echo "Sourcing ROS2 Agent Workspace layers..."
 
+# Source each layer's local_setup.bash (current layer only), NOT the baked
+# chained setup.bash: the chained file re-sources its entire parent chain
+# (O(N²) across N layers, ~4.5s vs ~0.5s) and trusts parent lists recorded at
+# build time, which go stale/polluted. Runtime chaining in layers.txt order
+# gives the last-sourced (topmost) layer highest precedence — canonical colcon
+# overlay semantics. See ADR-0016 and issue #559.
 for layer in "${LAYERS[@]}"; do
-    SETUP_FILE="$LAYERS_BASE/${layer}_ws/install/setup.bash"
+    SETUP_FILE="$LAYERS_BASE/${layer}_ws/install/local_setup.bash"
     if [ -f "$SETUP_FILE" ]; then
         echo "  - Sourcing $layer..."
         # shellcheck disable=SC1090
         source "$SETUP_FILE"
     else
         if [ -d "$LAYERS_BASE/${layer}_ws/src" ]; then
-             echo "  ! Warning: $layer exists but is not built (setup.bash not found)."
+             echo "  ! Warning: $layer exists but is not built (local_setup.bash not found)."
         fi
     fi
 done

--- a/.agent/scripts/setup.bash
+++ b/.agent/scripts/setup.bash
@@ -72,8 +72,10 @@ if [ ! -f "$LAYERS_CONFIG" ] && [ -n "$WORKTREE_CONTEXT" ]; then
 fi
 
 if [ -f "$LAYERS_CONFIG" ]; then
-    # Read non-empty lines into array
-    mapfile -t LAYERS < <(grep -v '^[[:space:]]*$' "$LAYERS_CONFIG" | grep -v '^#')
+    # Read non-empty lines into array (strip trailing whitespace so a stray
+    # space in layers.txt can't produce a bad "<layer> _ws" path; matches the
+    # regression guard in test_layer_sourcing.sh)
+    mapfile -t LAYERS < <(grep -v '^[[:space:]]*$' "$LAYERS_CONFIG" | grep -v '^#' | sed 's/[[:space:]]*$//')
 else
     # Fallback/Bootstrap layers
     echo "  ! Warning: Layer config not found at $LAYERS_CONFIG. Using defaults."

--- a/.agent/scripts/test.sh
+++ b/.agent/scripts/test.sh
@@ -93,9 +93,11 @@ for layer in "${LAYERS[@]}"; do
 
         cd "$LAYER_DIR" || continue
 
-        # Source existing install if available
-        if [ -f "install/setup.bash" ]; then
-            source "install/setup.bash"
+        # Source existing install if available. local_setup.bash (this layer
+        # only) suffices: the full workspace environment was already sourced
+        # via setup.bash above, so the baked chain would only redo that work.
+        if [ -f "install/local_setup.bash" ]; then
+            source "install/local_setup.bash"
         fi
 
         # Run Tests

--- a/.agent/scripts/test_layer_sourcing.sh
+++ b/.agent/scripts/test_layer_sourcing.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# .agent/scripts/test_layer_sourcing.sh
+# Regression guard for runtime layer chaining (ADR-0016, issue #559).
+#
+# Checks:
+#   1. STATIC (hard fail, runs everywhere incl. CI): no workspace script
+#      sources a layer's baked chained install/setup.bash — runtime chaining
+#      must use install/local_setup.bash.
+#   2. RUNTIME ORDER (hard fail, skipped when no layers are built): sourcing
+#      .agent/scripts/setup.bash in a clean shell must yield canonical overlay
+#      precedence in AMENT_PREFIX_PATH — topmost layer first, underlay just
+#      above /opt/ros/jazzy (i.e., layers.txt order reversed).
+#   3. CHAIN PURITY (warning only): each built layer's baked parent chain
+#      (COLCON_CURRENT_PREFIX lines in install/setup.sh) should reference only
+#      /opt/ros/jazzy and strictly-lower layers. Pollution means the layer was
+#      built with higher layers sourced (the pre-#559 build.sh bug) and needs
+#      the one-time bottom-up clean rebuild to heal. Warning-only because
+#      pre-existing installs are expected to be polluted until healed.
+#
+# Exit codes: 0 = pass (or skipped), 1 = check failed.
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    echo "Error: This script should be executed, not sourced."
+    echo "  Run: ${BASH_SOURCE[0]} $*"
+    return 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+LAYERS_BASE="$ROOT_DIR/layers/main"
+
+FAILURES=0
+
+echo "=== Layer sourcing regression guard (ADR-0016 / #559) ==="
+
+# --- Check 1: static — no chained install/setup.bash sourcing in scripts ---
+STATIC_TARGETS=(
+    "$SCRIPT_DIR/setup.bash"
+    "$SCRIPT_DIR/build.sh"
+    "$SCRIPT_DIR/test.sh"
+    "$SCRIPT_DIR/verify_change.sh"
+    "$SCRIPT_DIR/worktree_create.sh"
+)
+STATIC_BAD=0
+for f in "${STATIC_TARGETS[@]}"; do
+    [ -f "$f" ] || continue
+    # Match actual source statements (incl. heredoc-generated ones), not comments.
+    if grep -nE '^[^#]*source[^#]*install/setup\.bash' "$f" > /dev/null; then
+        echo "❌ Check 1: $f sources a baked chained install/setup.bash:"
+        grep -nE '^[^#]*source[^#]*install/setup\.bash' "$f" | sed 's/^/     /'
+        STATIC_BAD=1
+    fi
+done
+if [ "$STATIC_BAD" -eq 0 ]; then
+    echo "✅ Check 1: no baked-chain sourcing in workspace scripts"
+else
+    echo "   Layer sourcing must use install/local_setup.bash (see ADR-0016)."
+    FAILURES=$((FAILURES + 1))
+fi
+
+# --- Resolve layer list (worktree-aware, same fallback as setup.bash) ---
+LAYERS_CONFIG="$ROOT_DIR/configs/manifest/layers.txt"
+if [ ! -f "$LAYERS_CONFIG" ]; then
+    if [[ "$ROOT_DIR" == *"/.workspace-worktrees/"* ]]; then
+        LAYERS_CONFIG="$(dirname "$(dirname "$ROOT_DIR")")/configs/manifest/layers.txt"
+    elif [[ "$ROOT_DIR" == *"/layers/worktrees/"* ]]; then
+        LAYERS_CONFIG="$(dirname "$(dirname "$(dirname "$ROOT_DIR")")")/configs/manifest/layers.txt"
+    fi
+fi
+if [ ! -f "$LAYERS_CONFIG" ]; then
+    echo "⏭️  Checks 2-3 skipped: no layers.txt at $LAYERS_CONFIG"
+    exit "$((FAILURES > 0 ? 1 : 0))"
+fi
+mapfile -t LAYERS < <(grep -v '^[[:space:]]*$' "$LAYERS_CONFIG" | grep -v '^#' | sed 's/[[:space:]]*$//')
+
+BUILT=()
+for layer in "${LAYERS[@]}"; do
+    [ -f "$LAYERS_BASE/${layer}_ws/install/local_setup.bash" ] && BUILT+=("$layer")
+done
+if [ ${#BUILT[@]} -eq 0 ]; then
+    echo "⏭️  Checks 2-3 skipped: no built layers under $LAYERS_BASE (expected in CI)"
+    exit "$((FAILURES > 0 ? 1 : 0))"
+fi
+
+# --- Check 2: runtime precedence order ---
+# Source in a scrubbed shell so a pre-sourced caller environment can't skew
+# the order, then print first-occurrence layer names from AMENT_PREFIX_PATH.
+ACTUAL_ORDER=$(env -i HOME="$HOME" PATH="/usr/local/bin:/usr/bin:/bin" TERM=dumb \
+    bash --noprofile --norc -c \
+    "source '$SCRIPT_DIR/setup.bash' > /dev/null 2>&1
+     echo \"\$AMENT_PREFIX_PATH\" | tr ':' '\n' \
+       | sed -E 's|.*/layers/main/([a-z0-9_]+)_ws/.*|\1|; s|^/opt/ros/[a-z]+.*|ROS_BASE|' \
+       | uniq | tr '\n' ' '")
+ACTUAL_ORDER="${ACTUAL_ORDER% }"
+
+EXPECTED_ORDER=""
+for ((i=${#BUILT[@]}-1; i>=0; i--)); do
+    EXPECTED_ORDER+="${BUILT[$i]} "
+done
+EXPECTED_ORDER+="ROS_BASE"
+
+if [ "$ACTUAL_ORDER" == "$EXPECTED_ORDER" ]; then
+    echo "✅ Check 2: canonical overlay precedence ($ACTUAL_ORDER)"
+else
+    echo "❌ Check 2: AMENT_PREFIX_PATH layer order is not canonical."
+    echo "     expected: $EXPECTED_ORDER"
+    echo "     actual:   $ACTUAL_ORDER"
+    echo "   Overlays must outrank underlays (topmost layer first)."
+    FAILURES=$((FAILURES + 1))
+fi
+
+# --- Check 3: baked-chain purity (warning only) ---
+POLLUTED=()
+for ((i=0; i<${#LAYERS[@]}; i++)); do
+    layer="${LAYERS[$i]}"
+    chain_file="$LAYERS_BASE/${layer}_ws/install/setup.sh"
+    [ -f "$chain_file" ] || continue
+    bad_refs=""
+    while IFS= read -r prefix; do
+        case "$prefix" in
+            /opt/ros/*) continue ;;
+            *'$'*) continue ;;  # self-reference via shell variable, not a parent
+        esac
+        parent_ok=0
+        for ((j=0; j<i; j++)); do
+            if [[ "$prefix" == *"/${LAYERS[$j]}_ws/install" ]]; then
+                parent_ok=1
+                break
+            fi
+        done
+        if [ "$parent_ok" -eq 0 ]; then
+            ref_name=$(basename "$(dirname "$prefix")")
+            bad_refs="$bad_refs ${ref_name%_ws}"
+        fi
+    done < <(grep -oE '^COLCON_CURRENT_PREFIX="[^"]+"' "$chain_file" | cut -d'"' -f2)
+    [ -n "$bad_refs" ] && POLLUTED+=("$layer: non-parent chain refs →$bad_refs")
+done
+if [ ${#POLLUTED[@]} -eq 0 ]; then
+    echo "✅ Check 3: baked parent chains are clean (jazzy + lower layers only)"
+else
+    echo "⚠️  Check 3 (warning): polluted baked parent chains detected:"
+    printf '     %s\n' "${POLLUTED[@]}"
+    echo "   These layers were built with higher layers sourced (pre-#559"
+    echo "   build.sh). Heal with a one-time bottom-up clean rebuild:"
+    echo "     rm -rf layers/main/*_ws/{build,install,log} && make build"
+    echo "   (Warning only — runtime chaining ignores baked chains, but other"
+    echo "   consumers sourcing install/setup.bash directly inherit them.)"
+fi
+
+if [ "$FAILURES" -gt 0 ]; then
+    echo "=== FAILED: $FAILURES check(s) ==="
+    exit 1
+fi
+echo "=== PASSED ==="
+exit 0

--- a/.agent/scripts/test_layer_sourcing.sh
+++ b/.agent/scripts/test_layer_sourcing.sh
@@ -34,14 +34,12 @@ FAILURES=0
 echo "=== Layer sourcing regression guard (ADR-0016 / #559) ==="
 
 # --- Check 1: static — no chained install/setup.bash sourcing in scripts ---
-# Scan every workspace shell script (repo-wide glob, not a hardcoded allowlist)
-# so a future baked-chain source anywhere under .agent/scripts/ can't escape the
-# guard. Skip this script itself: its diagnostics necessarily name the
-# anti-pattern in echo strings, which are not real source statements.
+# Scan every workspace shell script recursively under .agent/scripts/ and
+# .agent/hooks/ (not a hardcoded allowlist) so a future baked-chain source
+# can't escape the guard. Skip this script itself: its diagnostics necessarily
+# name the anti-pattern in echo strings, which are not real source statements.
 STATIC_BAD=0
-shopt -s nullglob
-for f in "$SCRIPT_DIR"/*.sh "$SCRIPT_DIR"/*.bash; do
-    [ -f "$f" ] || continue
+while IFS= read -r f; do
     [ "$f" -ef "${BASH_SOURCE[0]}" ] && continue
     # Match actual source statements (incl. heredoc-generated ones), not comments.
     if grep -nE '^[^#]*source[^#]*install/setup\.bash' "$f" > /dev/null; then
@@ -49,8 +47,8 @@ for f in "$SCRIPT_DIR"/*.sh "$SCRIPT_DIR"/*.bash; do
         grep -nE '^[^#]*source[^#]*install/setup\.bash' "$f" | sed 's/^/     /'
         STATIC_BAD=1
     fi
-done
-shopt -u nullglob
+done < <(find "$SCRIPT_DIR" "$ROOT_DIR/.agent/hooks" \
+              \( -name '*.sh' -o -name '*.bash' \) -type f 2>/dev/null | sort)
 if [ "$STATIC_BAD" -eq 0 ]; then
     echo "✅ Check 1: no baked-chain sourcing in workspace scripts"
 else
@@ -104,7 +102,7 @@ ACTUAL_ORDER=$(env -i HOME="$HOME" PATH="/usr/local/bin:/usr/bin:/bin" TERM=dumb
     "source '$SCRIPT_DIR/setup.bash' > /dev/null 2>&1
      echo \"\$AMENT_PREFIX_PATH\" | tr ':' '\n' \
        | sed -E 's|.*/layers/main/([a-z0-9_]+)_ws/.*|\1|; s|^/opt/ros/[a-z]+.*|ROS_BASE|' \
-       | uniq | tr '\n' ' '")
+       | awk '!seen[\$0]++' | tr '\n' ' '")
 ACTUAL_ORDER="${ACTUAL_ORDER% }"
 
 EXPECTED_ORDER=""

--- a/.agent/scripts/test_layer_sourcing.sh
+++ b/.agent/scripts/test_layer_sourcing.sh
@@ -27,7 +27,7 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
-LAYERS_BASE="$ROOT_DIR/layers/main"
+# LAYERS_BASE is resolved (worktree-aware) alongside LAYERS_CONFIG below.
 
 FAILURES=0
 
@@ -58,15 +58,23 @@ else
     FAILURES=$((FAILURES + 1))
 fi
 
-# --- Resolve layer list (worktree-aware, same fallback as setup.bash) ---
-LAYERS_CONFIG="$ROOT_DIR/configs/manifest/layers.txt"
-if [ ! -f "$LAYERS_CONFIG" ]; then
+# --- Resolve layer list + built-layer base (worktree-aware) ---
+# LAYERS_CONFIG and LAYERS_BASE must resolve to the SAME workspace root. In a
+# worktree, configs/ (gitignored) is absent and built layers live under the
+# MAIN root's layers/main (a workspace worktree symlinks it; a layer worktree
+# does not). Derive one MAIN_ROOT and use it for both, so Checks 2-3 run
+# against the real built layers instead of silently skipping in a layer
+# worktree (and so the /layers/main/ sed below stays correct — see Check 2).
+MAIN_ROOT="$ROOT_DIR"
+if [ ! -f "$ROOT_DIR/configs/manifest/layers.txt" ]; then
     if [[ "$ROOT_DIR" == *"/.workspace-worktrees/"* ]]; then
-        LAYERS_CONFIG="$(dirname "$(dirname "$ROOT_DIR")")/configs/manifest/layers.txt"
+        MAIN_ROOT="$(dirname "$(dirname "$ROOT_DIR")")"
     elif [[ "$ROOT_DIR" == *"/layers/worktrees/"* ]]; then
-        LAYERS_CONFIG="$(dirname "$(dirname "$(dirname "$ROOT_DIR")")")/configs/manifest/layers.txt"
+        MAIN_ROOT="$(dirname "$(dirname "$(dirname "$ROOT_DIR")")")"
     fi
 fi
+LAYERS_CONFIG="$MAIN_ROOT/configs/manifest/layers.txt"
+LAYERS_BASE="$MAIN_ROOT/layers/main"
 if [ ! -f "$LAYERS_CONFIG" ]; then
     echo "⏭️  Checks 2-3 skipped: no layers.txt at $LAYERS_CONFIG"
     exit "$((FAILURES > 0 ? 1 : 0))"
@@ -85,7 +93,13 @@ fi
 # --- Check 2: runtime precedence order ---
 # Source in a scrubbed shell so a pre-sourced caller environment can't skew
 # the order, then print first-occurrence layer names from AMENT_PREFIX_PATH.
+# Pass ROS2_LAYERS_BASE so setup.bash sources the SAME layers we detected as
+# BUILT: in a layer worktree it would otherwise default LAYERS_BASE to the
+# worktree path and its AMENT entries wouldn't be under /layers/main/ (the
+# path the sed below keys on). setup.bash honors this override and won't
+# clobber it (see setup.bash's ROS2_LAYERS_BASE guard).
 ACTUAL_ORDER=$(env -i HOME="$HOME" PATH="/usr/local/bin:/usr/bin:/bin" TERM=dumb \
+    ROS2_LAYERS_BASE="$LAYERS_BASE" \
     bash --noprofile --norc -c \
     "source '$SCRIPT_DIR/setup.bash' > /dev/null 2>&1
      echo \"\$AMENT_PREFIX_PATH\" | tr ':' '\n' \

--- a/.agent/scripts/test_layer_sourcing.sh
+++ b/.agent/scripts/test_layer_sourcing.sh
@@ -34,16 +34,15 @@ FAILURES=0
 echo "=== Layer sourcing regression guard (ADR-0016 / #559) ==="
 
 # --- Check 1: static — no chained install/setup.bash sourcing in scripts ---
-STATIC_TARGETS=(
-    "$SCRIPT_DIR/setup.bash"
-    "$SCRIPT_DIR/build.sh"
-    "$SCRIPT_DIR/test.sh"
-    "$SCRIPT_DIR/verify_change.sh"
-    "$SCRIPT_DIR/worktree_create.sh"
-)
+# Scan every workspace shell script (repo-wide glob, not a hardcoded allowlist)
+# so a future baked-chain source anywhere under .agent/scripts/ can't escape the
+# guard. Skip this script itself: its diagnostics necessarily name the
+# anti-pattern in echo strings, which are not real source statements.
 STATIC_BAD=0
-for f in "${STATIC_TARGETS[@]}"; do
+shopt -s nullglob
+for f in "$SCRIPT_DIR"/*.sh "$SCRIPT_DIR"/*.bash; do
     [ -f "$f" ] || continue
+    [ "$f" -ef "${BASH_SOURCE[0]}" ] && continue
     # Match actual source statements (incl. heredoc-generated ones), not comments.
     if grep -nE '^[^#]*source[^#]*install/setup\.bash' "$f" > /dev/null; then
         echo "❌ Check 1: $f sources a baked chained install/setup.bash:"
@@ -51,6 +50,7 @@ for f in "${STATIC_TARGETS[@]}"; do
         STATIC_BAD=1
     fi
 done
+shopt -u nullglob
 if [ "$STATIC_BAD" -eq 0 ]; then
     echo "✅ Check 1: no baked-chain sourcing in workspace scripts"
 else

--- a/.agent/scripts/verify_change.sh
+++ b/.agent/scripts/verify_change.sh
@@ -59,10 +59,13 @@ if [ -n "$FOUND_LAYER" ]; then
     echo "Located package in: $FOUND_LAYER"
     cd "$FOUND_LAYER" || exit 1
 
-    # Source install if available to ensure environment is ready
-    if [ -f "install/setup.bash" ]; then
-        source "install/setup.bash"
-    fi
+    # Source the full workspace environment (jazzy + all layers in order).
+    # This script has no other environment setup — it previously leaned on the
+    # layer's baked chained install/setup.bash to pull in jazzy and lower
+    # layers, but baked chains go stale/polluted (#559); the workspace
+    # setup.bash is now cheap (~0.5s) and always current.
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/setup.bash" > /dev/null
 else
     echo "❌ Error: Could not locate layer for '$PKG'."
     echo "Search locations checked:"

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -119,17 +119,19 @@ export ROS2_LAYERS_BASE="$WORKTREE_DIR"
 SETUP_VARS2
     printf 'export ROS2_WORKSPACE_ROOT=%q\n\n' "$main_root" >> "$wt_dir/setup.bash"
 
-    # Source each layer's install/setup.bash
+    # Source each layer's install/local_setup.bash (current layer only, not
+    # the baked chained setup.bash) — runtime chaining in layers.txt order is
+    # O(N) and immune to stale/polluted build-time parent chains (ADR-0016).
     cat >> "$wt_dir/setup.bash" << 'SETUP_LAYERS_HEADER'
-# 2. Source workspace layers
+# 2. Source workspace layers (runtime chaining, see ADR-0016)
 echo "Sourcing ROS2 Agent Workspace layers..."
 SETUP_LAYERS_HEADER
 
     for layer in "${layers[@]}"; do
         cat >> "$wt_dir/setup.bash" << SETUP_LAYER
-if [ -f "\$WORKTREE_DIR/${layer}_ws/install/setup.bash" ]; then
+if [ -f "\$WORKTREE_DIR/${layer}_ws/install/local_setup.bash" ]; then
     echo "  - Sourcing ${layer}..."
-    source "\$WORKTREE_DIR/${layer}_ws/install/setup.bash"
+    source "\$WORKTREE_DIR/${layer}_ws/install/local_setup.bash"
 elif [ -d "\$WORKTREE_DIR/${layer}_ws/src" ]; then
     echo "  ! Warning: ${layer} exists but is not built."
 fi
@@ -272,12 +274,14 @@ COLCON_DEFAULTS
         preamble+="    echo \"ERROR: /opt/ros/jazzy/setup.bash not found. Please install ROS 2 Jazzy.\" 1>&2"$'\n'
         preamble+="    exit 1"$'\n'
         preamble+="fi"$'\n'
+        # Lower layers via local_setup.bash (jazzy base is sourced above;
+        # runtime chaining avoids stale baked parent chains — ADR-0016)
         for prev_layer in "${layers[@]}"; do
             if [ "$prev_layer" == "$layer" ]; then
                 break
             fi
-            preamble+="if [ -f \"$wt_dir/${prev_layer}_ws/install/setup.bash\" ]; then"$'\n'
-            preamble+="    source \"$wt_dir/${prev_layer}_ws/install/setup.bash\""$'\n'
+            preamble+="if [ -f \"$wt_dir/${prev_layer}_ws/install/local_setup.bash\" ]; then"$'\n'
+            preamble+="    source \"$wt_dir/${prev_layer}_ws/install/local_setup.bash\""$'\n'
             preamble+="fi"$'\n'
         done
 

--- a/.agent/work-plans/issue-559/plan.md
+++ b/.agent/work-plans/issue-559/plan.md
@@ -31,8 +31,11 @@ environment correctly with O(N) work and canonical precedence.
    highest precedence, which is correct colcon semantics.
 
 2. **Fix `build.sh` layer-list load** — replace the blind
-   `source "$SCRIPT_DIR/setup.bash"` (line 78) with a targeted parse of
-   `layers.txt` to populate the `LAYERS` array. After building each layer,
+   `source "$SCRIPT_DIR/setup.bash"` (line 78) with sourcing
+   `/opt/ros/jazzy/setup.bash` (the base only — the first `colcon build` needs a
+   ROS environment; sourcing layer overlays pre-build is the pollution bug being
+   fixed) plus a targeted parse of `layers.txt` to populate the `LAYERS` array
+   (same worktree-aware fallback as `setup.bash`). After building each layer,
    continue sourcing `install/local_setup.bash` (not `install/setup.bash`) for
    progressive chaining (line 126–127 pattern stays, file changes).
 
@@ -45,11 +48,18 @@ environment correctly with O(N) work and canonical precedence.
    lines 279–281: the preamble for each layer sources prior layers via
    `install/setup.bash`; change to `install/local_setup.bash`.
 
-5. **Fix `test.sh`** — lines 97–98 source `install/setup.bash` to stack
-   layers between test runs; change to `install/local_setup.bash`.
+5. **Fix `test.sh`** — lines 97–98 source `install/setup.bash` per layer inside
+   the test loop; safe to change to `install/local_setup.bash` because line 61
+   already sources the full workspace environment via
+   `.agent/scripts/setup.bash` before the loop.
 
-6. **Fix `verify_change.sh`** — lines 63–64: same pattern; change to
-   `install/local_setup.bash`.
+6. **Fix `verify_change.sh`** — lines 63–64. *Deviation from the reviewed plan,
+   found during implementation*: unlike `test.sh`, this script never sources the
+   workspace environment — it depends **entirely** on the layer's baked chained
+   `install/setup.bash` to bring in jazzy and lower layers, so a naive swap to
+   `local_setup.bash` would strip the ROS base out of its test environment.
+   Correct fix: source `.agent/scripts/setup.bash` (fast after step 1) instead of
+   the layer's baked chain.
 
 7. **Write an ADR** (`docs/decisions/0016-runtime-vs-baked-layer-chaining.md`)
    recording the decision to use runtime chaining (`local_setup.bash`) rather than
@@ -63,10 +73,31 @@ environment correctly with O(N) work and canonical precedence.
    bottom-up clean rebuild needed to heal polluted baked chains in existing
    installations. This is an operator step, not an automated script change.
 
-10. **Sweep result** — the grep in step 5–6 finds all remaining
-    `install/setup.bash` references in `.agent/`. `dashboard.sh:197` uses it only
-    for existence check (`-f`), which is unaffected. No other callers need
-    updating.
+10. **Sweep result** — full grep of `install/setup.bash` across `.agent/`,
+    triaged:
+    - `dashboard.sh:197` — existence check (`-f`) only; unaffected, no change.
+    - `.agent/templates/ci_workflow.yml:76` — **excluded**: sources a single
+      built `ws` in a flat CI workspace, no layered chaining, so neither the
+      O(N²) cost nor the precedence bug applies.
+    - `.agent/knowledge/ros2_development_patterns.md:154–155` — **updated**
+      (step 11): it documents the exact chained-ascending anti-pattern this PR
+      removes.
+    - Legacy work plans (`PLAN_ISSUE-324.md`, `PLAN_ISSUE-356.md`) — historical
+      records, not touched.
+
+11. **Update `ros2_development_patterns.md`** — replace the Environment
+    Sourcing Order example (chained `install/setup.bash` per layer) with the
+    runtime-chaining pattern (jazzy base + per-layer `local_setup.bash`).
+
+12. **Regression guard** (review-issue Action #4, operator-approved) — new
+    `.agent/scripts/test_layer_sourcing.sh` wired into `make validate`:
+    (a) asserts the sourced `AMENT_PREFIX_PATH` layer order matches `layers.txt`
+    reversed (top layer first, underlay just above jazzy) — catches precedence
+    inversion; (b) asserts each built layer's baked chain
+    (`COLCON_CURRENT_PREFIX` lines in `install/setup.sh`) references only jazzy
+    and strictly-lower layers — catches a `build.sh` pollution regression and
+    flags unhealed installs needing the one-time clean rebuild. Skips cleanly
+    (exit 0 with notice) when no layers are built, so CI is unaffected.
 
 ## Files to Change
 
@@ -76,7 +107,10 @@ environment correctly with O(N) work and canonical precedence.
 | `.agent/scripts/build.sh` | Line 78: replace `source setup.bash` with direct layers.txt parse; lines 126–127: `install/setup.bash` → `install/local_setup.bash` |
 | `.agent/scripts/worktree_create.sh` | Lines 130,132: generated setup.bash uses `local_setup.bash`; lines 279–281: build preamble uses `local_setup.bash` |
 | `.agent/scripts/test.sh` | Lines 97–98: `install/setup.bash` → `install/local_setup.bash` |
-| `.agent/scripts/verify_change.sh` | Lines 63–64: `install/setup.bash` → `install/local_setup.bash` |
+| `.agent/scripts/verify_change.sh` | Lines 63–64: source workspace `setup.bash` instead of the layer's baked chain (see step 6 deviation) |
+| `.agent/scripts/test_layer_sourcing.sh` | New regression guard: precedence order + baked-chain purity (step 12) |
+| `Makefile` | `validate` target also runs `test_layer_sourcing.sh` |
+| `.agent/knowledge/ros2_development_patterns.md` | Environment Sourcing Order example → runtime chaining (step 11) |
 | `docs/decisions/0016-runtime-vs-baked-layer-chaining.md` | New ADR documenting runtime chaining decision |
 | `.agent/WORKTREE_GUIDE.md` | Note in generated-scripts table about `local_setup.bash` |
 

--- a/.agent/work-plans/issue-559/plan.md
+++ b/.agent/work-plans/issue-559/plan.md
@@ -1,0 +1,116 @@
+# Plan: Fix O(N²) layer sourcing and inverted overlay precedence in setup.bash
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/559
+
+## Context
+
+`.agent/scripts/setup.bash` sources `install/setup.bash` (the baked chained
+version) for each layer. Each chained file re-sources its entire parent chain via
+Python helpers, producing O(N²) work: 7 layers × 7 chain expansions ≈ 4.5s per
+invocation, vs. 0.5s for `local_setup.bash` (current layer only).
+
+Two correctness bugs compound this:
+1. **Inverted precedence**: sourcing chained files in ascending order gives
+   `underlay` higher `AMENT_PREFIX_PATH` priority than overlays — the reverse of
+   colcon's intended semantics.
+2. **`build.sh` pollutes baked chains**: line 78 does
+   `source "$SCRIPT_DIR/setup.bash"` before building any layer, so when
+   `underlay_ws` is (re)built, colcon records all other layers as its parents.
+
+`local_setup.bash` sets up only the current layer's prefixes; runtime chaining
+(source jazzy → source each `local_setup.bash` in order) reproduces the full
+environment correctly with O(N) work and canonical precedence.
+
+## Approach
+
+1. **Fix `setup.bash` inner loop** — change `install/setup.bash` →
+   `install/local_setup.bash` (line 86). Source jazzy is already at the top; the
+   loop order (ascending layers.txt) naturally gives the last-sourced layer
+   highest precedence, which is correct colcon semantics.
+
+2. **Fix `build.sh` layer-list load** — replace the blind
+   `source "$SCRIPT_DIR/setup.bash"` (line 78) with a targeted parse of
+   `layers.txt` to populate the `LAYERS` array. After building each layer,
+   continue sourcing `install/local_setup.bash` (not `install/setup.bash`) for
+   progressive chaining (line 126–127 pattern stays, file changes).
+
+3. **Fix generated worktree `setup.bash`** in `worktree_create.sh`
+   `generate_worktree_scripts()` — lines 129–136: change
+   `install/setup.bash` → `install/local_setup.bash` in the generated per-layer
+   conditionals.
+
+4. **Fix generated per-layer `build.sh` preamble** in `worktree_create.sh` —
+   lines 279–281: the preamble for each layer sources prior layers via
+   `install/setup.bash`; change to `install/local_setup.bash`.
+
+5. **Fix `test.sh`** — lines 97–98 source `install/setup.bash` to stack
+   layers between test runs; change to `install/local_setup.bash`.
+
+6. **Fix `verify_change.sh`** — lines 63–64: same pattern; change to
+   `install/local_setup.bash`.
+
+7. **Write an ADR** (`docs/decisions/0016-runtime-vs-baked-layer-chaining.md`)
+   recording the decision to use runtime chaining (`local_setup.bash`) rather than
+   baked chaining (`setup.bash`). Issue review flagged this as an ADR-0001 trigger.
+
+8. **Update `WORKTREE_GUIDE.md`** — brief note in the generated-scripts table that
+   the generated `setup.bash` sources `local_setup.bash` per layer (not the baked
+   chain).
+
+9. **One-time clean rebuild instructions in PR description** — document the manual
+   bottom-up clean rebuild needed to heal polluted baked chains in existing
+   installations. This is an operator step, not an automated script change.
+
+10. **Sweep result** — the grep in step 5–6 finds all remaining
+    `install/setup.bash` references in `.agent/`. `dashboard.sh:197` uses it only
+    for existence check (`-f`), which is unaffected. No other callers need
+    updating.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/setup.bash` | Line 86: `install/setup.bash` → `install/local_setup.bash` |
+| `.agent/scripts/build.sh` | Line 78: replace `source setup.bash` with direct layers.txt parse; lines 126–127: `install/setup.bash` → `install/local_setup.bash` |
+| `.agent/scripts/worktree_create.sh` | Lines 130,132: generated setup.bash uses `local_setup.bash`; lines 279–281: build preamble uses `local_setup.bash` |
+| `.agent/scripts/test.sh` | Lines 97–98: `install/setup.bash` → `install/local_setup.bash` |
+| `.agent/scripts/verify_change.sh` | Lines 63–64: `install/setup.bash` → `install/local_setup.bash` |
+| `docs/decisions/0016-runtime-vs-baked-layer-chaining.md` | New ADR documenting runtime chaining decision |
+| `.agent/WORKTREE_GUIDE.md` | Note in generated-scripts table about `local_setup.bash` |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Enforcement over documentation | Behavioral fix; ADR prevents reversion by documenting the why |
+| A change includes its consequences | Sweep of all `install/setup.bash` callers included; WORKTREE_GUIDE updated |
+| Only what's needed | No changes outside the five scripts, ADR, and guide update |
+| Test what breaks | Manual verification steps below; dashboard.sh existence check unaffected |
+| Improve incrementally | Single PR; existing worktrees age out naturally |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0001 — Adopt ADRs | Yes | New ADR-0016 records runtime-vs-baked decision |
+| ADR-0007 — Retain Make with Dependency Tracking | Watch | `build.sh` change must not break Make stamp-file semantics; `make build` calls `build.sh`, which still builds layers in order and sources each on success |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `setup.bash` inner loop | `worktree_create.sh` generated `setup.bash` template | Yes — step 3 |
+| `build.sh` sourcing | progressive `install/setup.bash` refs in build loop | Yes — step 2 |
+| Generated worktree scripts | `WORKTREE_GUIDE.md` generated-scripts description | Yes — step 8 |
+| All `install/setup.bash` callers | `test.sh`, `verify_change.sh` | Yes — steps 5–6 |
+| Design decision in scripts | ADR to prevent future reversion | Yes — step 7 |
+
+## Open Questions
+
+- [ ] No open questions — plan is review-plan-ready.
+
+## Estimated Scope
+
+Single PR. All changes in workspace infrastructure; no ROS package modifications.

--- a/.agent/work-plans/issue-559/progress.md
+++ b/.agent/work-plans/issue-559/progress.md
@@ -92,3 +92,25 @@ worktree_create.sh) requires:
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-14 13:02 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-559/plan.md` at `057f99a`
+**PR**: PR-less (`--issue 559`, host-dispatched sub-agent, no GitHub auth)
+**Verdict**: changes-requested
+
+### Findings
+- [ ] (must-fix) `build.sh` step 2 must retain the ROS 2 base source. Line 78's `source "$SCRIPT_DIR/setup.bash"` currently supplies both the `LAYERS` array *and* `/opt/ros/jazzy/setup.bash`. The plan replaces it with "a targeted parse of `layers.txt` to populate the `LAYERS` array" only — a literal implementation drops the jazzy base, so the first `colcon build` (underlay) has no ROS environment and `make build` breaks. The replacement must still source `/opt/ros/jazzy/setup.bash` (the base only, NOT the layer overlays — sourcing overlays pre-build is the pollution bug being fixed). — `plan.md:33-37`
+- [ ] (suggestion) Sweep-completeness claim is overstated. Step 10 says the grep "finds all remaining `install/setup.bash` references in `.agent/`" and "No other callers need updating," but the sweep also hits `.agent/templates/ci_workflow.yml:76` and `.agent/knowledge/ros2_development_patterns.md:154-155`. Both are legitimately out of scope (ci_workflow sources a single built `ws`, not layered chaining; the knowledge doc is illustrative), but the plan should explicitly triage-and-exclude them with a reason rather than assert they don't exist. — `plan.md:66-69`
+- [ ] (suggestion) `ros2_development_patterns.md:154-155` documents sourcing each layer's `install/setup.bash` in ascending order — the exact O(N²)/inverted-precedence anti-pattern being fixed. Consider updating it to `local_setup.bash` (with an explicit `source /opt/ros/jazzy/setup.bash` first) or noting it's illustrative-only. Minor; acceptable as a follow-up.
+- [ ] (suggestion) review-issue Action #4 (automated timing/correctness regression check) is unaddressed. The plan's "Test what breaks" row lists only manual verification. Adopt a lightweight check (timed `source` assertion or a `validate` target) or explicitly defer it with a reason — right now it is silently dropped.
+
+### Notes on verified strengths
+- All plan line numbers confirmed against source: `setup.bash:86`, `build.sh:78`/`126-127`, `worktree_create.sh:130`/`132`/`279-281`, `test.sh:97-98`, `verify_change.sh:63-64`.
+- ADR-0016 is the correct next number; ADR-0001 trigger is valid.
+- Generated worktree `setup.bash` (worktree_create.sh:91) and the per-layer build preamble (worktree_create.sh:269) already source the jazzy base explicitly, so switching *their* layer sourcing to `local_setup.bash` is safe — no ROS-base regression there.
+- `dashboard.sh:197` correctly excluded (existence check only).
+- review-issue Actions #1 (ADR → step 7) and #3 (WORKTREE_GUIDE → step 8) are addressed.

--- a/.agent/work-plans/issue-559/progress.md
+++ b/.agent/work-plans/issue-559/progress.md
@@ -203,3 +203,21 @@ Lifecycle: **Implementation** → **review-code** (re-review the fixes). Hand of
 - [x] (suggestion) fallback LAYERS lists include site, synced build.sh + setup.bash (`9073b0e`)
 - [x] (suggestion) guard Check 1 recursive over .agent/scripts + .agent/hooks (`9073b0e`)
 - [x] (suggestion) guard Check 2 first-occurrence dedup replaces adjacent-only uniq (`9073b0e`)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-14 11:05 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #565 at `d19d3eb`
+**Sources**: 3 (Copilot R1 @ `d19d3eb`, Local Review (Pre-Push) R1 @ `080bd75` + R2 @ `7902bf3`, CI rollup)
+**Cross-source confirmations**: 0
+**CI**: all-pass (commit identity, script tests, docs validation, lint)
+
+### Findings
+(none — Copilot reviewed 13/13 files, generated no comments; both local
+pre-push rounds' findings were addressed pre-publish and verified at
+`d19d3eb`)
+
+### False positives
+(none)

--- a/.agent/work-plans/issue-559/progress.md
+++ b/.agent/work-plans/issue-559/progress.md
@@ -1,0 +1,82 @@
+---
+issue: 559
+---
+
+# Issue #559 — Fix O(N²) layer sourcing and inverted overlay precedence in setup.bash
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-14 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #559
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Summary
+
+The issue identifies two correctness bugs and one performance problem in
+`.agent/scripts/setup.bash` and `.agent/scripts/build.sh`, with benchmarks,
+root-cause analysis, and a concrete five-step fix. The root causes are verified
+by reading the actual scripts:
+
+- **`setup.bash:86`**: sources `install/setup.bash` (baked chained version)
+  instead of `install/local_setup.bash`, causing O(N²) Python invocations (one
+  full chain expansion per layer). Confirmed in code.
+- **`build.sh:78`**: `source "$SCRIPT_DIR/setup.bash" > /dev/null` before
+  building any layer loads the full ROS 2 prefix path, so when colcon builds
+  `underlay_ws` first, every other layer is already present as a parent — baked
+  into `underlay_ws/install/setup.sh` permanently. Confirmed in code.
+- **Inverted precedence**: result of sourcing in ascending order with chained
+  setup; the fast alternative produces correct canonical order.
+
+### Scope Assessment
+
+**Well-scoped?** Yes — change is bounded to `.agent/scripts/` (setup.bash,
+build.sh, worktree_create.sh templates) plus a one-time clean rebuild. Single PR.
+**Right repo?** Yes — workspace infrastructure, not project-repo content.
+**Dependencies?** None identified. A one-time clean rebuild is a manual step (not
+a script dependency), documented in the issue.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | Issue documents root cause, benchmarks, and expected outcomes clearly |
+| Enforcement over documentation | OK | Fix is behavioral, not documentation-only |
+| Capture decisions, not just implementations | Watch | Switching from `install/setup.bash` to `install/local_setup.bash` (runtime vs baked chaining) is a design choice worth an ADR; it isn't currently documented in `docs/decisions/` |
+| A change includes its consequences | Watch | Issue mentions sweeping `.agent/` for other `install/setup.bash` references and updating generated worktree scripts; existing worktrees age out. Implementer should track the sweep explicitly — grep result should appear in the PR. `WORKTREE_GUIDE.md` may need a note about the generated-script change |
+| Only what's needed | OK | Solves concrete, measured pain (4.5s → 0.5s per agent command); no speculative scope |
+| Improve incrementally | OK | Five-step plan is bounded; step 3 (worktree generators) is a natural scope inclusion to prevent regressions on new worktrees |
+| Test what breaks | Watch | Verification section lists manual timing/diff steps, not automated tests. The timing regression would be easy to catch with a timed `source` in CI; the precedence correctness could be checked with a script. Consider adding at least one automated check |
+| Workspace vs. project separation | OK | All changes in workspace infra scripts |
+| Workspace improvements cascade to projects | OK | Generated worktree scripts get the fix; existing worktrees noted as aging out naturally |
+| Primary framework first, portability where free | OK | No framework coupling in these shell scripts |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| 0001 — Adopt ADRs | Yes | The switch from baked-chain (`setup.bash`) to runtime-chain (`local_setup.bash`) sourcing is a design decision that future agents need to understand — should be recorded |
+| 0002 — Worktree isolation | OK | Standard; use worktree for implementation |
+| 0007 — Retain Make with Dependency Tracking | Watch | `build.sh` change should not break Make's stamp-file dependency semantics; verify `make build` still works correctly end-to-end |
+| 0013 — progress.md entry-type vocabulary | OK | This entry follows the Issue Review type per ADR-0013 |
+
+### Consequences
+
+Per the consequences map, changing `.agent/scripts/` (setup.bash, build.sh,
+worktree_create.sh) requires:
+- **AGENTS.md script reference table** — descriptions reference script purpose
+  only, not implementation; minor note may still be warranted if the semantics
+  change visibly (e.g., "sources `local_setup.bash` per layer").
+- **`.agent/WORKTREE_GUIDE.md`** — documents generated worktree scripts; if the
+  generated preambles change, the guide should reflect it.
+- **Sweep result** — grep for direct `install/setup.bash` sourcing across
+  `.agent/` (container/dispatch flows, other hooks) should be documented in the
+  PR; this is listed in the issue but not tracked as an explicit checklist item.
+
+### Actions
+- [ ] Record the runtime-vs-baked chaining design decision in an ADR (ADR-0001 trigger — strongly recommended before or alongside implementation to prevent accidental reversion by a future agent).
+- [ ] Sweep `.agent/` for all direct `install/setup.bash` sourcing; document findings in PR description.
+- [ ] Update `.agent/WORKTREE_GUIDE.md` if generated worktree script preambles change.
+- [ ] Consider adding an automated timing/correctness check (e.g., timed `source` assertion in CI or a Makefile validate target) to prevent O(N²) regression.

--- a/.agent/work-plans/issue-559/progress.md
+++ b/.agent/work-plans/issue-559/progress.md
@@ -188,3 +188,18 @@ Lifecycle: **Implementation** → **review-code** (re-review the fixes). Hand of
 - All 4 round-1 findings confirmed addressed in the branch diff.
 - Two independent adversarial passes (Lens A logic, Lens B systemic) both confirmed runtime-chaining equivalence to a clean baked chain and the real-world pollution it fixes; empirically verified jazzy does not clear `COLCON_PREFIX_PATH` and `make build` inherits it.
 - Full plan adherence; `verify_change.sh` deviation documented and correct. Consequences map (AGENTS.md table, WORKTREE_GUIDE, ros2_development_patterns) all addressed. Sweep complete (`ci_workflow.yml:76` out of scope; `dashboard.sh:197` existence check only).
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-14 10:49 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**Branch**: feature/issue-559 at `9073b0e`
+**Addressed**: Local Review (Pre-Push) — 2026-07-14 14:43 +00:00, Round 2 (Ship: recommended — remaining findings host-applied instead of a full round 3)
+**Commits**: `9073b0e`
+
+### Actions
+- [x] (must-fix) build.sh scrubs inherited COLCON/AMENT/CMAKE prefix paths before sourcing jazzy; verified scrub reproduces pristine-shell env (`9073b0e`)
+- [x] (suggestion) fallback LAYERS lists include site, synced build.sh + setup.bash (`9073b0e`)
+- [x] (suggestion) guard Check 1 recursive over .agent/scripts + .agent/hooks (`9073b0e`)
+- [x] (suggestion) guard Check 2 first-occurrence dedup replaces adjacent-only uniq (`9073b0e`)

--- a/.agent/work-plans/issue-559/progress.md
+++ b/.agent/work-plans/issue-559/progress.md
@@ -80,3 +80,15 @@ worktree_create.sh) requires:
 - [ ] Sweep `.agent/` for all direct `install/setup.bash` sourcing; document findings in PR description.
 - [ ] Update `.agent/WORKTREE_GUIDE.md` if generated worktree script preambles change.
 - [ ] Consider adding an automated timing/correctness check (e.g., timed `source` assertion in CI or a Makefile validate target) to prevent O(N²) regression.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-14 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-559/plan.md` at `057f99a`
+**Branch**: feature/issue-559 at `057f99a`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-559/progress.md
+++ b/.agent/work-plans/issue-559/progress.md
@@ -128,10 +128,10 @@ worktree_create.sh) requires:
 **Round**: 1 | **Ship**: continue — one mechanical consequence fix (AGENTS.md table); all else are low-impact robustness suggestions
 
 ### Findings
-- [ ] (must-fix) New script `test_layer_sourcing.sh` not added to AGENTS.md Script Reference table — consequences map mandates it (`principles_review_guide.md:45`); precedent at `AGENTS.md:489` — `AGENTS.md`
-- [ ] (suggestion) Guard `LAYERS_BASE` not worktree-aware (asymmetric with worktree-aware `LAYERS_CONFIG`); Checks 2-3 silently skip in a layer worktree; sed at :92 is `layers/main`-specific — `.agent/scripts/test_layer_sourcing.sh:30,92` [cross-confirmed: Lens A + Lens B]
-- [ ] (suggestion) Trailing-whitespace strip diverges: guard strips, `setup.bash`/`build.sh` don't — align all three — `.agent/scripts/setup.bash:76`, `.agent/scripts/build.sh:105`, `.agent/scripts/test_layer_sourcing.sh:74` [cross-confirmed: Lens A + Lens B]
-- [ ] (suggestion) Check 1 static allowlist is a hardcoded 5-file list; a future baked-chain source escapes the guard — prefer a repo-wide `.agent/scripts/*.sh` glob — `.agent/scripts/test_layer_sourcing.sh:37`
+- [x] (must-fix) New script `test_layer_sourcing.sh` not added to AGENTS.md Script Reference table — consequences map mandates it (`principles_review_guide.md:45`); precedent at `AGENTS.md:489` — `AGENTS.md`
+- [x] (suggestion) Guard `LAYERS_BASE` not worktree-aware (asymmetric with worktree-aware `LAYERS_CONFIG`); Checks 2-3 silently skip in a layer worktree; sed at :92 is `layers/main`-specific — `.agent/scripts/test_layer_sourcing.sh:30,92` [cross-confirmed: Lens A + Lens B]
+- [x] (suggestion) Trailing-whitespace strip diverges: guard strips, `setup.bash`/`build.sh` don't — align all three — `.agent/scripts/setup.bash:76`, `.agent/scripts/build.sh:105`, `.agent/scripts/test_layer_sourcing.sh:74` [cross-confirmed: Lens A + Lens B]
+- [x] (suggestion) Check 1 static allowlist is a hardcoded 5-file list; a future baked-chain source escapes the guard — prefer a repo-wide `.agent/scripts/*.sh` glob — `.agent/scripts/test_layer_sourcing.sh:37`
 
 ### Notes on verified strengths
 - shellcheck `--severity=warning` clean on all 6 changed shell scripts.
@@ -140,3 +140,27 @@ worktree_create.sh) requires:
 - Full plan adherence: every planned file changed, no scope creep; `verify_change.sh` deviation (source workspace `setup.bash`, not a naive `local_setup.bash` swap) transparently documented and correct.
 - `build.sh` retains the jazzy base pre-build (plan-review must-fix addressed) and sources lower layers progressively post-build; no chain pollution.
 - Sweep complete: only other baked-chain source is `ci_workflow.yml:76` (flat project CI template, out of scope); `dashboard.sh:197` is `-f` existence check only.
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-14 14:33 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-559 at `7902bf3`
+**Addressed**: Local Review (Pre-Push) — 2026-07-14 14:21 +00:00, branch at `080bd75`
+**Commits**: `d7d0376`, `5eb17f4`, `fb7ebd0`, `7902bf3`
+
+### Actions
+- [x] (must-fix) Added `test_layer_sourcing.sh` row to the AGENTS.md Script Reference table (next to the other regression-test scripts) — `AGENTS.md:490` (`d7d0376`)
+- [x] (suggestion) Trailing-whitespace strip aligned across all three layers.txt readers: added `sed 's/[[:space:]]*$//'` to `setup.bash` and `build.sh` so a stray trailing space can't yield a bad `<layer> _ws` path — `.agent/scripts/setup.bash:78`, `.agent/scripts/build.sh:105` (`5eb17f4`)
+- [x] (suggestion) Made the guard's `LAYERS_BASE` worktree-aware: derive one `MAIN_ROOT` and set both `LAYERS_CONFIG` and `LAYERS_BASE` from it, and pass `ROS2_LAYERS_BASE` into Check 2's scrubbed env so `setup.bash` sources the same built layers (keeps the `/layers/main/` sed correct from a layer worktree instead of silently skipping) — `.agent/scripts/test_layer_sourcing.sh:28-30,61-83,85-100` (`fb7ebd0`)
+- [x] (suggestion) Replaced Check 1's hardcoded 5-file allowlist with a repo-wide `.agent/scripts/*.sh`/`*.bash` glob (self-excluded via `-ef`, loose pattern kept so heredoc-generated regressions are still caught) — `.agent/scripts/test_layer_sourcing.sh:36-53` (`7902bf3`)
+
+### Verification
+- `shellcheck --severity=warning` clean on `setup.bash`, `build.sh`, `test_layer_sourcing.sh`.
+- Guard runs green here (Check 1 passes, Checks 2-3 skip — no built layers, expected in CI); positive-tested that a fresh script with a direct *and* a heredoc-builder baked-chain `source` is flagged (exit 1), confirming self-exclusion doesn't blind the glob.
+
+### Next step
+Lifecycle: **Implementation** → **review-code** (re-review the fixes). Hand off to a fresh-context sub-agent:
+
+    .agent/scripts/dispatch_subagent.sh --mode in-process --issue 559 --skill review-code

--- a/.agent/work-plans/issue-559/progress.md
+++ b/.agent/work-plans/issue-559/progress.md
@@ -164,3 +164,27 @@ worktree_create.sh) requires:
 Lifecycle: **Implementation** → **review-code** (re-review the fixes). Hand off to a fresh-context sub-agent:
 
     .agent/scripts/dispatch_subagent.sh --mode in-process --issue 559 --skill review-code
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-14 14:43 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-559 at `e41b4b6`
+**Mode**: pre-push
+**Depth**: Deep (reason: new ADR + cross-cutting environment-sourcing change across 6 scripts)
+**Must-fix**: 1 | **Suggestions**: 3
+**Round**: 2 | **Ship**: recommended — one mechanical one-line env scrub (not rising, obvious correction); a full re-review round isn't warranted for it
+
+### Findings
+- [ ] (must-fix) `build.sh` doesn't scrub an inherited `COLCON_PREFIX_PATH`; sourcing jazzy doesn't clear it and `make build` passes it through, so `source setup.bash; make build` (and the ADR's own heal command in a sourced shell) re-bakes higher layers into lower chains — reintroducing ADR problem #3. Add `unset COLCON_PREFIX_PATH AMENT_PREFIX_PATH CMAKE_PREFIX_PATH AMENT_CURRENT_PREFIX` before sourcing jazzy — `.agent/scripts/build.sh:76-90`
+- [ ] (suggestion) Fallback `LAYERS` array omits `site` (present in real layers.txt); introduces a second stale copy alongside `setup.bash:82` — sync both — `.agent/scripts/build.sh:110`
+- [ ] (suggestion) Check 1 comment says "repo-wide glob" but scan is top-level `.agent/scripts/*.sh` only (misses `tests/`, `.agent/hooks/`); make recursive or narrow the comment — `.agent/scripts/test_layer_sourcing.sh:37-43`
+- [ ] (suggestion) Check 2 `uniq` collapses only adjacent duplicates; fragile if a layer ever contributes non-adjacent AMENT prefixes — note or first-occurrence dedup — `.agent/scripts/test_layer_sourcing.sh:105-107`
+
+### Notes on verified strengths
+- shellcheck `--severity=warning` clean on all 6 changed shell scripts; guard runs green here (Check 1 pass, Checks 2-3 skip — no built layers).
+- All 4 round-1 findings confirmed addressed in the branch diff.
+- Two independent adversarial passes (Lens A logic, Lens B systemic) both confirmed runtime-chaining equivalence to a clean baked chain and the real-world pollution it fixes; empirically verified jazzy does not clear `COLCON_PREFIX_PATH` and `make build` inherits it.
+- Full plan adherence; `verify_change.sh` deviation documented and correct. Consequences map (AGENTS.md table, WORKTREE_GUIDE, ros2_development_patterns) all addressed. Sweep complete (`ci_workflow.yml:76` out of scope; `dashboard.sh:197` existence check only).

--- a/.agent/work-plans/issue-559/progress.md
+++ b/.agent/work-plans/issue-559/progress.md
@@ -114,3 +114,29 @@ worktree_create.sh) requires:
 - Generated worktree `setup.bash` (worktree_create.sh:91) and the per-layer build preamble (worktree_create.sh:269) already source the jazzy base explicitly, so switching *their* layer sourcing to `local_setup.bash` is safe — no ROS-base regression there.
 - `dashboard.sh:197` correctly excluded (existence check only).
 - review-issue Actions #1 (ADR → step 7) and #3 (WORKTREE_GUIDE → step 8) are addressed.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-14 14:21 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-559 at `080bd75`
+**Mode**: pre-push
+**Depth**: Deep (reason: ADR addition + 585 lines >200 + 12 files >10)
+**Must-fix**: 1 | **Suggestions**: 3
+**Round**: 1 | **Ship**: continue — one mechanical consequence fix (AGENTS.md table); all else are low-impact robustness suggestions
+
+### Findings
+- [ ] (must-fix) New script `test_layer_sourcing.sh` not added to AGENTS.md Script Reference table — consequences map mandates it (`principles_review_guide.md:45`); precedent at `AGENTS.md:489` — `AGENTS.md`
+- [ ] (suggestion) Guard `LAYERS_BASE` not worktree-aware (asymmetric with worktree-aware `LAYERS_CONFIG`); Checks 2-3 silently skip in a layer worktree; sed at :92 is `layers/main`-specific — `.agent/scripts/test_layer_sourcing.sh:30,92` [cross-confirmed: Lens A + Lens B]
+- [ ] (suggestion) Trailing-whitespace strip diverges: guard strips, `setup.bash`/`build.sh` don't — align all three — `.agent/scripts/setup.bash:76`, `.agent/scripts/build.sh:105`, `.agent/scripts/test_layer_sourcing.sh:74` [cross-confirmed: Lens A + Lens B]
+- [ ] (suggestion) Check 1 static allowlist is a hardcoded 5-file list; a future baked-chain source escapes the guard — prefer a repo-wide `.agent/scripts/*.sh` glob — `.agent/scripts/test_layer_sourcing.sh:37`
+
+### Notes on verified strengths
+- shellcheck `--severity=warning` clean on all 6 changed shell scripts.
+- Guard runs in CI: `run_script_tests.sh` auto-discovers `test_*.sh` (glob) → `make test-scripts` (validate.yml:71) runs Check 1; Checks 2-3 skip cleanly with no built layers. Also wired into `make validate`.
+- Overlay precedence logic verified against colcon `local_setup` prepend semantics — ADR-0016 claim, Check 2 `EXPECTED_ORDER`, and actual behavior agree.
+- Full plan adherence: every planned file changed, no scope creep; `verify_change.sh` deviation (source workspace `setup.bash`, not a naive `local_setup.bash` swap) transparently documented and correct.
+- `build.sh` retains the jazzy base pre-build (plan-review must-fix addressed) and sources lower layers progressively post-build; no chain pollution.
+- Sweep complete: only other baked-chain source is `ci_workflow.yml:76` (flat project CI template, out of scope); `dashboard.sh:197` is `-f` existence check only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,6 +487,7 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/fetch_pr_reviews.sh` | Fetch all PR reviews and CI status |
 | `.agent/scripts/progress_read.py` | Extract `progress.md` entries by type + correlation key as JSON (consumed by `triage-reviews` integrator) |
 | `.agent/scripts/test_check_commit_identity.sh` | Regression test for `check-commit-identity.py` branch+env gate |
+| `.agent/scripts/test_layer_sourcing.sh` | Regression guard for runtime layer chaining (ADR-0016 / #559): static no-baked-chain-source check + built-layer overlay precedence + baked-chain purity; run by `make test-scripts` / `make validate` |
 | `.agent/hooks/identity_patterns.py` | Shared agent/human email patterns + agent-branch regex (imported by commit-identity hooks + CI script) |
 | `.agent/hooks/check_pr_authors.py` | CI-callable PR-commit author validator (Mechanism C from issue #468) |
 

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ test-scripts:
 
 validate:
 	@python3 ./.agent/scripts/validate_workspace.py
+	@./.agent/scripts/test_layer_sourcing.sh
 
 # =============================================================================
 # Tier 1 — Setup chain (stamp-based dependencies)

--- a/docs/decisions/0016-runtime-vs-baked-layer-chaining.md
+++ b/docs/decisions/0016-runtime-vs-baked-layer-chaining.md
@@ -1,0 +1,80 @@
+# ADR-0016: Runtime Layer Chaining via local_setup.bash (not Baked Chains)
+
+## Status
+
+Accepted.
+
+## Context
+
+Colcon generates two entry points per workspace install:
+
+- `install/setup.bash` — the **baked chain**: re-sources every parent prefix
+  recorded on `COLCON_PREFIX_PATH` *at build time*, then the workspace itself.
+- `install/local_setup.bash` — the workspace itself only.
+
+The workspace's environment scripts (`setup.bash`, `build.sh`, `test.sh`,
+`verify_change.sh`, and the worktree-generated scripts) sourced each layer's
+baked `install/setup.bash` in ascending `layers.txt` order. Investigation for
+[#559](https://github.com/rolker/ros2_agent_workspace/issues/559) found three
+compounding problems:
+
+1. **O(N²) cost.** Each baked chain re-sources its full parent list (each link
+   spawning a Python environment helper), so sourcing N layers does
+   N + (N−1) + … chain expansions. Measured on 7 built layers: **~4.5s vs
+   ~0.5s** — paid on nearly every agent build/test command.
+2. **Inverted overlay precedence.** The combination of baked chains, colcon's
+   prepend-dedup, and ascending sourcing produced an `AMENT_PREFIX_PATH` with
+   `underlay` *outranking* every overlay — the reverse of colcon's overlay
+   semantics.
+3. **Chain pollution.** `build.sh` sourced the *full* workspace environment
+   before building the first layer, so every rebuilt layer baked **all other
+   layers — including higher ones — into its parent chain** (e.g.
+   `underlay_ws` recording `ui_ws` as a parent). Every `make build` re-wrote
+   the corruption; every layer in the tree was found polluted.
+
+The baked chain is a snapshot of the build-time environment. In a layered
+workspace whose composition is defined by a config file (`layers.txt`) and
+whose layers rebuild independently, that snapshot is inherently prone to going
+stale — and, per (3), was actively wrong.
+
+## Decision
+
+**Chain layers at source time (runtime chaining), never via baked chains:**
+
+1. Source `/opt/ros/jazzy/setup.bash` once, then each built layer's
+   `install/local_setup.bash` in ascending `layers.txt` order. The last-sourced
+   (topmost) layer gets highest precedence — canonical colcon semantics,
+   decided by `layers.txt` at source time and immune to baked-chain staleness.
+2. Build steps see only the ROS base plus layers **strictly below** the layer
+   being built (sourced progressively, post-build). The full workspace
+   environment is never sourced before building — that is what polluted the
+   chains.
+3. Worktree-generated scripts (`setup.bash`, per-layer `build.sh`/`test.sh`
+   preambles) follow the same rule.
+
+The regression guard `.agent/scripts/test_layer_sourcing.sh` (run by
+`make validate`) enforces this: a static check that no workspace script
+sources a baked `install/setup.bash`, a runtime check that the sourced
+precedence order is canonical, and a warning-level purity check on the baked
+chains themselves.
+
+## Consequences
+
+- Environment setup drops from ~4.5s to ~0.5s per shell; overlay precedence is
+  canonical and deterministic.
+- Existing installs keep polluted baked chains until a **one-time bottom-up
+  clean rebuild** (`rm -rf layers/main/*_ws/{build,install,log} && make build`).
+  Runtime chaining doesn't read them, but anything sourcing a layer's
+  `install/setup.bash` directly inherits them — the guard warns until healed.
+- Sourcing a *single* layer's `install/setup.bash` by hand no longer matches
+  how the workspace composes its environment; use `.agent/scripts/setup.bash`
+  (or the worktree's generated `setup.bash`), which is now cheap.
+- Existing worktrees keep their old generated scripts (slow but functional)
+  and age out as worktrees are removed.
+
+## References
+
+- [#559](https://github.com/rolker/ros2_agent_workspace/issues/559) —
+  measurement, root-cause analysis, and implementation.
+- Colcon documentation: `setup.bash` (prefix chain) vs `local_setup.bash`
+  (single prefix).


### PR DESCRIPTION
Closes #559

## What

Replaces baked-chain layer sourcing (`install/setup.bash` per layer) with **runtime chaining** (`/opt/ros/jazzy` base once + each layer's `install/local_setup.bash` in `layers.txt` order) across the workspace scripts and worktree-generated scripts, and fixes the `build.sh` bug that was corrupting every layer's baked parent chain.

## Why (measured)

| | before | after |
|---|---|---|
| `source .agent/scripts/setup.bash` | ~4.5s (O(N²) chain re-expansion) | ~0.5s (O(N)) |
| `AMENT_PREFIX_PATH` precedence | **inverted** (underlay outranked all overlays) | canonical (ui → … → underlay → jazzy) |

Root cause of the inversion: `build.sh` sourced the full workspace env before building the first layer, so every rebuilt layer baked **all other layers — including higher ones — into its parent chain** (underlay_ws recorded ui_ws as a parent). Every `make build` re-corrupted the chains; all 7 layers are currently polluted.

## Changes

- `setup.bash` / `test.sh`: per-layer `local_setup.bash` sourcing.
- `build.sh`: scrubs inherited prefix paths, sources only the jazzy base + parses `layers.txt`, sources each layer progressively post-build — a layer is never built with higher layers in its env.
- `verify_change.sh`: sources the workspace `setup.bash` (its only env source was the stale-prone baked chain — deviation from plan, documented in `plan.md`).
- `worktree_create.sh`: generated worktree `setup.bash` + per-layer `build.sh`/`test.sh` preambles use `local_setup.bash`. Existing worktrees keep old scripts and age out.
- **New regression guard** `.agent/scripts/test_layer_sourcing.sh` (wired into `make validate`): static no-baked-chain-source scan (CI-effective), runtime precedence assertion, baked-chain purity warning.
- Docs: **ADR-0016** (runtime-vs-baked decision), `WORKTREE_GUIDE.md`, `ros2_development_patterns.md` (its sourcing example taught the exact anti-pattern), AGENTS.md Script Reference row for the new guard.

## ⚠️ One-time operator step after merge (heal polluted chains)

Runtime chaining ignores the baked chains, but anything sourcing a layer's `install/setup.bash` directly still inherits the pollution. From a **fresh shell** (build.sh now also self-scrubs):

```bash
rm -rf layers/main/*_ws/{build,install,log} && make build
```

`make validate` (Check 3) warns until healed and verifies afterward.

## Sweep triage

Full grep of `install/setup.bash` under `.agent/`: `dashboard.sh:197` is a `-f` existence check (unaffected); `.agent/templates/ci_workflow.yml:76` sources a single flat CI workspace (no layered chaining — out of scope); legacy work plans are historical records.

## Review history

Two pre-push review rounds (fresh-context container agents): round 1 `changes-requested` (AGENTS.md consequence row + 3 guard robustness fixes — applied), round 2 `Ship: recommended` (build.sh env-scrub must-fix — applied and verified: scrub + jazzy reproduces the pristine-shell env exactly).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
