### PR TITLE
Per-repo root AGENTS.md: template, ADR-0017, and skill wiring

### DIFF
--- a/.agent/knowledge/README.md
+++ b/.agent/knowledge/README.md
@@ -32,5 +32,9 @@ Project repositories may contain a `.agents/README.md` at their root with repo-s
 guidance for agents. To create one, use the template at
 [`../templates/project_agents_guide.md`](../templates/project_agents_guide.md).
 
+Project repositories should also carry a thin root `AGENTS.md` that references the
+workspace rules (read by GitHub Copilot code review). To create one, use the template at
+[`../templates/project_agents_md.md`](../templates/project_agents_md.md) (see ADR-0017).
+
 ---
 *Note: This index is manually maintained. Update it when adding new knowledge files.*

--- a/.agent/templates/project_agents_md.md
+++ b/.agent/templates/project_agents_md.md
@@ -15,6 +15,11 @@ never restate or fork them.
 
 ## Quality Standard
 
+<!-- Standalone excerpt of the workspace AGENTS.md § Quality Standard. It is
+     intentionally condensed for repos reviewed without workspace context; when
+     the workspace § Quality Standard changes materially, re-sync this excerpt
+     (the drift ADR-0017 acknowledges). -->
+
 This is software for autonomous robot boats operating on open water.
 Robustness is not optional.
 

--- a/.agent/templates/project_agents_md.md
+++ b/.agent/templates/project_agents_md.md
@@ -1,0 +1,60 @@
+# AGENTS.md — {REPO_NAME}
+
+Instructions for AI agents working in this repository — including **GitHub
+Copilot code review**, which reads this file when reviewing PRs. Coding
+agents: the deep guide (packages, layout, pitfalls) is
+[`.agents/README.md`](.agents/README.md); read it before making changes.
+
+## Workspace Rules
+
+This repo is developed inside a [ROS 2 Agent Workspace]({WORKSPACE_REPO_URL}).
+The workspace root `AGENTS.md` carries the full shared rules (worktree
+isolation, issue-first policy, commit conventions, AI signatures). This file
+**references** those rules and adds repo-specific context only — it must
+never restate or fork them.
+
+## Quality Standard
+
+This is software for autonomous robot boats operating on open water.
+Robustness is not optional.
+
+- Fix bugs completely: add the test, handle the edge case, check the
+  lifecycle transition.
+- Concerns about error handling, silent failures, stale data, or missing
+  validation are not nits — flag them unless the failure mode genuinely
+  cannot occur. "Config is under our control" and "pathological input" are
+  not blanket dismissals; field configs change under pressure.
+- A change includes its consequences: tests, documentation, and dependent
+  references update in the same PR.
+
+## Reviewing PRs
+
+- If the PR carries a work plan (`.agent/work-plans/issue-<N>/plan.md` or a
+  plan in the PR body), the plan is kept **in sync with the implementation
+  as it evolves** — an implementation that matches the current plan text is
+  not "plan drift", even if the plan changed after the PR opened.
+- Verify claims against source: parameters, topics, services, and message
+  types in docs must match the code.
+
+## Review Context — {REPO_NAME}
+
+<!-- Repo-specific context for reviewers: what this code controls, known
+     risk areas, conventions that look wrong but are deliberate.
+     Examples: "safety-critical: publishes cmd_vel on the live boat",
+     "TF frames use the <ns>/ prefix convention", "hardware I/O in pkg X
+     cannot be unit-tested; sim coverage lives in Y".
+     Replace this comment in each repo. -->
+
+## Instructions for Use
+
+<!-- DELETE this section when instantiating the template in a repo. -->
+
+1. Copy this file to the project repo root as `AGENTS.md`.
+2. Replace `{REPO_NAME}` and `{WORKSPACE_REPO_URL}` (use `gh repo view
+   --json url` on the workspace repo — never guess URLs).
+3. Fill in **Review Context** with repo-specific guidance; delete the
+   placeholder comment.
+4. Keep it short (≤60 lines). Detail belongs in `.agents/README.md`; shared
+   rules belong in the workspace `AGENTS.md`. Reference, never fork.
+5. Keep the `## Quality Standard` heading verbatim — `audit-project` uses it
+   as the currency marker.

--- a/.agent/templates/project_agents_md.md
+++ b/.agent/templates/project_agents_md.md
@@ -59,7 +59,8 @@ Robustness is not optional.
    --json url` on the workspace repo — never guess URLs).
 3. Fill in **Review Context** with repo-specific guidance; delete the
    placeholder comment.
-4. Keep it short (≤60 lines). Detail belongs in `.agents/README.md`; shared
-   rules belong in the workspace `AGENTS.md`. Reference, never fork.
+4. Keep the instantiated file short — ≤60 lines *after this section is
+   deleted*. Detail belongs in `.agents/README.md`; shared rules belong in
+   the workspace `AGENTS.md`. Reference, never fork.
 5. Keep the `## Quality Standard` heading verbatim — `audit-project` uses it
    as the currency marker.

