### PR TITLE
docker_run_agent.sh: pre-create anonymous-volume mountpoints user-owned (#566)

### DIFF
--- a/.agent/scripts/docker_run_agent.sh
+++ b/.agent/scripts/docker_run_agent.sh
@@ -336,9 +336,15 @@ MOUNT_ARGS+=(-v "$ROOT_DIR/.agent/scratchpad:$ROOT_DIR/.agent/scratchpad")
 
 # 4. Anonymous volumes for build/install/log in each layer workspace
 #    (container gets its own build artifacts, doesn't pollute host)
+#    Pre-create each mountpoint as the invoking user: docker creates missing
+#    mountpoint sources as root:root, which breaks subsequent host-side builds
+#    (EACCES) — e.g. a container start racing the #559 clean-rebuild heal.
+#    Docker never chowns an existing dir, so mkdir -p here removes the hazard
+#    and is a no-op when the dirs already exist (#566).
 for ws_dir in "$ROOT_DIR"/layers/main/*_ws; do
     [ -d "$ws_dir" ] || continue
     for subdir in build install log; do
+        mkdir -p "$ws_dir/$subdir"
         MOUNT_ARGS+=(-v "$ws_dir/$subdir")
     done
 done

--- a/.agent/scripts/docker_run_agent.sh
+++ b/.agent/scripts/docker_run_agent.sh
@@ -339,12 +339,19 @@ MOUNT_ARGS+=(-v "$ROOT_DIR/.agent/scratchpad:$ROOT_DIR/.agent/scratchpad")
 #    Pre-create each mountpoint as the invoking user: docker creates missing
 #    mountpoint sources as root:root, which breaks subsequent host-side builds
 #    (EACCES) — e.g. a container start racing the #559 clean-rebuild heal.
-#    Docker never chowns an existing dir, so mkdir -p here removes the hazard
-#    and is a no-op when the dirs already exist (#566).
+#    Docker never chowns an existing dir, so mkdir -p here prevents the hazard
+#    in normal use (a concurrent rm between mkdir and docker run remains
+#    possible but self-inflicted) and is a no-op when the dirs exist (#566).
+#    Fail loud if mkdir fails — proceeding would let docker recreate the
+#    mountpoint root-owned, silently defeating the fix.
 for ws_dir in "$ROOT_DIR"/layers/main/*_ws; do
     [ -d "$ws_dir" ] || continue
     for subdir in build install log; do
-        mkdir -p "$ws_dir/$subdir"
+        if ! mkdir -p "$ws_dir/$subdir"; then
+            echo "❌ Error: cannot create mountpoint $ws_dir/$subdir (would be" >&2
+            echo "   created root-owned by docker — see #566). Fix and retry." >&2
+            exit 1
+        fi
         MOUNT_ARGS+=(-v "$ws_dir/$subdir")
     done
 done

--- a/.agent/scripts/test_layer_sourcing.sh
+++ b/.agent/scripts/test_layer_sourcing.sh
@@ -89,10 +89,11 @@ if [ -d "$LAYERS_BASE" ]; then
     NOT_OWNED=()
     CURRENT_UID="$(id -u)"
     # Numeric UID compare: %U prints "UNKNOWN"-style names for orphaned UIDs,
-    # which would false-positive against id -un.
+    # which would false-positive against id -un. GNU stat first, BSD stat -f
+    # fallback (same pattern as discover_governance.sh).
     for d in "$LAYERS_BASE"/*_ws/build "$LAYERS_BASE"/*_ws/install "$LAYERS_BASE"/*_ws/log; do
         [ -d "$d" ] || continue
-        owner_uid=$(stat -c %u "$d" 2>/dev/null) || continue
+        owner_uid=$(stat -c %u "$d" 2>/dev/null || stat -f %u "$d" 2>/dev/null) || continue
         [ "$owner_uid" != "$CURRENT_UID" ] && NOT_OWNED+=("$d (owner uid: $owner_uid)")
     done
     if [ ${#NOT_OWNED[@]} -eq 0 ]; then

--- a/.agent/scripts/test_layer_sourcing.sh
+++ b/.agent/scripts/test_layer_sourcing.sh
@@ -16,6 +16,13 @@
 #      built with higher layers sourced (the pre-#559 build.sh bug) and needs
 #      the one-time bottom-up clean rebuild to heal. Warning-only because
 #      pre-existing installs are expected to be polluted until healed.
+#   4. MOUNTPOINT OWNERSHIP (warning only): layer build/install/log dirs must
+#      be owned by the invoking user. Docker creates missing anonymous-volume
+#      mountpoints as root:root (pre-#566 docker_run_agent.sh), which blocks
+#      host-side builds with EACCES. Runs whenever layers/main exists — NOT
+#      behind the Checks 2-3 built-layer early-exit, because the failure state
+#      (empty root-owned dirs, nothing built) is exactly the one with no built
+#      layers. Reported as Check 4 even though it prints before Checks 2-3.
 #
 # Exit codes: 0 = pass (or skipped), 1 = check failed.
 
@@ -73,6 +80,32 @@ if [ ! -f "$ROOT_DIR/configs/manifest/layers.txt" ]; then
 fi
 LAYERS_CONFIG="$MAIN_ROOT/configs/manifest/layers.txt"
 LAYERS_BASE="$MAIN_ROOT/layers/main"
+
+# --- Check 4: mountpoint ownership (warning only) ---
+# Deliberately placed BEFORE the Checks 2-3 early-exits: the root-owned
+# failure state (#566) is typically one where nothing is built, so gating
+# this on built layers would skip it exactly when it matters.
+if [ -d "$LAYERS_BASE" ]; then
+    NOT_OWNED=()
+    CURRENT_USER="$(id -un)"
+    for d in "$LAYERS_BASE"/*_ws/build "$LAYERS_BASE"/*_ws/install "$LAYERS_BASE"/*_ws/log; do
+        [ -d "$d" ] || continue
+        owner=$(stat -c %U "$d" 2>/dev/null) || continue
+        [ "$owner" != "$CURRENT_USER" ] && NOT_OWNED+=("$d (owner: $owner)")
+    done
+    if [ ${#NOT_OWNED[@]} -eq 0 ]; then
+        echo "✅ Check 4: layer build/install/log dirs are user-owned"
+    else
+        echo "⚠️  Check 4 (warning): non-user-owned layer artifact dirs:"
+        printf '     %s\n' "${NOT_OWNED[@]}"
+        echo "   Docker creates missing anonymous-volume mountpoints as root when"
+        echo "   an agent container starts (#566; fixed in docker_run_agent.sh)."
+        echo "   Fix: remove the dirs (empty root-owned dirs rmdir fine as the"
+        echo "   user since the parent is user-owned), recreate with mkdir, and"
+        echo "   re-run the build."
+    fi
+fi
+
 if [ ! -f "$LAYERS_CONFIG" ]; then
     echo "⏭️  Checks 2-3 skipped: no layers.txt at $LAYERS_CONFIG"
     exit "$((FAILURES > 0 ? 1 : 0))"

--- a/.agent/scripts/test_layer_sourcing.sh
+++ b/.agent/scripts/test_layer_sourcing.sh
@@ -87,11 +87,13 @@ LAYERS_BASE="$MAIN_ROOT/layers/main"
 # this on built layers would skip it exactly when it matters.
 if [ -d "$LAYERS_BASE" ]; then
     NOT_OWNED=()
-    CURRENT_USER="$(id -un)"
+    CURRENT_UID="$(id -u)"
+    # Numeric UID compare: %U prints "UNKNOWN"-style names for orphaned UIDs,
+    # which would false-positive against id -un.
     for d in "$LAYERS_BASE"/*_ws/build "$LAYERS_BASE"/*_ws/install "$LAYERS_BASE"/*_ws/log; do
         [ -d "$d" ] || continue
-        owner=$(stat -c %U "$d" 2>/dev/null) || continue
-        [ "$owner" != "$CURRENT_USER" ] && NOT_OWNED+=("$d (owner: $owner)")
+        owner_uid=$(stat -c %u "$d" 2>/dev/null) || continue
+        [ "$owner_uid" != "$CURRENT_UID" ] && NOT_OWNED+=("$d (owner uid: $owner_uid)")
     done
     if [ ${#NOT_OWNED[@]} -eq 0 ]; then
         echo "✅ Check 4: layer build/install/log dirs are user-owned"

--- a/.agent/work-plans/issue-566/plan.md
+++ b/.agent/work-plans/issue-566/plan.md
@@ -36,12 +36,16 @@ mountpoints and never chowns existing ones.
 
 3. **`test_layer_sourcing.sh` Check 4 — root-ownership detection** — add a
    warning-level check that scans `layers/main/*_ws/{build,install,log}` for
-   directories owned by root. Warning-only (not a hard fail): the core fix prevents
-   new occurrences, but the check surfaces the state if a root-owned dir survives from
-   before the fix or enters via another path. Run only when `LAYERS_BASE` is visible
-   (same skip condition as Checks 2–3). Add a one-line entry to the
-   `## Consequences` section of ADR-0016 noting that `make validate` now detects the
-   stale-root-owned state.
+   directories not owned by the invoking user. Warning-only (not a hard fail): the
+   core fix prevents new occurrences, but the check surfaces the state if a
+   root-owned dir survives from before the fix or enters via another path.
+   *Per plan review (operator-approved)*: gate on `[ -d "$LAYERS_BASE" ]` and run
+   **before** the Checks 2–3 early-exits — the #566 failure state (empty
+   root-owned dirs, build blocked) is exactly one with no built layers, so the
+   Checks 2–3 skip condition would suppress the check precisely when needed.
+   Add a one-line entry to the `## Consequences` section of ADR-0016 noting that
+   `make validate` now detects the stale-root-owned state. Also refresh the
+   AGENTS.md script-table row for the guard (it enumerates the checks).
 
 ## Files to Change
 

--- a/.agent/work-plans/issue-566/plan.md
+++ b/.agent/work-plans/issue-566/plan.md
@@ -1,0 +1,87 @@
+# Plan: Fix docker_run_agent.sh anonymous volumes creating root-owned host dirs
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/566
+
+## Context
+
+`docker_run_agent.sh` adds anonymous volumes for each layer's `build/`, `install/`,
+and `log/` subdirectories to isolate container build artifacts from the host. When
+those directories don't exist at container start, Docker creates them as `root:root`
+on the host. Any subsequent host-side colcon process writing to those paths fails with
+`EACCES`.
+
+This was observed during the #559 heal rebuild: a concurrent agent container for issue
+#563 re-created the still-missing `simulation_ws/{build,install,log}` as root-owned,
+blocking `make build`.
+
+The fix is a single `mkdir -p` call inside the existing loop, which pre-creates each
+mountpoint as the invoking user before Docker can claim it. Docker only creates missing
+mountpoints and never chowns existing ones.
+
+## Approach
+
+1. **Core fix — pre-create mountpoints in `docker_run_agent.sh`** — add `mkdir -p
+   "$ws_dir/$subdir"` inside the inner loop (section 4, ~line 340), immediately before
+   the `-v "$ws_dir/$subdir"` anonymous-volume entry. The outer `[ -d "$ws_dir" ]`
+   guard already ensures `$ws_dir` exists; `mkdir -p` for each subdir is safe to call
+   unconditionally (a no-op if the dir already exists and user-owned).
+
+2. **ADR-0016 Consequences update** — add a note to the `## Consequences` section of
+   `docs/decisions/0016-runtime-vs-baked-layer-chaining.md` documenting the
+   concurrent-container-dispatch collision hazard and referencing the fix. The issue
+   body derives directly from the #559 incident; without this note the hazard and its
+   fix exist only in issue history.
+
+3. **`test_layer_sourcing.sh` Check 4 — root-ownership detection** — add a
+   warning-level check that scans `layers/main/*_ws/{build,install,log}` for
+   directories owned by root. Warning-only (not a hard fail): the core fix prevents
+   new occurrences, but the check surfaces the state if a root-owned dir survives from
+   before the fix or enters via another path. Run only when `LAYERS_BASE` is visible
+   (same skip condition as Checks 2–3). Add a one-line entry to the
+   `## Consequences` section of ADR-0016 noting that `make validate` now detects the
+   stale-root-owned state.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/docker_run_agent.sh` | Add `mkdir -p "$ws_dir/$subdir"` before anonymous-volume `-v` line in section-4 loop |
+| `docs/decisions/0016-runtime-vs-baked-layer-chaining.md` | Add Consequences note: concurrent-container hazard + `make validate` detection |
+| `.agent/scripts/test_layer_sourcing.sh` | Add Check 4: warning if any `build/install/log` dir under `layers/main` is root-owned |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Enforcement over documentation | Check 4 in `test_layer_sourcing.sh` catches root-owned dirs in `make validate`, not just in prose |
+| Capture decisions, not just implementations | ADR-0016 Consequences note documents the concurrent-dispatch hazard with reference to #559 so the why isn't buried in issue history |
+| A change includes its consequences | All three files updated together; no separate follow-up needed for the ADR or detection |
+| Only what's needed | Three targeted changes; Check 4 is warning-only and reuses the existing layer-scan infrastructure |
+| Test what breaks | Check 4 covers the failure mode (root-owned mountpoints) that the fix prevents |
+| Improve incrementally | Single focused PR; no unrelated cleanup |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0016 — Runtime vs. baked layer chaining | Yes | Consequences section update documents concurrent-container collision; Check 4 enforces the invariant in validate |
+| ADR-0002 — Worktree isolation | Tangential | Fix supports the container-dispatch pathway used alongside worktrees; no structural change needed |
+| ADR-0004 — Enforcement hierarchy | Yes (Check 4 path) | Adding a detection check to `test_layer_sourcing.sh` (run by `make validate`) satisfies the "enforce mechanically" principle |
+
+## Consequences
+
+| If we change… | Also update… | Included in plan? |
+|---|---|---|
+| `docker_run_agent.sh` section-4 loop | No API/interface change; AGENTS.md script-table entry is already accurate at the level of detail it describes | Yes — no cascade needed |
+| ADR-0016 Consequences | Review guide ADR table unchanged (title unchanged); no cascade | Yes — self-contained |
+| `test_layer_sourcing.sh` Check 4 | ADR-0016 Consequences gets a one-liner noting `make validate` detects root-owned dirs (bundled with step 2) | Yes |
+
+## Open Questions
+
+- [ ] No open questions — plan is review-plan-ready.
+
+## Estimated Scope
+
+Single PR. All three changes are in workspace infrastructure files, no ROS packages affected.

--- a/.agent/work-plans/issue-566/progress.md
+++ b/.agent/work-plans/issue-566/progress.md
@@ -76,3 +76,20 @@ The issue was observed concurrently with the #559 heal rebuild.
 
 ### Findings
 - [ ] (suggestion) Check 4 skip condition: gate on `[ -d "$LAYERS_BASE" ]`, not the Checks 2–3 "no built layers" early-exit (`test_layer_sourcing.sh:87-88`) — the #559 failure state has empty root-owned dirs that blocked the build, so `BUILT` is empty and the script would `exit` before Check 4 runs, skipping the exact state it targets — `plan.md:41`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-14 17:06 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-566 at `b96b37a`
+**Mode**: pre-push
+**Depth**: Deep (reason: non-status-bump edit to existing ADR-0016 + governance-touching AGENTS.md)
+**Must-fix**: 0 | **Suggestions**: 3
+**Round**: 1 | **Ship**: recommended — no must-fix; static clean, both Deep adversarial passes returned suggestions only
+
+### Findings
+- [ ] (suggestion) `mkdir -p` has no failure handling; a silent failure would let Docker recreate the mountpoint root-owned, defeating the fix — `.agent/scripts/docker_run_agent.sh:347`
+- [ ] (suggestion) Compare numeric UIDs (`stat -c %u` vs `id -u`) instead of `%U`/`id -un` to avoid false-positive warnings on orphaned UIDs — `.agent/scripts/test_layer_sourcing.sh:93`
+- [ ] (suggestion) Comment "removes the hazard" overclaims vs residual concurrent-`rm` window; soften to "prevents in normal use" — `.agent/scripts/docker_run_agent.sh:342`

--- a/.agent/work-plans/issue-566/progress.md
+++ b/.agent/work-plans/issue-566/progress.md
@@ -93,3 +93,17 @@ The issue was observed concurrently with the #559 heal rebuild.
 - [ ] (suggestion) `mkdir -p` has no failure handling; a silent failure would let Docker recreate the mountpoint root-owned, defeating the fix — `.agent/scripts/docker_run_agent.sh:347`
 - [ ] (suggestion) Compare numeric UIDs (`stat -c %u` vs `id -u`) instead of `%U`/`id -un` to avoid false-positive warnings on orphaned UIDs — `.agent/scripts/test_layer_sourcing.sh:93`
 - [ ] (suggestion) Comment "removes the hazard" overclaims vs residual concurrent-`rm` window; soften to "prevents in normal use" — `.agent/scripts/docker_run_agent.sh:342`
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-14 13:42 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**Branch**: feature/issue-566 at `7b1fc58`
+**Addressed**: Local Review (Pre-Push) — Round 1, approved / Ship: recommended; 3 suggestions host-applied pre-publish
+**Commits**: `7b1fc58`
+
+### Actions
+- [x] (suggestion) mkdir -p failure handling in docker_run_agent.sh (`7b1fc58`)
+- [x] (suggestion) Check 4 numeric-UID comparison (`7b1fc58`)
+- [x] (suggestion) softened over-claiming comment (`7b1fc58`)

--- a/.agent/work-plans/issue-566/progress.md
+++ b/.agent/work-plans/issue-566/progress.md
@@ -64,3 +64,15 @@ The issue was observed concurrently with the #559 heal rebuild.
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-14 16:49 +00:00
+**By**: Claude Code Agent (Claude Opus) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-566/plan.md` at `e1b2182`
+**PR**: PR-less
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) Check 4 skip condition: gate on `[ -d "$LAYERS_BASE" ]`, not the Checks 2–3 "no built layers" early-exit (`test_layer_sourcing.sh:87-88`) — the #559 failure state has empty root-owned dirs that blocked the build, so `BUILT` is empty and the script would `exit` before Check 4 runs, skipping the exact state it targets — `plan.md:41`

--- a/.agent/work-plans/issue-566/progress.md
+++ b/.agent/work-plans/issue-566/progress.md
@@ -1,0 +1,54 @@
+---
+issue: 566
+---
+
+# Issue #566 — Fix docker_run_agent.sh anonymous volumes creating root-owned host dirs
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-14 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #566
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Summary
+
+`docker_run_agent.sh` mounts layer `build/install/log` dirs as anonymous volumes
+without pre-creating the host mountpoints. When those dirs don't exist at container
+start, Docker creates them as `root:root`, causing `EACCES` for host-side colcon
+processes. The fix is one `mkdir -p` call per subdir inside the existing loop.
+The issue was observed concurrently with the #559 heal rebuild.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | Fix is minimal; behavior change is explicit — dirs created before mount |
+| Enforcement over documentation | Watch | Optional `test_layer_sourcing.sh` hardening (root-ownership detection) would enforce the invariant; worth including if low-cost |
+| Capture decisions, not just implementations | Watch | ADR-0016 Consequences describes the clean-rebuild procedure but omits the concurrent-container hazard; a short note there preserves institutional knowledge |
+| A change includes its consequences | Action needed | Issue flags ADR-0016 update and optional test hardening as "Consider." Implementation must scope them in or explicitly defer with reasoning |
+| Only what's needed | OK | Core fix is a single line; optional items are incremental |
+| Improve incrementally | OK | Single clear PR |
+| Test what breaks | Watch | No automated check for root-owned mountpoints; optional `test_layer_sourcing.sh` check would catch this in `make validate` |
+| Workspace vs. project separation | OK | Fix is in workspace script `.agent/scripts/docker_run_agent.sh` |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| ADR-0016 — Runtime vs. baked layer chaining | Yes | Consequences section describes the clean rebuild (`rm -rf layers/main/*_ws/{build,install,log} && make build`) that triggered this bug; a note on concurrent-container-dispatch collision belongs there |
+| ADR-0002 — Worktree isolation | Tangential | Fix supports the container-dispatch pathway used with worktrees |
+| ADR-0004 — Enforcement hierarchy | Conditional | Applies if `test_layer_sourcing.sh` hardening is in scope — detection in CI/validate strengthens enforcement |
+
+### Consequences
+
+- `docker_run_agent.sh` change: no AGENTS.md script-table update needed (entry already exists; behavior description is unaffected at that level of detail).
+- If ADR-0016 is updated: review guide ADR table title is unchanged — no cascade.
+- If `test_layer_sourcing.sh` gets root-ownership detection: `make validate` surface and script-reference table in AGENTS.md already list the script; no structural update needed.
+
+### Actions
+- [ ] Add `mkdir -p "$ws_dir/$subdir"` before the anonymous-volume line in `docker_run_agent.sh` (the core fix)
+- [ ] Evaluate including an ADR-0016 heal-instructions note about concurrent-container-dispatch collision (low cost, preserves context from the #559 incident)
+- [ ] Evaluate whether root-ownership detection in `test_layer_sourcing.sh` (or `make build`) belongs in this PR or a separate follow-up issue

--- a/.agent/work-plans/issue-566/progress.md
+++ b/.agent/work-plans/issue-566/progress.md
@@ -52,3 +52,15 @@ The issue was observed concurrently with the #559 heal rebuild.
 - [ ] Add `mkdir -p "$ws_dir/$subdir"` before the anonymous-volume line in `docker_run_agent.sh` (the core fix)
 - [ ] Evaluate including an ADR-0016 heal-instructions note about concurrent-container-dispatch collision (low cost, preserves context from the #559 incident)
 - [ ] Evaluate whether root-ownership detection in `test_layer_sourcing.sh` (or `make build`) belongs in this PR or a separate follow-up issue
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-14 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-566/plan.md` at `e1b2182`
+**Branch**: feature/issue-566 at `e1b2182`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-566/progress.md
+++ b/.agent/work-plans/issue-566/progress.md
@@ -107,3 +107,19 @@ The issue was observed concurrently with the #559 heal rebuild.
 - [x] (suggestion) mkdir -p failure handling in docker_run_agent.sh (`7b1fc58`)
 - [x] (suggestion) Check 4 numeric-UID comparison (`7b1fc58`)
 - [x] (suggestion) softened over-claiming comment (`7b1fc58`)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-14 14:14 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #568 at `2e00096`
+**Sources**: 3 (Copilot R1 @ `2e00096`, Local Review (Pre-Push) R1 @ `b96b37a`, CI rollup)
+**Cross-source confirmations**: 0
+**CI**: all-pass (lint, commit identity, script tests, docs validation)
+
+### Findings
+- [x] (minor, Copilot) bare GNU `stat -c` in Check 4 silently false-passes on BSD/macOS via `|| continue` — fixed with the discover_governance.sh GNU→BSD fallback pattern (`18d10ac`) — `.agent/scripts/test_layer_sourcing.sh`
+
+### False positives
+(none)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,7 +491,7 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/fetch_pr_reviews.sh` | Fetch all PR reviews and CI status |
 | `.agent/scripts/progress_read.py` | Extract `progress.md` entries by type + correlation key as JSON (consumed by `triage-reviews` integrator) |
 | `.agent/scripts/test_check_commit_identity.sh` | Regression test for `check-commit-identity.py` branch+env gate |
-| `.agent/scripts/test_layer_sourcing.sh` | Regression guard for runtime layer chaining (ADR-0016 / #559): static no-baked-chain-source check + built-layer overlay precedence + baked-chain purity; run by `make test-scripts` / `make validate` |
+| `.agent/scripts/test_layer_sourcing.sh` | Regression guard for runtime layer chaining (ADR-0016 / #559, #566): static no-baked-chain-source check + built-layer overlay precedence + baked-chain purity + mountpoint ownership; run by `make test-scripts` / `make validate` |
 | `.agent/hooks/identity_patterns.py` | Shared agent/human email patterns + agent-branch regex (imported by commit-identity hooks + CI script) |
 | `.agent/hooks/check_pr_authors.py` | CI-callable PR-commit author validator (Mechanism C from issue #468) |
 

--- a/docs/decisions/0016-runtime-vs-baked-layer-chaining.md
+++ b/docs/decisions/0016-runtime-vs-baked-layer-chaining.md
@@ -71,6 +71,15 @@ chains themselves.
   (or the worktree's generated `setup.bash`), which is now cheap.
 - Existing worktrees keep their old generated scripts (slow but functional)
   and age out as worktrees are removed.
+- **Concurrent container dispatch can race the clean rebuild**
+  ([#566](https://github.com/rolker/ros2_agent_workspace/issues/566)): agent
+  containers declare anonymous volumes at every layer's `build/install/log`
+  path, and docker creates missing mountpoints **root-owned** — during the
+  first #559 heal attempt, a concurrently dispatched container re-created the
+  deleted dirs as root and the rebuild failed with `EACCES`.
+  `docker_run_agent.sh` now pre-creates the mountpoints user-owned before
+  `docker run`, and `test_layer_sourcing.sh` Check 4 (run by `make validate`)
+  detects any surviving root-owned artifact dirs with remediation steps.
 
 ## References
 


### PR DESCRIPTION
Closes #566

## What

`docker_run_agent.sh` pre-creates every anonymous-volume mountpoint (`layers/main/*_ws/{build,install,log}`) as the invoking user before `docker run`, failing loud if it can't. Docker creates missing mountpoint sources as `root:root` and never chowns existing ones — so pre-creating removes the hazard where a container start leaves root-owned dirs that block host-side builds with `EACCES`.

## Why

During the #559 heal rebuild, a concurrently dispatched agent container (issue #563) re-created the just-deleted `simulation_ws`/`ui_ws` artifact dirs root-owned — twice — failing `make build` both times. Full timeline and `docker events` evidence in #566.

## Changes

- **`docker_run_agent.sh`**: `mkdir -p` (with loud failure) before each anonymous-volume `-v` arg. Sandbox-verified: identical `-v` args, dirs user-owned.
- **`test_layer_sourcing.sh` Check 4**: warning-level numeric-UID ownership scan of layer artifact dirs, with remediation steps. Deliberately gated on `layers/main` existing and placed **before** the built-layer early-exits — the failure state is exactly one with nothing built (plan-review catch).
- **ADR-0016**: Consequences note documenting the container-dispatch/clean-rebuild race, the fix, and the detection.
- **AGENTS.md**: guard's Script Reference row refreshed to enumerate Check 4.

## Review history

Pre-push review round 1: **approved / Ship: recommended** (no must-fix; both Deep adversarial passes suggestions-only). All 3 suggestions applied pre-publish: mkdir failure handling, numeric-UID compare, comment scope softened.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