--- a/.agent/templates/project_governance.md
+++ b/.agent/templates/project_governance.md
@@ -10,6 +10,7 @@ recommended structure.
 
 ```
 <project-repo>/
+├── AGENTS.md                   # Root agent/review instructions (see project_agents_md.md template)
 ├── .agents/
 │   ├── README.md               # Agent guide (see project_agents_guide.md template)
 │   ├── work-plans/             # Task plans for this repo
@@ -25,6 +26,7 @@ recommended structure.
 
 | File | Purpose | When to Add |
 |------|---------|-------------|
+| `AGENTS.md` | Root instructions for coding agents AND Copilot code review (reference, never fork, workspace rules — ADR-0017) | Always for repos receiving Copilot PR reviews |
 | `.agents/README.md` | Agent onboarding: packages, layout, build, pitfalls | Always — first file agents read |
 | `PRINCIPLES.md` | Project-specific guiding principles | When the project has domain rules beyond workspace principles |
 | `ARCHITECTURE.md` | Design overview, data flows, component relationships | When the project has multiple packages or non-obvious structure |
@@ -36,7 +38,8 @@ recommended structure.
 
 Not every project needs full governance. Start minimal and add as needed:
 
-1. **Minimal**: `.agents/README.md` only — enough for agents to navigate the repo
+1. **Minimal**: root `AGENTS.md` + `.agents/README.md` — review instructions plus enough
+   for agents to navigate the repo
 2. **Standard**: Add `ARCHITECTURE.md` when structure isn't self-evident
 3. **Full**: Add `PRINCIPLES.md` and `docs/decisions/` for projects with domain-specific
    rules or significant design choices
@@ -50,6 +53,7 @@ Not every project needs full governance. Start minimal and add as needed:
 
 ## Related Templates
 
+- [`project_agents_md.md`](project_agents_md.md) — Template for the root `AGENTS.md`
 - [`project_agents_guide.md`](project_agents_guide.md) — Template for `.agents/README.md`
 
 ## Instructions for Use

--- a/.agent/work-plans/issue-563/plan.md
+++ b/.agent/work-plans/issue-563/plan.md
@@ -16,7 +16,9 @@ This workspace PR delivers:
 1. Template `.agent/templates/project_agents_md.md` — the canonical starting point
 2. Skill updates — `onboard-project` adds AGENTS.md to its checklist; `audit-project`
    checks presence and Quality-Standard currency
-3. ADR-0006 cross-reference addendum (via ADR-0012) recording the extension to project-repo level
+3. New thin ADR-0017 recording the extension to project-repo level and the
+   "reference, never fork" invariant, plus a purely navigational ADR-0012
+   cross-reference addendum on ADR-0006 pointing to it
 
 Pilot rollout (7 repos getting actual `AGENTS.md` files) is a separate follow-up stacked
 on this issue — out of scope for this PR.
@@ -30,33 +32,40 @@ on this issue — out of scope for this PR.
    - Repo-specific review context slot (placeholder filled per-repo in pilot PRs)
    - Pointer to `.agents/README.md` for the deep agent guide
 
-2. **Add ADR-0006 cross-reference addendum** to `docs/decisions/0006-adopt-agents-md-as-shared-instruction-file.md`:
-   - Append a References entry noting the extension of the pattern to project-repo level (issue #563)
-   - Record the "reference, never fork" invariant as a one-line note in Status
-   - This is a cross-reference addendum (navigational) per ADR-0012 — not a substantive rewrite
+2. **Add ADR-0017** (`docs/decisions/0017-extend-agents-md-to-project-repos.md`) — thin
+   ADR recording the substantive decision: extend the two-tier AGENTS.md pattern
+   (ADR-0006) to project-repo level; per-repo files **reference, never fork**, workspace
+   rules; the file serves both coding agents (closest-file-wins) and Copilot code review.
+   Then add a **purely navigational** cross-reference addendum on ADR-0006 (Status note +
+   References entry pointing at ADR-0017) per ADR-0012.
 
 3. **Update `onboard-project` skill** (`.claude/skills/onboard-project/SKILL.md`):
    - Add "Root `AGENTS.md`" row to the checklist table with check = file exists at repo root,
      fix approach = copy from `.agent/templates/project_agents_md.md`
    - Insert in ordered presentation (after "Agent guide", before "License headers")
+   - Add an apply-fixes bullet in step 5
 
 4. **Update `audit-project` skill** (`.claude/skills/audit-project/SKILL.md`):
-   - Add `AGENTS.md` row to the governance coverage table (step 2 of the skill)
+   - Add `AGENTS.md` row to the governance coverage table (step 2 of the skill) and the
+     report-format table
    - In the recommended actions section, flag absence as a distinct action item
-   - Add a currency check: does the file reference the Quality Standard? (string search for "nits")
+   - Add a currency check keyed on the template's stable `## Quality Standard` heading
+     (not a prose string search)
 
-5. **Run `make generate-skills`** — required because `.claude/skills/` SKILL.md files changed
-   (CLAUDE.md § Makefile targets)
+5. **Sync `.agent/templates/project_governance.md`** — add root `AGENTS.md` to the suggested
+   structure, file table, and adoption levels so the governance template and `audit-project`
+   stay consistent
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
 | `.agent/templates/project_agents_md.md` | New template (40–60 lines) |
-| `docs/decisions/0006-adopt-agents-md-as-shared-instruction-file.md` | Cross-reference addendum (ADR-0012) — Status note + References entry |
+| `docs/decisions/0017-extend-agents-md-to-project-repos.md` | New thin ADR (the substantive decision) |
+| `docs/decisions/0006-adopt-agents-md-as-shared-instruction-file.md` | Navigational cross-reference addendum (ADR-0012) pointing at ADR-0017 |
 | `.claude/skills/onboard-project/SKILL.md` | Add root `AGENTS.md` checklist item |
 | `.claude/skills/audit-project/SKILL.md` | Add `AGENTS.md` governance row + currency check |
-| (generated) `.claude/skills/make_generate-skills/` or equivalent | Updated by `make generate-skills` |
+| `.agent/templates/project_governance.md` | Add root `AGENTS.md` to structure/table/adoption levels |
 
 ## Principles Self-Check
 
@@ -64,9 +73,9 @@ on this issue — out of scope for this PR.
 |---|---|
 | Human control and transparency | Rationale is explicit and quantified (FP baseline). Template must include standalone context — Copilot reviewers on project repos should know the field-deployment stakes. |
 | Enforcement over documentation | `audit-project` check is the nearest thing to enforcement — flagged prominently as a recommended action when absent. No mechanical hook; adoption relies on skill use. |
-| Capture decisions, not just implementations | ADR-0006 addendum records the "reference, never fork" invariant and the extension to project-repo level so future reviewers can find it. |
-| A change includes its consequences | `make generate-skills` is included in the plan. The consequences map entry for template changes (docs + skills) is covered. |
-| Only what's needed | Template is purposely thin (~40–60 lines). No new ADR file — addendum suffices. Pilot rollout deferred. |
+| Capture decisions, not just implementations | ADR-0017 records the "reference, never fork" invariant and the extension to project-repo level; a navigational addendum makes it discoverable from ADR-0006. |
+| A change includes its consequences | Template changes propagate to both consuming skills and the governance template in the same PR. |
+| Only what's needed | Template is purposely thin (~40–60 lines). ADR-0017 is a thin decision record, not a rewrite. Pilot rollout deferred. |
 | Workspace vs. project separation | Template lives in workspace; the AGENTS.md files themselves live in project repos. Template references, never forks, workspace rules. |
 | Workspace improvements cascade to projects | This is the explicit intent — workspace skill + template, then project-repo adoption. |
 
@@ -74,18 +83,19 @@ on this issue — out of scope for this PR.
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| ADR-0001 — Adopt ADRs | Yes — extending AGENTS.md pattern is a design decision | ADR-0006 addendum records it via ADR-0012's cross-reference-addendum mechanism |
+| ADR-0001 — Adopt ADRs | Yes — extending AGENTS.md pattern is a design decision | New thin ADR-0017 records the decision (immutability of ADR-0006 preserved) |
 | ADR-0003 — Project-agnostic workspace | Yes — template in workspace repo | Template is generic (no project-specific content); placeholder slots filled per-repo in pilots |
-| ADR-0006 — Shared AGENTS.md | Directly relevant — pattern extended to project-repo level | Addendum to ADR-0006; "reference, never fork" invariant recorded there |
-| ADR-0012 — Cross-reference addendums | Governs the ADR-0006 addendum | Addendum is purely navigational (Status note + References) — passes the "would it mislead a reader?" test |
+| ADR-0006 — Shared AGENTS.md | Directly relevant — pattern extended to project-repo level | ADR-0017 extends it; ADR-0006 gets only a navigational pointer |
+| ADR-0012 — Cross-reference addendums | Governs the ADR-0006 addendum | Addendum is purely navigational (Status note + References pointing at ADR-0017) — no decision content added |
 
 ## Consequences
 
 | If we change... | Also update... | Included in plan? |
 |---|---|---|
-| `.claude/skills/` SKILL.md files | Run `make generate-skills` | Yes — step 5 |
-| Template in `.agent/templates/` | Docs that reference it; skills that use it | Yes — `onboard-project` + `audit-project` both reference it in their SKILL.md |
+| Template in `.agent/templates/` | Docs that reference it; skills that use it | Yes — `onboard-project` + `audit-project` + `project_governance.md` all updated (steps 3–5) |
+| `docs/decisions/` (new ADR) | Older ADRs it qualifies | Yes — navigational addendum on ADR-0006 (step 2) |
 | `AGENTS.md` (workspace) | Framework adapters | Not triggered — we are not changing workspace AGENTS.md |
+| `.claude/skills/` SKILL.md files | Nothing — `make generate-skills` only regenerates `/make_*` commands from Makefile `.PHONY`, not SKILL.md content | N/A (removed no-op step per plan review) |
 
 ## Open Questions
 

--- a/.agent/work-plans/issue-563/plan.md
+++ b/.agent/work-plans/issue-563/plan.md
@@ -1,0 +1,97 @@
+# Plan: Project-repo root AGENTS.md for Copilot code review
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/563
+
+## Context
+
+GitHub Copilot code review reads root-level `AGENTS.md` (since 2026-06-18). Zero
+first-party project repos currently have one, so Copilot reviews their PRs uninstructed.
+A `triage-reviews` baseline counts ~200 false-positive classifications across 18 repos,
+with the top 7 totaling 158 FPs. The closest-AGENTS.md-to-file-wins rule also means this
+file becomes the first instruction any coding agent sees in a layer worktree.
+
+This workspace PR delivers:
+1. Template `.agent/templates/project_agents_md.md` — the canonical starting point
+2. Skill updates — `onboard-project` adds AGENTS.md to its checklist; `audit-project`
+   checks presence and Quality-Standard currency
+3. ADR-0006 cross-reference addendum (via ADR-0012) recording the extension to project-repo level
+
+Pilot rollout (7 repos getting actual `AGENTS.md` files) is a separate follow-up stacked
+on this issue — out of scope for this PR.
+
+## Approach
+
+1. **Create template** `.agent/templates/project_agents_md.md` — 40–60 lines with:
+   - Workspace rules pointer (reference, never fork — points to workspace `AGENTS.md`)
+   - Standalone context block so Copilot reviewers on project repos get useful guidance
+     without workspace access (Quality Standard, plan-sync convention, ROS 2 field-deployment context)
+   - Repo-specific review context slot (placeholder filled per-repo in pilot PRs)
+   - Pointer to `.agents/README.md` for the deep agent guide
+
+2. **Add ADR-0006 cross-reference addendum** to `docs/decisions/0006-adopt-agents-md-as-shared-instruction-file.md`:
+   - Append a References entry noting the extension of the pattern to project-repo level (issue #563)
+   - Record the "reference, never fork" invariant as a one-line note in Status
+   - This is a cross-reference addendum (navigational) per ADR-0012 — not a substantive rewrite
+
+3. **Update `onboard-project` skill** (`.claude/skills/onboard-project/SKILL.md`):
+   - Add "Root `AGENTS.md`" row to the checklist table with check = file exists at repo root,
+     fix approach = copy from `.agent/templates/project_agents_md.md`
+   - Insert in ordered presentation (after "Agent guide", before "License headers")
+
+4. **Update `audit-project` skill** (`.claude/skills/audit-project/SKILL.md`):
+   - Add `AGENTS.md` row to the governance coverage table (step 2 of the skill)
+   - In the recommended actions section, flag absence as a distinct action item
+   - Add a currency check: does the file reference the Quality Standard? (string search for "nits")
+
+5. **Run `make generate-skills`** — required because `.claude/skills/` SKILL.md files changed
+   (CLAUDE.md § Makefile targets)
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/templates/project_agents_md.md` | New template (40–60 lines) |
+| `docs/decisions/0006-adopt-agents-md-as-shared-instruction-file.md` | Cross-reference addendum (ADR-0012) — Status note + References entry |
+| `.claude/skills/onboard-project/SKILL.md` | Add root `AGENTS.md` checklist item |
+| `.claude/skills/audit-project/SKILL.md` | Add `AGENTS.md` governance row + currency check |
+| (generated) `.claude/skills/make_generate-skills/` or equivalent | Updated by `make generate-skills` |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Rationale is explicit and quantified (FP baseline). Template must include standalone context — Copilot reviewers on project repos should know the field-deployment stakes. |
+| Enforcement over documentation | `audit-project` check is the nearest thing to enforcement — flagged prominently as a recommended action when absent. No mechanical hook; adoption relies on skill use. |
+| Capture decisions, not just implementations | ADR-0006 addendum records the "reference, never fork" invariant and the extension to project-repo level so future reviewers can find it. |
+| A change includes its consequences | `make generate-skills` is included in the plan. The consequences map entry for template changes (docs + skills) is covered. |
+| Only what's needed | Template is purposely thin (~40–60 lines). No new ADR file — addendum suffices. Pilot rollout deferred. |
+| Workspace vs. project separation | Template lives in workspace; the AGENTS.md files themselves live in project repos. Template references, never forks, workspace rules. |
+| Workspace improvements cascade to projects | This is the explicit intent — workspace skill + template, then project-repo adoption. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0001 — Adopt ADRs | Yes — extending AGENTS.md pattern is a design decision | ADR-0006 addendum records it via ADR-0012's cross-reference-addendum mechanism |
+| ADR-0003 — Project-agnostic workspace | Yes — template in workspace repo | Template is generic (no project-specific content); placeholder slots filled per-repo in pilots |
+| ADR-0006 — Shared AGENTS.md | Directly relevant — pattern extended to project-repo level | Addendum to ADR-0006; "reference, never fork" invariant recorded there |
+| ADR-0012 — Cross-reference addendums | Governs the ADR-0006 addendum | Addendum is purely navigational (Status note + References) — passes the "would it mislead a reader?" test |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `.claude/skills/` SKILL.md files | Run `make generate-skills` | Yes — step 5 |
+| Template in `.agent/templates/` | Docs that reference it; skills that use it | Yes — `onboard-project` + `audit-project` both reference it in their SKILL.md |
+| `AGENTS.md` (workspace) | Framework adapters | Not triggered — we are not changing workspace AGENTS.md |
+
+## Open Questions
+
+- [ ] No open questions — plan is review-plan-ready.
+
+## Estimated Scope
+
+Single PR. All changes are in workspace infrastructure (template + skill updates + ADR addendum).
+Pilot rollout is a separate follow-up.

--- a/.agent/work-plans/issue-563/progress.md
+++ b/.agent/work-plans/issue-563/progress.md
@@ -106,9 +106,27 @@ recorded as independent, not self-review. -->
 **Round**: 1 | **Ship**: continue — one mechanical must-fix (wrong-cwd URL lookup); near-shippable once fixed
 
 ### Findings
-- [ ] (must-fix) `onboard-project` fix step looks up `{WORKSPACE_REPO_URL}` via `gh repo view --json url` from the project-repo cwd, yielding the project URL not the workspace URL; add "on the workspace repo" qualifier (template line 53 has it) — `.claude/skills/onboard-project/SKILL.md:188-190`
-- [ ] (suggestion) New root-`AGENTS.md` template not added to the project-guides index (footer asks to keep current) — `.agent/knowledge/README.md:29-33`
-- [ ] (suggestion) "Project-Level Guidance" section could cross-link the new template (Ask First — instruction-file edit) — `AGENTS.md:409-417`
+- [x] (must-fix) `onboard-project` fix step looks up `{WORKSPACE_REPO_URL}` via `gh repo view --json url` from the project-repo cwd, yielding the project URL not the workspace URL; add "on the workspace repo" qualifier (template line 53 has it) — `.claude/skills/onboard-project/SKILL.md:188-190`
+- [x] (suggestion) New root-`AGENTS.md` template not added to the project-guides index (footer asks to keep current) — `.agent/knowledge/README.md:29-33`
+- [x] (suggestion) "Project-Level Guidance" section could cross-link the new template (Ask First — instruction-file edit) — `AGENTS.md:409-417`
   - Note (host, 2026-07-14): operator APPROVED this instruction-file edit at the round-1 checkpoint — apply it; keep the edit to a one-sentence cross-link in § Project-Level Guidance.
-- [ ] (suggestion) Pin the template's standalone `## Quality Standard` excerpt to its workspace source to bound the drift ADR-0017 acknowledges — `.agent/templates/project_agents_md.md:15-24`
-- [ ] (suggestion) Currency-check snippet references undefined `$REPO_DIR`; define it or use the skill's `<repo-name>` convention — `.claude/skills/audit-project/SKILL.md:62`
+- [x] (suggestion) Pin the template's standalone `## Quality Standard` excerpt to its workspace source to bound the drift ADR-0017 acknowledges — `.agent/templates/project_agents_md.md:15-24`
+- [x] (suggestion) Currency-check snippet references undefined `$REPO_DIR`; define it or use the skill's `<repo-name>` convention — `.claude/skills/audit-project/SKILL.md:62`
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-14 15:47 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-563 at `b0d1781`
+**Addressed**: Local Review (Pre-Push) — 2026-07-14 15:38 +00:00, `feature/issue-563` at `e8ffa8e`
+**Commits**: 18f8edf, f41587b, fd46d55, 84d792c, b0d1781
+
+### Actions
+- [x] (must-fix) Qualify `{WORKSPACE_REPO_URL}` lookup with "on the workspace repo" — `.claude/skills/onboard-project/SKILL.md:189` (`18f8edf`)
+- [x] (suggestion) Index the root `AGENTS.md` template in the project-guides section — `.agent/knowledge/README.md:29-35` (`f41587b`)
+- [x] (suggestion) Cross-link the new template in § Project-Level Guidance (operator-approved instruction-file edit; one-sentence link + ADR-0017) — `AGENTS.md:421-423` (`fd46d55`)
+- [x] (suggestion) Pin the template's standalone `## Quality Standard` excerpt to its workspace source via a re-sync comment — `.agent/templates/project_agents_md.md:16-21` (`84d792c`)
+- [x] (suggestion) Replace undefined `$REPO_DIR` with the skill's `layers/main/*/src/<repo-name>` convention in the currency-check snippet — `.claude/skills/audit-project/SKILL.md:62` (`b0d1781`)
+
+No deferrals — all five findings were actionable and fixed. Changes are docs/skill-template only; pre-commit hooks ran clean on every commit.

--- a/.agent/work-plans/issue-563/progress.md
+++ b/.agent/work-plans/issue-563/progress.md
@@ -92,3 +92,22 @@ recorded as independent, not self-review. -->
 - [ ] (must-fix) Step 5 `make generate-skills` is a no-op: it regenerates gitignored `/make_*` slash commands from the Makefile `.PHONY` line, not from hand-crafted SKILL.md content. Remove step 5 and the "(generated)" Files-to-Change row — `plan.md:48,59`
 - [ ] (suggestion) Adding a root `AGENTS.md` row to `audit-project`'s coverage table should also add it to the reference template `.agent/templates/project_governance.md` so skill and template stay in sync — `plan.md:44-46`
 - [ ] (suggestion) Currency check via string-search for "nits" is brittle; have the template emit a stable marker (e.g. a `## Quality Standard` heading) and grep for that — `plan.md:46`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-14 15:38 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-563 at `e8ffa8e`
+**Mode**: pre-push
+**Depth**: Deep (reason: new ADR-0017 — Deep promotion trigger; 369 lines / governance-trigger files; guidance-doc calibration #537 applied)
+**Must-fix**: 1 | **Suggestions**: 4
+**Round**: 1 | **Ship**: continue — one mechanical must-fix (wrong-cwd URL lookup); near-shippable once fixed
+
+### Findings
+- [ ] (must-fix) `onboard-project` fix step looks up `{WORKSPACE_REPO_URL}` via `gh repo view --json url` from the project-repo cwd, yielding the project URL not the workspace URL; add "on the workspace repo" qualifier (template line 53 has it) — `.claude/skills/onboard-project/SKILL.md:188-190`
+- [ ] (suggestion) New root-`AGENTS.md` template not added to the project-guides index (footer asks to keep current) — `.agent/knowledge/README.md:29-33`
+- [ ] (suggestion) "Project-Level Guidance" section could cross-link the new template (Ask First — instruction-file edit) — `AGENTS.md:409-417`
+- [ ] (suggestion) Pin the template's standalone `## Quality Standard` excerpt to its workspace source to bound the drift ADR-0017 acknowledges — `.agent/templates/project_agents_md.md:15-24`
+- [ ] (suggestion) Currency-check snippet references undefined `$REPO_DIR`; define it or use the skill's `<repo-name>` convention — `.claude/skills/audit-project/SKILL.md:62`

--- a/.agent/work-plans/issue-563/progress.md
+++ b/.agent/work-plans/issue-563/progress.md
@@ -151,3 +151,32 @@ container — issue title from progress.md frontmatter; diffed vs local origin/m
 ### Findings
 - [x] (suggestion) Currency-check `grep … || echo STALE` conflates Missing and Stale (absent file prints STALE, contradicting line 65 + the Present/Missing/Stale table); guard existence first — `.claude/skills/audit-project/SKILL.md:62`
 - [x] (suggestion) ADR-0017 §Consequences overstates the currency check as full mitigation; it is presence-only, not content-currency — soften wording — `docs/decisions/0017-extend-agents-md-to-project-repos.md:49`
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-14 12:16 -04:00
+**By**: Claude Code Agent (Claude Opus)
+
+**PR**: #567 at `6e79af6`
+**Sources**: 3 (Copilot R1 @ `67a4239`, Local Review Pre-Push @ `e8ffa8e`, Local Review Pre-Push @ `3c97342`)
+**Cross-source confirmations**: 0
+**CI**: all-pass (8 checks green; one duplicate "Validate commit identity" run skipped, non-blocking)
+
+Copilot's review (commit `67a4239`) predates the current head `6e79af6`; both of its
+inline comments were re-evaluated against current code. The prior two local Pre-Push
+review rounds (7 findings total) are all checked off and disjoint from Copilot's two
+comments — no cross-source overlap.
+
+### Findings
+- [ ] (low, Copilot) Line-count guidance is self-contradictory: template advises "≤60 lines"
+  but the template file is 65 lines until the *Instructions for Use* section (lines 53–65) is
+  deleted; the ≤60 target applies to the instantiated file after that section is removed.
+  Clarify instruction #4 to say so — `.agent/templates/project_agents_md.md:62`
+
+### False positives
+- (Copilot) "`layers/main/*/src/...` won't match the actual layer workspace layout; add the
+  `*_ws` component" — the stated failure mode cannot occur: the `*` wildcard already matches
+  every `<layer>_ws` directory (`core_ws`, `platforms_ws`, …), verified against the live
+  `layers/main/` tree — `layers/main/*/src/unh_marine_autonomy` resolves correctly. Narrowing
+  to `*_ws` would be marginally more specific but is not required; the glob is functional as
+  written, at both `.claude/skills/audit-project/SKILL.md:40` (step 1) and `:62` (currency check).

--- a/.agent/work-plans/issue-563/progress.md
+++ b/.agent/work-plans/issue-563/progress.md
@@ -149,5 +149,5 @@ with two disjoint-lens adversarial subagents; recorded as independent. gh unavai
 container — issue title from progress.md frontmatter; diffed vs local origin/main (fetch failed). -->
 
 ### Findings
-- [ ] (suggestion) Currency-check `grep … || echo STALE` conflates Missing and Stale (absent file prints STALE, contradicting line 65 + the Present/Missing/Stale table); guard existence first — `.claude/skills/audit-project/SKILL.md:62`
-- [ ] (suggestion) ADR-0017 §Consequences overstates the currency check as full mitigation; it is presence-only, not content-currency — soften wording — `docs/decisions/0017-extend-agents-md-to-project-repos.md:49`
+- [x] (suggestion) Currency-check `grep … || echo STALE` conflates Missing and Stale (absent file prints STALE, contradicting line 65 + the Present/Missing/Stale table); guard existence first — `.claude/skills/audit-project/SKILL.md:62`
+- [x] (suggestion) ADR-0017 §Consequences overstates the currency check as full mitigation; it is presence-only, not content-currency — soften wording — `docs/decisions/0017-extend-agents-md-to-project-repos.md:49`

--- a/.agent/work-plans/issue-563/progress.md
+++ b/.agent/work-plans/issue-563/progress.md
@@ -1,0 +1,62 @@
+---
+issue: 563
+---
+
+# Issue #563 — Project-repo root AGENTS.md for Copilot code review
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-14 10:30 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #563
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Scope Assessment
+
+The issue separates its work into two distinct tracks:
+
+1. **Workspace PR**: template (`.agent/templates/project_agents_md.md`) + skill integration (`onboard-project` offers to create it; `audit-project` checks presence + Quality-Standard currency). Single PR, self-contained.
+2. **Pilot rollout**: separate per-repo PRs, stacked on this issue, for five first-party repos. Correctly deferred to follow-up.
+
+Right repo: yes — template and skill changes belong in the workspace repo; the resulting AGENTS.md files live in project repos.
+
+Dependencies: pilot PRs depend on the template being merged first.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | Explicit rationale (Copilot reads root AGENTS.md since 2026-06-18); FP baseline quantifies the pain |
+| Enforcement over documentation | Watch | Template is documentation; no mechanical enforcement for adoption. Copilot benefit is indirect. `audit-project` check is the nearest thing to enforcement — make it prominent in the skill's output |
+| Capture decisions, not just implementations | Action needed | Extending AGENTS.md to project-repo level is a design decision. ADR-0006 covers workspace-level only. Needs an ADR-0006 addendum (ADR-0012 allows cross-reference addendums) or a new ADR capturing: "project repos get a thin AGENTS.md that references workspace rules, never forks them" |
+| A change includes its consequences | Watch | Skill integration is planned. If `.claude/skills/` files change, `make generate-skills` must run. The issue doesn't mention this step — plan-task should include it |
+| Only what's needed | OK | Driven by concrete FP-baseline data (200 FP classifications across 18 repos); template is purposely thin (~40–60 lines) |
+| Improve incrementally | OK | Phased: workspace infra first, then pilot repos |
+| Workspace vs. project separation | OK | Template stays in workspace; AGENTS.md files live in project repos |
+| Workspace improvements cascade to projects | OK | This is the explicit intent of the issue — exactly what this principle calls for |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| ADR-0001 — Adopt ADRs | Yes | Decision to extend AGENTS.md pattern to project-repo level should be recorded |
+| ADR-0003 — Project-agnostic workspace | OK | Template is generic; issue explicitly excludes third-party forks |
+| ADR-0006 — Shared AGENTS.md | Directly relevant | Extension of this pattern. Issue correctly says "reference workspace rules, never fork them" — aligns with ADR-0006's rationale. Needs an addendum or successor |
+| ADR-0012 — Cross-reference addendums | Relevant | ADR-0012 allows extending ADR-0006 via addendum instead of a full new ADR — a valid, lighter path |
+
+### Consequences
+
+Per the consequences map (template in `.agent/templates/` → docs that reference it + skills that use it):
+
+- `onboard-project` skill: planned in issue — check for presence, offer to create.
+- `audit-project` skill: planned in issue — check presence + Quality-Standard currency.
+- If `.claude/skills/` files change: `make generate-skills` must run (CLAUDE.md § Makefile targets).
+- No changes to `.agent/scripts/` or worktree scripts are implied.
+
+### Actions
+- [ ] Add an ADR (or ADR-0006 addendum via ADR-0012's cross-reference-addendum mechanism) recording the decision to extend AGENTS.md to project-repo level, so the "reference, never fork" invariant is enforceable by future reviewers
+- [ ] Ensure plan-task includes `make generate-skills` if any `.claude/skills/` SKILL.md files are modified
+- [ ] Consider whether `udp_bridge` (28 FPs) and `marine_tools` (19 FPs) — both above some pilot-list repos — warrant inclusion in the first pilot wave; issue currently stops at 5 repos
+- [ ] Template should include standalone context about workspace-in-context vs. standalone use (same as `.agent/templates/project_agents_guide.md` does) so Copilot reviewers on project repos get useful context even without workspace access

--- a/.agent/work-plans/issue-563/progress.md
+++ b/.agent/work-plans/issue-563/progress.md
@@ -60,3 +60,15 @@ Per the consequences map (template in `.agent/templates/` → docs that referenc
 - [ ] Ensure plan-task includes `make generate-skills` if any `.claude/skills/` SKILL.md files are modified
 - [ ] Consider whether `udp_bridge` (28 FPs) and `marine_tools` (19 FPs) — both above some pilot-list repos — warrant inclusion in the first pilot wave; issue currently stops at 5 repos
 - [ ] Template should include standalone context about workspace-in-context vs. standalone use (same as `.agent/templates/project_agents_guide.md` does) so Copilot reviewers on project repos get useful context even without workspace access
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-14 12:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-563/plan.md` at `0216e2a`
+**Branch**: feature/issue-563 at `0216e2a`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-563/progress.md
+++ b/.agent/work-plans/issue-563/progress.md
@@ -109,5 +109,6 @@ recorded as independent, not self-review. -->
 - [ ] (must-fix) `onboard-project` fix step looks up `{WORKSPACE_REPO_URL}` via `gh repo view --json url` from the project-repo cwd, yielding the project URL not the workspace URL; add "on the workspace repo" qualifier (template line 53 has it) — `.claude/skills/onboard-project/SKILL.md:188-190`
 - [ ] (suggestion) New root-`AGENTS.md` template not added to the project-guides index (footer asks to keep current) — `.agent/knowledge/README.md:29-33`
 - [ ] (suggestion) "Project-Level Guidance" section could cross-link the new template (Ask First — instruction-file edit) — `AGENTS.md:409-417`
+  - Note (host, 2026-07-14): operator APPROVED this instruction-file edit at the round-1 checkpoint — apply it; keep the edit to a one-sentence cross-link in § Project-Level Guidance.
 - [ ] (suggestion) Pin the template's standalone `## Quality Standard` excerpt to its workspace source to bound the drift ADR-0017 acknowledges — `.agent/templates/project_agents_md.md:15-24`
 - [ ] (suggestion) Currency-check snippet references undefined `$REPO_DIR`; define it or use the skill's `<repo-name>` convention — `.claude/skills/audit-project/SKILL.md:62`

--- a/.agent/work-plans/issue-563/progress.md
+++ b/.agent/work-plans/issue-563/progress.md
@@ -168,10 +168,12 @@ review rounds (7 findings total) are all checked off and disjoint from Copilot's
 comments — no cross-source overlap.
 
 ### Findings
-- [ ] (low, Copilot) Line-count guidance is self-contradictory: template advises "≤60 lines"
+- [x] (low, Copilot) Line-count guidance is self-contradictory: template advises "≤60 lines"
   but the template file is 65 lines until the *Instructions for Use* section (lines 53–65) is
   deleted; the ≤60 target applies to the instantiated file after that section is removed.
   Clarify instruction #4 to say so — `.agent/templates/project_agents_md.md:62`
+  - Addressed host-inline (trivial docs clarity): instruction #4 now reads "≤60 lines *after
+    this section is deleted*".
 
 ### False positives
 - (Copilot) "`layers/main/*/src/...` won't match the actual layer workspace layout; add the

--- a/.agent/work-plans/issue-563/progress.md
+++ b/.agent/work-plans/issue-563/progress.md
@@ -130,3 +130,24 @@ recorded as independent, not self-review. -->
 - [x] (suggestion) Replace undefined `$REPO_DIR` with the skill's `layers/main/*/src/<repo-name>` convention in the currency-check snippet — `.claude/skills/audit-project/SKILL.md:62` (`b0d1781`)
 
 No deferrals — all five findings were actionable and fixed. Changes are docs/skill-template only; pre-commit hooks ran clean on every commit.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-14 15:55 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-563 at `3c97342`
+**Mode**: pre-push
+**Depth**: Deep (reason: new ADR-0017 — ADR-add Deep-promotion trigger; docs/skill-template only; guidance-doc calibration #537 applied)
+**Must-fix**: 0 | **Suggestions**: 2
+**Round**: 2 | **Ship**: recommended — no must-fix; all 5 Round-1 findings verified addressed; 2 optional ~1-min polish suggestions remain
+
+<!-- Independence: $AGENT_NAME "Claude Code Agent" is shared across workspace agents, so the
+name-match heuristic misfires. This is a fresh-context, separately-dispatched Deep review
+with two disjoint-lens adversarial subagents; recorded as independent. gh unavailable in
+container — issue title from progress.md frontmatter; diffed vs local origin/main (fetch failed). -->
+
+### Findings
+- [ ] (suggestion) Currency-check `grep … || echo STALE` conflates Missing and Stale (absent file prints STALE, contradicting line 65 + the Present/Missing/Stale table); guard existence first — `.claude/skills/audit-project/SKILL.md:62`
+- [ ] (suggestion) ADR-0017 §Consequences overstates the currency check as full mitigation; it is presence-only, not content-currency — soften wording — `docs/decisions/0017-extend-agents-md-to-project-repos.md:49`

--- a/.agent/work-plans/issue-563/progress.md
+++ b/.agent/work-plans/issue-563/progress.md
@@ -72,3 +72,23 @@ Per the consequences map (template in `.agent/templates/` → docs that referenc
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-14 14:47 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-563/plan.md` at `0216e2a`
+**PR**: PR-less (reviewed from `feature/issue-563` worktree)
+**Verdict**: changes-requested
+
+<!-- Independence: name-match heuristic misfires here — $AGENT_NAME "Claude Code Agent"
+is shared across all workspace agents, so it always matches the plan author. This is a
+fresh-context, separately-dispatched, different-model (Opus vs the Sonnet author) review;
+recorded as independent, not self-review. -->
+
+### Findings
+- [ ] (must-fix) ADR-0006 addendum records a *new* "reference, never fork" invariant in Status — exceeds ADR-0012's navigational scope; the project-repo extension is a substantive decision that belongs in a new thin ADR with a genuine cross-reference addendum on ADR-0006. Under-captures per "Capture decisions" (review-issue "Action needed") — `plan.md:34-36`
+- [ ] (must-fix) Step 5 `make generate-skills` is a no-op: it regenerates gitignored `/make_*` slash commands from the Makefile `.PHONY` line, not from hand-crafted SKILL.md content. Remove step 5 and the "(generated)" Files-to-Change row — `plan.md:48,59`
+- [ ] (suggestion) Adding a root `AGENTS.md` row to `audit-project`'s coverage table should also add it to the reference template `.agent/templates/project_governance.md` so skill and template stay in sync — `plan.md:44-46`
+- [ ] (suggestion) Currency check via string-search for "nits" is brittle; have the template emit a stable marker (e.g. a `## Quality Standard` heading) and grep for that — `plan.md:46`

--- a/.claude/skills/audit-project/SKILL.md
+++ b/.claude/skills/audit-project/SKILL.md
@@ -59,7 +59,7 @@ contain the template's stable `## Quality Standard` heading (the marker
 `.agent/templates/project_agents_md.md` instructs repos to keep verbatim):
 
 ```bash
-grep -q '^## Quality Standard' "$REPO_DIR/AGENTS.md" || echo "STALE: Quality Standard section missing"
+grep -q '^## Quality Standard' layers/main/*/src/<repo-name>/AGENTS.md || echo "STALE: Quality Standard section missing"
 ```
 
 Report `Stale` when the file exists but the marker is absent — it predates

--- a/.claude/skills/audit-project/SKILL.md
+++ b/.claude/skills/audit-project/SKILL.md
@@ -47,14 +47,27 @@ as reference, check what exists:
 
 | Item | Status | Path |
 |---|---|---|
+| `AGENTS.md` (root) | Present / Missing / Stale | ... |
 | `.agents/README.md` | Present / Missing | ... |
 | `PRINCIPLES.md` | Present / Missing | ... |
 | `ARCHITECTURE.md` | Present / Missing | ... |
 | `docs/decisions/` | Present / Missing (N ADRs) | ... |
 | `.agents/workspace-context/` | Present / Missing | ... |
 
+For the root `AGENTS.md`, also run the **currency check**: the file must
+contain the template's stable `## Quality Standard` heading (the marker
+`.agent/templates/project_agents_md.md` instructs repos to keep verbatim):
+
+```bash
+grep -q '^## Quality Standard' "$REPO_DIR/AGENTS.md" || echo "STALE: Quality Standard section missing"
+```
+
+Report `Stale` when the file exists but the marker is absent — it predates
+the template or lost its standalone review context (ADR-0017).
+
 This is a **coverage report**, not a mandate — not every repo needs full
-governance. But missing items should be noted.
+governance. But missing items should be noted, and a missing root
+`AGENTS.md` means Copilot code review runs uninstructed on that repo.
 
 ### 3. Check agent guide quality
 
@@ -116,6 +129,7 @@ Report test existence and pass/fail, not test quality.
 
 | Item | Status |
 |---|---|
+| `AGENTS.md` (root) | Present / Missing / Stale |
 | `.agents/README.md` | Present / Missing |
 | `PRINCIPLES.md` | Present / Missing |
 | ... | ... |
@@ -150,6 +164,11 @@ creating one with the project_agents_guide.md template">
 
 - [ ] <specific action items>
 ```
+
+When the root `AGENTS.md` is Missing or Stale, list it as a distinct
+recommended action (fix = instantiate/refresh from
+`.agent/templates/project_agents_md.md`, e.g. via `onboard-project`) —
+don't fold it into a generic "improve governance" item.
 
 ## Guidelines
 

--- a/.claude/skills/audit-project/SKILL.md
+++ b/.claude/skills/audit-project/SKILL.md
@@ -59,7 +59,12 @@ contain the template's stable `## Quality Standard` heading (the marker
 `.agent/templates/project_agents_md.md` instructs repos to keep verbatim):
 
 ```bash
-grep -q '^## Quality Standard' layers/main/*/src/<repo-name>/AGENTS.md || echo "STALE: Quality Standard section missing"
+AGENTS_FILE=$(ls layers/main/*/src/<repo-name>/AGENTS.md 2>/dev/null | head -1)
+if [ -z "$AGENTS_FILE" ]; then
+    echo "MISSING: no root AGENTS.md"
+elif ! grep -q '^## Quality Standard' "$AGENTS_FILE"; then
+    echo "STALE: Quality Standard section missing"
+fi
 ```
 
 Report `Stale` when the file exists but the marker is absent — it predates

--- a/.claude/skills/onboard-project/SKILL.md
+++ b/.claude/skills/onboard-project/SKILL.md
@@ -187,7 +187,7 @@ cd <layer>_ws/src/<repo-name>
 
 - **Root `AGENTS.md`**: Copy `.agent/templates/project_agents_md.md`, replace
   `{REPO_NAME}` and `{WORKSPACE_REPO_URL}` (look the URL up with `gh repo view
-  --json url` — never guess), fill the Review Context section with
+  --json url` **on the workspace repo** — never guess), fill the Review Context section with
   repo-specific reviewer guidance, delete the "Instructions for Use" section.
   Keep the `## Quality Standard` heading verbatim (audit-project's currency
   marker) and never restate workspace rules — reference them (ADR-0017).

--- a/.claude/skills/onboard-project/SKILL.md
+++ b/.claude/skills/onboard-project/SKILL.md
@@ -68,6 +68,7 @@ whether it's already done, missing, or partially done.
 | **Pre-commit config** | `.pre-commit-config.yaml` exists at repo root | Copy from `.agent/templates/pre-commit-config.yaml`, adjust protected branches to match repo's default branch |
 | **CI workflow** | `.github/workflows/*.yml` exists with colcon build/test | Copy from `.agent/templates/ci_workflow.yml`, fill in default branch and package list |
 | **Agent guide** | `.agents/README.md` exists at repo root | Generate from `.agent/templates/project_agents_guide.md` by reading repo code (packages, launch files, nodes, topics) |
+| **Root `AGENTS.md`** | `AGENTS.md` exists at repo root | Copy from `.agent/templates/project_agents_md.md`; fill `{REPO_NAME}` / `{WORKSPACE_REPO_URL}` and the Review Context slot (ADR-0017: reference workspace rules, never fork them) |
 | **Branch protection** | GitHub branch ruleset requires PRs on default branch | Configure via `gh api` — requires admin access |
 | **Copilot auto-review** | Copilot is configured to review PRs | Check via `gh api` — requires admin access |
 | **Package labels** | `pkg:` labels exist (multi-package repos only) | Create via `gh label create` for each package |
@@ -89,7 +90,8 @@ Present items in this order (quick wins first):
 4. git-bug bridge (if git-bug is installed)
 5. Branch protection / Copilot auto-review
 6. Agent guide (`.agents/README.md`)
-7. License headers (always suggest "open issue" — too invasive for batch fix)
+7. Root `AGENTS.md` (steers Copilot code review + closest-file-wins agents)
+8. License headers (always suggest "open issue" — too invasive for batch fix)
 
 Skip items that are already in place. If everything is already done, report
 that and exit.
@@ -182,6 +184,13 @@ cd <layer>_ws/src/<repo-name>
   fill in sections: package inventory (from `package.xml`), layout (from
   directory structure), key files, dependencies. Follow the documentation
   verification workflow — every claim must be verified against source.
+
+- **Root `AGENTS.md`**: Copy `.agent/templates/project_agents_md.md`, replace
+  `{REPO_NAME}` and `{WORKSPACE_REPO_URL}` (look the URL up with `gh repo view
+  --json url` — never guess), fill the Review Context section with
+  repo-specific reviewer guidance, delete the "Instructions for Use" section.
+  Keep the `## Quality Standard` heading verbatim (audit-project's currency
+  marker) and never restate workspace rules — reference them (ADR-0017).
 
 - **Package labels**: Create via `gh label create` (done in step 4, no
   file changes needed).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,6 +418,10 @@ If no `.agents/README.md` exists, note this gap. To create one, use the template
 and follow the [documentation verification workflow](.agent/knowledge/documentation_verification.md).
 This should be a dedicated task with its own issue, not a side-effect of unrelated work.
 
+Project repos should also carry a thin root `AGENTS.md` (read by GitHub Copilot code
+review) that references — never forks — these workspace rules; create it from
+[`.agent/templates/project_agents_md.md`](.agent/templates/project_agents_md.md) (see [ADR-0017](docs/decisions/0017-extend-agents-md-to-project-repos.md)).
+
 ## Workspace Cleanliness
 
 - Keep repo root and `layers/*/src/` clean — no temp files, build artifacts, or logs.

--- a/docs/decisions/0006-adopt-agents-md-as-shared-instruction-file.md
+++ b/docs/decisions/0006-adopt-agents-md-as-shared-instruction-file.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Accepted
+Accepted. [ADR-0017](0017-extend-agents-md-to-project-repos.md) extends the
+pattern to project-repo level.
 
 ## Context
 
@@ -96,4 +97,5 @@ both over-cautious behavior and unauthorized actions.
 - ADR-0003: Workspace infrastructure is project-agnostic
 - ADR-0004: Enforcement hierarchy for agent compliance
 - ADR-0005: Layered enforcement — framework-agnostic backbone
+- [ADR-0017](0017-extend-agents-md-to-project-repos.md): Extends this pattern to project repos
 - [AGENTS.md convention](https://github.com/agentsmd/agents.md)

--- a/docs/decisions/0017-extend-agents-md-to-project-repos.md
+++ b/docs/decisions/0017-extend-agents-md-to-project-repos.md
@@ -53,8 +53,10 @@ eliminated.
 
 ### Negative
 
-- One more per-repo file to keep current; mitigated by the `audit-project`
-  currency check rather than manual vigilance.
+- One more per-repo file to keep current; partially mitigated by the
+  `audit-project` currency check — a marker-presence check only, which
+  detects a missing/pre-template file but not a drifted excerpt. Content
+  currency still relies on the re-sync instruction in the template.
 
 ### Neutral
 

--- a/docs/decisions/0017-extend-agents-md-to-project-repos.md
+++ b/docs/decisions/0017-extend-agents-md-to-project-repos.md
@@ -1,0 +1,70 @@
+# ADR-0017: Extend AGENTS.md to project repos (reference, never fork)
+
+## Status
+
+Accepted. Extends [ADR-0006](0006-adopt-agents-md-as-shared-instruction-file.md)
+to project-repo level.
+
+## Context
+
+ADR-0006 adopted a two-tier instruction structure at the **workspace** level:
+a shared `AGENTS.md` plus thin framework adapters. Project repos were left
+with only the `.agents/README.md` agent guide — an onboarding encyclopedia,
+not behavioral rules.
+
+Two developments changed the calculus (2026-07 research digest):
+
+1. **GitHub Copilot code review reads a repo's root `AGENTS.md`**
+   (2026-06-18) and applies it when generating review feedback. Our project
+   repos receive Copilot PR reviews with no instructions — a measured
+   baseline of ~200 false-positive review findings across 18 repos, much of
+   it noise a short instruction file can address (e.g. recurring plan-drift
+   flags).
+2. **Closest-AGENTS.md-to-file wins** is the cross-framework convention, so
+   a project-repo root `AGENTS.md` is also the first instruction file any
+   coding agent sees when working inside a layer worktree.
+
+Without a rule, per-repo files would accumulate copies of workspace rules —
+recreating, one level down, exactly the duplication/drift problem ADR-0006
+eliminated.
+
+## Decision
+
+1. Project repos in this workspace get a thin root `AGENTS.md` (~40–60
+   lines), instantiated from `.agent/templates/project_agents_md.md`.
+2. **Reference, never fork**: the per-repo file points to the workspace
+   `AGENTS.md` for shared rules and adds only repo-specific content
+   (review context, Quality Standard excerpt, pointers). Restating or
+   rewording workspace rules in a project AGENTS.md is a defect.
+3. The file must carry a standalone context block (Quality Standard,
+   plan-sync convention) because one consumer — Copilot code review — has
+   no workspace access.
+4. `onboard-project` offers the file; `audit-project` checks presence and
+   currency (keyed on the template's stable `## Quality Standard` heading).
+
+## Consequences
+
+### Positive
+
+- Copilot code review on project repos is steered by the same standards the
+  workspace enforces; false-positive review noise becomes measurable
+  (progress.md triage baseline → re-measure after rollout).
+- Coding agents in layer worktrees see repo-specific guidance first.
+
+### Negative
+
+- One more per-repo file to keep current; mitigated by the `audit-project`
+  currency check rather than manual vigilance.
+
+### Neutral
+
+- Rollout is incremental (pilot repos first, tracked per-repo); repos
+  without the file simply behave as before.
+
+## References
+
+- [ADR-0006](0006-adopt-agents-md-as-shared-instruction-file.md) — the
+  workspace-level pattern this extends
+- [ADR-0003](0003-workspace-infrastructure-is-project-agnostic.md) — the
+  template stays generic; repo-specific content is filled per-repo
+- Issue [#563](https://github.com/rolker/ros2_agent_workspace/issues/563)


### PR DESCRIPTION
## Summary

Workspace half of the per-repo root `AGENTS.md` effort: now that GitHub
Copilot code review reads root-level AGENTS.md (2026-06-18), give project
repos a thin instruction file that steers both Copilot reviews and
closest-file-wins coding agents. Pilot rollout (7 repos, ordered by the
~200-classification false-positive baseline) follows in stacked per-repo PRs.

- **New template** `.agent/templates/project_agents_md.md` — standalone
  Quality Standard + plan-sync context (Copilot has no workspace access),
  per-repo Review Context slot, stable `## Quality Standard` currency marker,
  reference-never-fork rule
- **ADR-0017** records the extension decision; ADR-0006 gets a purely
  navigational cross-reference (ADR-0012)
- **`onboard-project`**: checklist row + apply-fixes recipe
- **`audit-project`**: governance-coverage row (Present/Missing/Stale) +
  marker-based currency check
- **`project_governance.md`** template synced (structure, file table,
  adoption levels); knowledge README indexed; one-sentence cross-link in
  workspace AGENTS.md § Project-Level Guidance (operator-approved)

## Review

Full /run-issue lifecycle: issue review → plan → plan review
(changes-requested, ADR mechanism corrected) → implementation → 2 pre-push
review rounds (Deep; round 2 **approved, Ship: recommended**, all findings
addressed). Timeline in `.agent/work-plans/issue-563/progress.md`.

Closes #563

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
