### PR TITLE
review-code: add default-on Local Model Adversarial Specialist (Ollama, --no-local opt-out)

### DIFF
--- a/.agent/knowledge/review_depth_classification.md
+++ b/.agent/knowledge/review_depth_classification.md
@@ -70,11 +70,14 @@ source path differs:
 - Claude Adversarial — one pass (Lens A: logic & correctness)
 - Copilot Adversarial — **opt-in only** (`--copilot`); off by default,
   skipped with notice if opted in but the CLI is unavailable
+- Local Model Adversarial — **default-on** (`--no-local` to opt out);
+  skipped with notice if the Ollama server/model is unavailable
 
 **Report format**: Condensed — static analysis findings, Claude
 Adversarial findings, plus a one-line governance note ("No governance
 concerns for a change of this scope"). A Copilot Adversarial section
-appears only when `--copilot` was passed.
+appears only when `--copilot` was passed; a Local Adversarial section
+(or its skip notice) appears unless `--no-local` was passed.
 
 #### Standard
 
@@ -92,6 +95,8 @@ appears only when `--copilot` was passed.
   cross-cutting), each a separate fresh-context dispatch
 - Copilot Adversarial — **opt-in only** (`--copilot`); off by default,
   skipped with notice if opted in but the CLI is unavailable
+- Local Model Adversarial — **default-on** (`--no-local` to opt out);
+  skipped with notice if the Ollama server/model is unavailable
 
 **Report format**: Full report with all sections.
 
@@ -106,7 +111,8 @@ appears only when `--copilot` was passed.
 
 **Specialists dispatched**:
 - Same as Standard (two disjoint-lens Claude Adversarial passes;
-  Copilot opt-in via `--copilot`). Deep runs both Claude passes at a
+  Copilot opt-in via `--copilot`; Local Model Adversarial default-on,
+  not tier-differentiated). Deep runs both Claude passes at a
   longer file horizon with an explicit security/concurrency/lifecycle
   checklist, using the same fresh-context dispatch mechanism. The
   Standard→Deep difference is horizon and rigor, not which lenses run.
@@ -122,7 +128,12 @@ appears only when `--copilot` was passed.
 > "Partially adopted" entry in `inspiration_agent_workspace_digest.md`.
 > The Gemini/Codex tmux dispatch from upstream `cross_model_review.sh`
 > remains unadopted. When you want a third or fourth model's read on a
-> Deep PR, run that agent's review-code skill manually.
+> Deep PR, run that agent's review-code skill manually. A quota-free
+> local-model read (Ollama, default `qwen3.5:35b`) is wired in as
+> step 5f (`.agent/scripts/local_review.sh`, default-on, `--no-local`
+> to opt out — see
+> [#570](https://github.com/rolker/ros2_agent_workspace/issues/570));
+> its findings carry low-trust weighting in the silence filter.
 
 ## Override-Trigger Files
 

--- a/.agent/knowledge/skill_workflows.md
+++ b/.agent/knowledge/skill_workflows.md
@@ -35,7 +35,10 @@ auto-classified depth tier — Light runs Static Analysis + one Claude
 Adversarial pass, while Standard and Deep add Governance, Plan Drift,
 and a second disjoint-lens Claude Adversarial pass. Copilot Adversarial
 is opt-in at every tier via `--copilot` (off by default to conserve the
-Premium quota). `review-code` also
+Premium quota). Local Model Adversarial (a quota-free Ollama read via
+`.agent/scripts/local_review.sh`, runtime-agnostic — needs only
+bash/curl/jq and a local Ollama server) is default-on at every tier,
+opted out via `--no-local`. `review-code` also
 accepts a PR number / URL for post-PR review of someone else's work.
 `triage-reviews` runs after a PR has accumulated review comments
 (human + bot) and classifies each against the current code.

--- a/.agent/scripts/local_review.sh
+++ b/.agent/scripts/local_review.sh
@@ -20,7 +20,11 @@
 #   LOCAL_REVIEW_NUM_CTX  context window tokens (default: 32768; the
 #                         script fails loud, with the size it needed,
 #                         when the prompt would overflow this — Ollama
-#                         would otherwise truncate silently. The
+#                         would otherwise truncate silently. A
+#                         post-response check on the server's measured
+#                         prompt_eval_count backstops the byte-based
+#                         estimate: a run whose ingested tokens reach
+#                         the window ceiling fails loud too. The
 #                         window must also fit the model's reasoning:
 #                         qwen3.5:35b thinks for ~7k tokens on even a
 #                         100-line diff, hence the large default and
@@ -182,7 +186,10 @@ EOF
 # Fail loud on context overflow — Ollama silently truncates oversized
 # prompts (dropping the instructions and the head of the diff), which
 # would produce a confident review of a tail fragment. ~3 bytes/token
-# is conservative for diff text. The headroom must cover reasoning +
+# is a typical ratio for diff text, not a guaranteed bound — dense
+# tokenization (byte-level BPE fallback on unusual bytes) can beat it,
+# so a post-response check on the server's measured prompt_eval_count
+# backstops this estimate. The headroom must cover reasoning +
 # answer: a thinking model that runs out of window mid-reasoning
 # returns an empty answer with done_reason=length (observed at 2048
 # headroom on a ~500-line diff).
@@ -253,6 +260,24 @@ CONTENT=$(jq -r '.message.content // empty' "$RESPONSE_FILE" 2>/dev/null) || {
     echo "local review failed: non-JSON response from $BASE_URL (proxy in the way?)" >&2
     exit 1
 }
+
+# Silent-truncation guard: the pre-flight size check estimates tokens
+# from bytes, and dense tokenization can beat the estimate — the server
+# then silently drops the head of the prompt (the instructions) and the
+# model confidently reviews a tail fragment. Truncation is detectable
+# post-hoc from the tokens the server actually ingested: the pre-check
+# guarantees an untruncated prompt leaves >= 12288 tokens of window
+# free, so an ingested count at the ceiling can only mean the prompt
+# was cut down to fit (or the estimate undershot so badly the answer
+# is untrustworthy anyway). Caveat: server-side prompt caching may
+# report fewer ingested tokens than the full prompt, so this check can
+# miss — it is a backstop for the pre-check, not a replacement.
+PROMPT_EVAL=$(jq -r '.prompt_eval_count // 0' "$RESPONSE_FILE" 2>/dev/null || echo 0)
+if (( PROMPT_EVAL >= NUM_CTX - 1024 )); then
+    echo "local review failed: prompt filled the context window (server ingested $PROMPT_EVAL of num_ctx=$NUM_CTX tokens) — input was likely silently truncated;" >&2
+    echo "  raise LOCAL_REVIEW_NUM_CTX (needs RAM) or review a smaller diff" >&2
+    exit 1
+fi
 
 if [[ -z "$CONTENT" ]]; then
     DONE_REASON=$(jq -r '.done_reason // "unknown"' "$RESPONSE_FILE" 2>/dev/null || echo "unparseable")

--- a/.agent/scripts/local_review.sh
+++ b/.agent/scripts/local_review.sh
@@ -17,10 +17,14 @@
 #                         up for large diffs — reasoning time grows
 #                         with diff size, and a ~500-line diff can
 #                         exceed 600s on 8GB-VRAM-class hardware)
-#   LOCAL_REVIEW_NUM_CTX  context window tokens (default: 16384; the
+#   LOCAL_REVIEW_NUM_CTX  context window tokens (default: 32768; the
 #                         script fails loud, with the size it needed,
 #                         when the prompt would overflow this — Ollama
-#                         would otherwise truncate silently)
+#                         would otherwise truncate silently. The
+#                         window must also fit the model's reasoning:
+#                         qwen3.5:35b thinks for ~7k tokens on even a
+#                         100-line diff, hence the large default and
+#                         the 12k-token answer/reasoning headroom)
 #
 # Exit codes:
 #   0  review produced (findings on stdout)
@@ -52,7 +56,7 @@ set -euo pipefail
 MODEL="${LOCAL_REVIEW_MODEL:-qwen3.5:35b}"
 BASE_URL="${LOCAL_REVIEW_URL:-http://localhost:11434}"
 TIMEOUT="${LOCAL_REVIEW_TIMEOUT:-900}"
-NUM_CTX="${LOCAL_REVIEW_NUM_CTX:-16384}"
+NUM_CTX="${LOCAL_REVIEW_NUM_CTX:-32768}"
 
 BASE_BRANCH=""
 CONTEXT_FILE=""
@@ -178,8 +182,11 @@ EOF
 # Fail loud on context overflow — Ollama silently truncates oversized
 # prompts (dropping the instructions and the head of the diff), which
 # would produce a confident review of a tail fragment. ~3 bytes/token
-# is conservative for diff text; reserve headroom for the answer.
-EST_TOKENS=$(( ${#PROMPT} / 3 + 2048 ))
+# is conservative for diff text. The headroom must cover reasoning +
+# answer: a thinking model that runs out of window mid-reasoning
+# returns an empty answer with done_reason=length (observed at 2048
+# headroom on a ~500-line diff).
+EST_TOKENS=$(( ${#PROMPT} / 3 + 12288 ))
 if (( EST_TOKENS > NUM_CTX )); then
     echo "Error: prompt (~$EST_TOKENS tokens incl. answer headroom) exceeds num_ctx=$NUM_CTX;" >&2
     echo "  re-run with LOCAL_REVIEW_NUM_CTX=$EST_TOKENS (needs RAM) or review a smaller diff" >&2
@@ -249,7 +256,11 @@ CONTENT=$(jq -r '.message.content // empty' "$RESPONSE_FILE" 2>/dev/null) || {
 
 if [[ -z "$CONTENT" ]]; then
     DONE_REASON=$(jq -r '.done_reason // "unknown"' "$RESPONSE_FILE" 2>/dev/null || echo "unparseable")
-    echo "local review failed: model returned an empty answer (done_reason: $DONE_REASON)" >&2
+    if [[ "$DONE_REASON" == "length" ]]; then
+        echo "local review failed: reasoning consumed the context window before an answer was produced (done_reason: length); raise LOCAL_REVIEW_NUM_CTX (current: $NUM_CTX)" >&2
+    else
+        echo "local review failed: model returned an empty answer (done_reason: $DONE_REASON)" >&2
+    fi
     exit 1
 fi
 

--- a/.agent/scripts/local_review.sh
+++ b/.agent/scripts/local_review.sh
@@ -13,14 +13,28 @@
 # Environment:
 #   LOCAL_REVIEW_MODEL    model tag (default: qwen3.5:35b)
 #   LOCAL_REVIEW_URL      Ollama base URL (default: http://localhost:11434)
-#   LOCAL_REVIEW_TIMEOUT  request timeout seconds (default: 600)
-#   LOCAL_REVIEW_NUM_CTX  context window tokens (default: 16384)
+#   LOCAL_REVIEW_TIMEOUT  request timeout seconds (default: 900; scale
+#                         up for large diffs — reasoning time grows
+#                         with diff size, and a ~500-line diff can
+#                         exceed 600s on 8GB-VRAM-class hardware)
+#   LOCAL_REVIEW_NUM_CTX  context window tokens (default: 16384; the
+#                         script fails loud, with the size it needed,
+#                         when the prompt would overflow this — Ollama
+#                         would otherwise truncate silently)
 #
 # Exit codes:
 #   0  review produced (findings on stdout)
-#   1  invocation error (timeout, HTTP error, empty answer)
-#   2  unavailable (server down or model not pulled) — callers should
-#      treat this as skip-with-notice, not failure
+#   1  invocation error (timeout, HTTP error, empty answer, oversized
+#      prompt, bad configuration)
+#   2  unavailable (server down, model not pulled, or jq missing) —
+#      callers should treat this as skip-with-notice, not failure
+#   Callers must treat any other exit status as 1 (defensive: an
+#   unhandled tool failure under `set -e` can surface its own code).
+#
+# Reasoning models: requests are sent with think:true so the model can
+# reason before answering; if the server rejects that for a
+# non-reasoning LOCAL_REVIEW_MODEL, the request is retried once with
+# think:false, so non-reasoning models work without configuration.
 #
 # Uses the HTTP API rather than `ollama run`: with reasoning models the
 # CLI's thinking handling can swallow the entire answer (observed with
@@ -37,7 +51,7 @@ set -euo pipefail
 
 MODEL="${LOCAL_REVIEW_MODEL:-qwen3.5:35b}"
 BASE_URL="${LOCAL_REVIEW_URL:-http://localhost:11434}"
-TIMEOUT="${LOCAL_REVIEW_TIMEOUT:-600}"
+TIMEOUT="${LOCAL_REVIEW_TIMEOUT:-900}"
 NUM_CTX="${LOCAL_REVIEW_NUM_CTX:-16384}"
 
 BASE_BRANCH=""
@@ -70,7 +84,10 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -h|--help)
-            sed -n '2,28p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            # Print the header comment block (everything from line 2 to
+            # the first non-comment line) so the help text cannot drift
+            # from the documentation above as lines are added/removed.
+            awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "${BASH_SOURCE[0]}"
             exit 0
             ;;
         *)
@@ -80,10 +97,18 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]] || ! [[ "$NUM_CTX" =~ ^[0-9]+$ ]]; then
+    echo "Error: LOCAL_REVIEW_TIMEOUT and LOCAL_REVIEW_NUM_CTX must be plain integers (got '$TIMEOUT' / '$NUM_CTX')" >&2
+    exit 1
+fi
+
 # --- Gather the diff ---
 
 if [[ -n "$BASE_BRANCH" ]]; then
-    DIFF=$(git diff --merge-base "$BASE_BRANCH" HEAD)
+    DIFF=$(git diff --merge-base "$BASE_BRANCH" HEAD) || {
+        echo "Error: git diff failed for base '$BASE_BRANCH' (not a ref?)" >&2
+        exit 1
+    }
 elif [[ ! -t 0 ]]; then
     DIFF=$(cat)
 else
@@ -98,13 +123,21 @@ fi
 
 # --- Availability probes (exit 2 = skip-with-notice) ---
 
+if ! command -v jq >/dev/null 2>&1; then
+    echo "local review unavailable: jq not installed" >&2
+    exit 2
+fi
+
 if ! curl -sf --max-time 5 "$BASE_URL/api/version" >/dev/null 2>&1; then
     echo "local review unavailable: no Ollama server at $BASE_URL" >&2
     exit 2
 fi
 
+# Accept both fully-tagged names and the bare form users pass to
+# `ollama run` (Ollama registers untagged pulls as "<name>:latest").
 if ! curl -sf --max-time 10 "$BASE_URL/api/tags" 2>/dev/null \
-        | jq -e --arg m "$MODEL" '.models[] | select(.name == $m)' >/dev/null; then
+        | jq -e --arg m "$MODEL" \
+            '.models[] | select(.name == $m or .name == ($m + ":latest"))' >/dev/null; then
     echo "local review unavailable: model '$MODEL' not pulled (ollama pull $MODEL)" >&2
     exit 2
 fi
@@ -142,36 +175,81 @@ $DIFF
 EOF
 )
 
+# Fail loud on context overflow — Ollama silently truncates oversized
+# prompts (dropping the instructions and the head of the diff), which
+# would produce a confident review of a tail fragment. ~3 bytes/token
+# is conservative for diff text; reserve headroom for the answer.
+EST_TOKENS=$(( ${#PROMPT} / 3 + 2048 ))
+if (( EST_TOKENS > NUM_CTX )); then
+    echo "Error: prompt (~$EST_TOKENS tokens incl. answer headroom) exceeds num_ctx=$NUM_CTX;" >&2
+    echo "  re-run with LOCAL_REVIEW_NUM_CTX=$EST_TOKENS (needs RAM) or review a smaller diff" >&2
+    exit 1
+fi
+
 # --- Invoke ---
 
-RESPONSE_FILE=$(mktemp /tmp/local_review.XXXXXX.json)
-trap 'rm -f "$RESPONSE_FILE"' EXIT
+PROMPT_FILE=$(mktemp /tmp/local_review_prompt.XXXXXX)
+BODY_FILE=$(mktemp /tmp/local_review_body.XXXXXX)
+RESPONSE_FILE=$(mktemp /tmp/local_review_resp.XXXXXX)
+trap 'rm -f "$PROMPT_FILE" "$BODY_FILE" "$RESPONSE_FILE"' EXIT
 
-HTTP_CODE=$(jq -n \
+# Prompt travels via file + --rawfile: as an --arg it would be a single
+# execve argument, capped at ~128 KB on Linux (MAX_ARG_STRLEN) — large
+# diffs would fail before ever reaching the model.
+printf '%s' "$PROMPT" > "$PROMPT_FILE"
+
+build_body() {  # $1 = "true" | "false" (think flag)
+    jq -n \
         --arg model "$MODEL" \
-        --arg prompt "$PROMPT" \
+        --rawfile prompt "$PROMPT_FILE" \
         --argjson num_ctx "$NUM_CTX" \
+        --argjson think "$1" \
         '{model: $model,
           messages: [{role: "user", content: $prompt}],
-          stream: false, think: true,
-          options: {num_ctx: $num_ctx}}' \
-    | curl -s --max-time "$TIMEOUT" \
+          stream: false, think: $think,
+          options: {num_ctx: $num_ctx}}' > "$BODY_FILE"
+}
+
+send_request() {
+    # curl runs alone here (jq already wrote $BODY_FILE) so a failure
+    # is attributable: exit 28 = timeout, anything else = transport.
+    CURL_EXIT=0
+    HTTP_CODE=$(curl -s --max-time "$TIMEOUT" \
         -o "$RESPONSE_FILE" -w '%{http_code}' \
         -H 'Content-Type: application/json' \
-        -d @- "$BASE_URL/api/chat") || {
-    echo "local review failed: request timed out or connection lost (${TIMEOUT}s limit)" >&2
-    exit 1
+        -d @"$BODY_FILE" "$BASE_URL/api/chat") || CURL_EXIT=$?
+    if [[ "$CURL_EXIT" == "28" ]]; then
+        echo "local review failed: request timed out (${TIMEOUT}s limit; LOCAL_REVIEW_TIMEOUT to raise)" >&2
+        exit 1
+    elif [[ "$CURL_EXIT" != "0" ]]; then
+        echo "local review failed: connection to $BASE_URL failed (curl exit $CURL_EXIT)" >&2
+        exit 1
+    fi
 }
+
+build_body true
+send_request
+
+# Non-reasoning models reject think:true with a 400; retry once without.
+if [[ "$HTTP_CODE" == "400" ]] \
+        && grep -qi "does not support thinking" "$RESPONSE_FILE"; then
+    build_body false
+    send_request
+fi
 
 if [[ "$HTTP_CODE" != "200" ]]; then
     echo "local review failed: HTTP $HTTP_CODE: $(head -c 200 "$RESPONSE_FILE")" >&2
     exit 1
 fi
 
-CONTENT=$(jq -r '.message.content // empty' "$RESPONSE_FILE")
+CONTENT=$(jq -r '.message.content // empty' "$RESPONSE_FILE" 2>/dev/null) || {
+    echo "local review failed: non-JSON response from $BASE_URL (proxy in the way?)" >&2
+    exit 1
+}
 
 if [[ -z "$CONTENT" ]]; then
-    echo "local review failed: model returned an empty answer (done_reason: $(jq -r '.done_reason // "unknown"' "$RESPONSE_FILE"))" >&2
+    DONE_REASON=$(jq -r '.done_reason // "unknown"' "$RESPONSE_FILE" 2>/dev/null || echo "unparseable")
+    echo "local review failed: model returned an empty answer (done_reason: $DONE_REASON)" >&2
     exit 1
 fi
 

--- a/.agent/scripts/local_review.sh
+++ b/.agent/scripts/local_review.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# Local Model Adversarial Review
+# Sends a diff to a locally served Ollama model and prints its review
+# findings to stdout. Used by the review-code skill (specialist 5f) and
+# usable standalone — including offline / field mode, where the
+# GitHub- and Claude-based review pipeline is unavailable.
+#
+# Usage:
+#   git diff main...HEAD | local_review.sh            # diff on stdin
+#   local_review.sh --base main                        # diff computed here
+#   local_review.sh --base main --context ctx.txt      # extra task context
+#
+# Environment:
+#   LOCAL_REVIEW_MODEL    model tag (default: qwen3.5:35b)
+#   LOCAL_REVIEW_URL      Ollama base URL (default: http://localhost:11434)
+#   LOCAL_REVIEW_TIMEOUT  request timeout seconds (default: 600)
+#   LOCAL_REVIEW_NUM_CTX  context window tokens (default: 16384)
+#
+# Exit codes:
+#   0  review produced (findings on stdout)
+#   1  invocation error (timeout, HTTP error, empty answer)
+#   2  unavailable (server down or model not pulled) — callers should
+#      treat this as skip-with-notice, not failure
+#
+# Uses the HTTP API rather than `ollama run`: with reasoning models the
+# CLI's thinking handling can swallow the entire answer (observed with
+# qwen3.5:35b + --hidethinking on ollama 0.32.0), while /api/chat
+# returns thinking and content as separate fields.
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    echo "Error: This script should be executed, not sourced." >&2
+    echo "  Run: ${BASH_SOURCE[0]} $*" >&2
+    return 1
+fi
+
+set -euo pipefail
+
+MODEL="${LOCAL_REVIEW_MODEL:-qwen3.5:35b}"
+BASE_URL="${LOCAL_REVIEW_URL:-http://localhost:11434}"
+TIMEOUT="${LOCAL_REVIEW_TIMEOUT:-600}"
+NUM_CTX="${LOCAL_REVIEW_NUM_CTX:-16384}"
+
+BASE_BRANCH=""
+CONTEXT_FILE=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --base)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --base requires a branch name" >&2
+                exit 1
+            fi
+            BASE_BRANCH="$2"
+            shift 2
+            ;;
+        --context)
+            if [[ -z "${2:-}" || ! -r "${2:-}" ]]; then
+                echo "Error: --context requires a readable file" >&2
+                exit 1
+            fi
+            CONTEXT_FILE="$2"
+            shift 2
+            ;;
+        --model)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --model requires a model tag" >&2
+                exit 1
+            fi
+            MODEL="$2"
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,28p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# --- Gather the diff ---
+
+if [[ -n "$BASE_BRANCH" ]]; then
+    DIFF=$(git diff --merge-base "$BASE_BRANCH" HEAD)
+elif [[ ! -t 0 ]]; then
+    DIFF=$(cat)
+else
+    echo "Error: pipe a diff on stdin or pass --base <branch>" >&2
+    exit 1
+fi
+
+if [[ -z "$DIFF" ]]; then
+    echo "Error: diff is empty — nothing to review" >&2
+    exit 1
+fi
+
+# --- Availability probes (exit 2 = skip-with-notice) ---
+
+if ! curl -sf --max-time 5 "$BASE_URL/api/version" >/dev/null 2>&1; then
+    echo "local review unavailable: no Ollama server at $BASE_URL" >&2
+    exit 2
+fi
+
+if ! curl -sf --max-time 10 "$BASE_URL/api/tags" 2>/dev/null \
+        | jq -e --arg m "$MODEL" '.models[] | select(.name == $m)' >/dev/null; then
+    echo "local review unavailable: model '$MODEL' not pulled (ollama pull $MODEL)" >&2
+    exit 2
+fi
+
+# --- Build the prompt ---
+
+CONTEXT=""
+if [[ -n "$CONTEXT_FILE" ]]; then
+    CONTEXT=$(cat "$CONTEXT_FILE")
+fi
+
+PROMPT=$(cat <<EOF
+You are a rigorous code reviewer for a ROS 2 robotics workspace
+(autonomous survey boats — robustness is mandatory, silent failures are
+unacceptable). Review the following diff.
+
+${CONTEXT:+Task context: $CONTEXT
+
+}Focus areas: missed edge cases and boundary conditions; assumption
+violations; subtle bugs (off-by-one, race conditions, resource leaks);
+logic errors (does the code do what it claims?); security implications;
+concurrency and lifecycle ordering; cross-cutting effects; portability
+(GNU vs BSD tools); silent-failure paths; misleading comments.
+
+Rules: review only what the diff changes (lines starting with + or -);
+do not flag unchanged context lines. Only report defects you can trace
+to specific changed lines — no speculation about environments or inputs
+the code visibly does not target. Number the findings. For each give:
+file, line(s), why it is wrong, and a concrete failure scenario. Do not
+pad with style nits. If you find nothing, say "No findings."
+
+DIFF:
+
+$DIFF
+EOF
+)
+
+# --- Invoke ---
+
+RESPONSE_FILE=$(mktemp /tmp/local_review.XXXXXX.json)
+trap 'rm -f "$RESPONSE_FILE"' EXIT
+
+HTTP_CODE=$(jq -n \
+        --arg model "$MODEL" \
+        --arg prompt "$PROMPT" \
+        --argjson num_ctx "$NUM_CTX" \
+        '{model: $model,
+          messages: [{role: "user", content: $prompt}],
+          stream: false, think: true,
+          options: {num_ctx: $num_ctx}}' \
+    | curl -s --max-time "$TIMEOUT" \
+        -o "$RESPONSE_FILE" -w '%{http_code}' \
+        -H 'Content-Type: application/json' \
+        -d @- "$BASE_URL/api/chat") || {
+    echo "local review failed: request timed out or connection lost (${TIMEOUT}s limit)" >&2
+    exit 1
+}
+
+if [[ "$HTTP_CODE" != "200" ]]; then
+    echo "local review failed: HTTP $HTTP_CODE: $(head -c 200 "$RESPONSE_FILE")" >&2
+    exit 1
+fi
+
+CONTENT=$(jq -r '.message.content // empty' "$RESPONSE_FILE")
+
+if [[ -z "$CONTENT" ]]; then
+    echo "local review failed: model returned an empty answer (done_reason: $(jq -r '.done_reason // "unknown"' "$RESPONSE_FILE"))" >&2
+    exit 1
+fi
+
+echo "## Local Adversarial ($MODEL)"
+echo
+echo "$CONTENT"

--- a/.agent/scripts/local_review.sh
+++ b/.agent/scripts/local_review.sh
@@ -279,13 +279,22 @@ if (( PROMPT_EVAL >= NUM_CTX - 1024 )); then
     exit 1
 fi
 
-if [[ -z "$CONTENT" ]]; then
-    DONE_REASON=$(jq -r '.done_reason // "unknown"' "$RESPONSE_FILE" 2>/dev/null || echo "unparseable")
-    if [[ "$DONE_REASON" == "length" ]]; then
+# done_reason must be checked independent of content emptiness: a
+# window exhausted mid-answer yields non-empty content that reads as a
+# complete review but is a truncated findings list — as untrustworthy
+# as an empty one.
+DONE_REASON=$(jq -r '.done_reason // "unknown"' "$RESPONSE_FILE" 2>/dev/null || echo "unparseable")
+if [[ "$DONE_REASON" == "length" ]]; then
+    if [[ -z "$CONTENT" ]]; then
         echo "local review failed: reasoning consumed the context window before an answer was produced (done_reason: length); raise LOCAL_REVIEW_NUM_CTX (current: $NUM_CTX)" >&2
     else
-        echo "local review failed: model returned an empty answer (done_reason: $DONE_REASON)" >&2
+        echo "local review failed: answer was cut off mid-stream by the context window (done_reason: length) — a partial findings list is not trustworthy; raise LOCAL_REVIEW_NUM_CTX (current: $NUM_CTX)" >&2
     fi
+    exit 1
+fi
+
+if [[ -z "$CONTENT" ]]; then
+    echo "local review failed: model returned an empty answer (done_reason: $DONE_REASON)" >&2
     exit 1
 fi
 

--- a/.agent/work-plans/issue-570/progress.md
+++ b/.agent/work-plans/issue-570/progress.md
@@ -124,3 +124,22 @@ localhost:11434); Copilot off (default). Plan Drift skipped (no plan.md).
 
 ### Findings
 - [x] (must-fix) mid-answer truncation silently accepted as complete — `done_reason == "length"` is only checked when `$CONTENT` is empty, so a non-empty answer truncated mid-stream (content + `done_reason: length`) prints as a clean review and exits 0; guard it independent of content emptiness — `.agent/scripts/local_review.sh:282`
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-24 09:55 -0400
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #571 at `67b8ea5`
+**Addressed**: Local Review (Pre-Push) @ 2026-07-24 13:01 +00:00 (round 2, `c7d6354`)
+**Commits**: `67b8ea5`
+
+### Actions
+- [x] Mid-answer truncation silently accepted as complete — `done_reason`
+  is now checked independent of content emptiness: `length` with
+  non-empty content fails loud ("answer was cut off mid-stream ... a
+  partial findings list is not trustworthy"), `length` with empty
+  content keeps the reasoning-exhaustion message, and the plain
+  empty-answer check follows. Verified all three response shapes
+  against mock servers (mid-truncation → exit 1, empty+length →
+  exit 1, normal → exit 0) — `.agent/scripts/local_review.sh`

--- a/.agent/work-plans/issue-570/progress.md
+++ b/.agent/work-plans/issue-570/progress.md
@@ -65,7 +65,7 @@ claims at different heads, so not a formal cross-confirmation)
 **CI**: all-pass
 
 ### Findings
-- [ ] (medium, Copilot) Context-overflow guard's `~3 bytes/token` estimate is
+- [x] (medium, Copilot) Context-overflow guard's `~3 bytes/token` estimate is
   not conservative for dense tokenization; silent *input* truncation (model
   confidently reviews a tail fragment) can slip past both the pre-check and
   the `done_reason=length` post-check — `.agent/scripts/local_review.sh:189`.

--- a/.agent/work-plans/issue-570/progress.md
+++ b/.agent/work-plans/issue-570/progress.md
@@ -51,3 +51,35 @@ interrupted by a host shutdown; rerun with:
 `git diff --merge-base main HEAD | .agent/scripts/local_review.sh --context <ctx>`
 The specialist's mechanics are verified end-to-end regardless (small-diff
 run produced findings; llama3.2:1b fallback run produced findings).
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-24 08:38 -0400
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #571 at `86f26e1`
+**Sources**: 3 (Copilot R1 @ `86f26e1`, Local Review (Pre-Push) @ `a7c7038`, CI rollup)
+**Cross-source confirmations**: 0 (Copilot's finding refines the guard the
+pre-push review's suggestion #10 introduced — related lineage, different
+claims at different heads, so not a formal cross-confirmation)
+**CI**: all-pass
+
+### Findings
+- [ ] (medium, Copilot) Context-overflow guard's `~3 bytes/token` estimate is
+  not conservative for dense tokenization; silent *input* truncation (model
+  confidently reviews a tail fragment) can slip past both the pre-check and
+  the `done_reason=length` post-check — `.agent/scripts/local_review.sh:189`.
+  Scope verified: at default 32k ctx the slip requires <~1.9 bytes/token
+  (pathological but possible — byte-BPE fallback on unusual bytes), and the
+  guard *weakens as `LOCAL_REVIEW_NUM_CTX` grows* because the 12288-token
+  headroom is fixed while the byte budget scales — and the overflow error
+  message itself steers users to raise num_ctx. Root-cause fix: post-response
+  check on the API's `prompt_eval_count` — fail loud when it reaches the
+  num_ctx ceiling (actual measured tokens, no bytes/token guessing);
+  optionally soften the "conservative" claim in the comment.
+
+### False positives
+- (Copilot, partial) "may ... still hit `done_reason=length` behavior" — the
+  empty-answer/`done_reason=length` case is already caught loud post-hoc
+  (`local_review.sh:257-264`, exit 1 with a raise-num_ctx message); only the
+  silent-input-truncation half of the claim stands (tracked above).

--- a/.agent/work-plans/issue-570/progress.md
+++ b/.agent/work-plans/issue-570/progress.md
@@ -123,4 +123,4 @@ systemic/safety); Local Adversarial skipped (no Ollama server at
 localhost:11434); Copilot off (default). Plan Drift skipped (no plan.md).
 
 ### Findings
-- [ ] (must-fix) mid-answer truncation silently accepted as complete — `done_reason == "length"` is only checked when `$CONTENT` is empty, so a non-empty answer truncated mid-stream (content + `done_reason: length`) prints as a clean review and exits 0; guard it independent of content emptiness — `.agent/scripts/local_review.sh:282`
+- [x] (must-fix) mid-answer truncation silently accepted as complete — `done_reason == "length"` is only checked when `$CONTENT` is empty, so a non-empty answer truncated mid-stream (content + `done_reason: length`) prints as a clean review and exits 0; guard it independent of content emptiness — `.agent/scripts/local_review.sh:282`

--- a/.agent/work-plans/issue-570/progress.md
+++ b/.agent/work-plans/issue-570/progress.md
@@ -83,3 +83,22 @@ claims at different heads, so not a formal cross-confirmation)
   empty-answer/`done_reason=length` case is already caught loud post-hoc
   (`local_review.sh:257-264`, exit 1 with a raise-num_ctx message); only the
   silent-input-truncation half of the claim stands (tracked above).
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-24 08:46 -0400
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #571 at `947465d`
+**Addressed**: Integrated Review @ 2026-07-24 08:38 -0400 (PR #571 at `86f26e1`)
+**Commits**: `947465d`
+
+### Actions
+- [x] Silent-input-truncation gap in the context-overflow guard — added a
+  post-response check on the server's measured `prompt_eval_count` (fail
+  loud, exit 1, when ingested tokens reach the num_ctx ceiling), softened
+  the "conservative" claim in the pre-check comment, and documented the
+  backstop in the header/--help block. Verified both the guard path
+  (mock server reporting ceiling ingestion → exit 1 with actionable
+  message) and the happy path (normal ingestion → review printed,
+  exit 0) — `.agent/scripts/local_review.sh:189`

--- a/.agent/work-plans/issue-570/progress.md
+++ b/.agent/work-plans/issue-570/progress.md
@@ -1,0 +1,53 @@
+---
+issue: 570
+---
+
+# Issue #570 — review-code: default-on Local Model Adversarial Specialist (Ollama qwen3.5) with --no-local opt-out
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-16 15:58 -0400
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: approved
+
+**Branch**: feature/issue-570 at `a7c7038`
+**Mode**: pre-push
+**Depth**: Standard (reason: new workspace script + governance-adjacent skill/knowledge docs)
+**Must-fix**: 5 (all fixed) | **Suggestions**: 8 (all fixed)
+**Round**: 1 | **Ship**: recommended — all 13 adversarial findings fixed and re-verified; static clean
+
+**Specialists**: Static Analysis (shellcheck, full severity: clean);
+Governance/consequence pass (found 2 stale specialist rosters in
+knowledge docs — fixed in `d0fa8e1`); Claude Adversarial (1 fresh-context
+pass, both lenses: 13 findings, several experimentally verified);
+Local Adversarial (dogfooded on this branch's own diff — see below).
+
+### Findings (all addressed in `21221a6` / `a7c7038`)
+- [x] (must-fix) prompt passed as single argv arg — Linux MAX_ARG_STRLEN caps at ~128KB; large diffs never reached the model → `--rawfile` via temp file — `.agent/scripts/local_review.sh`
+- [x] (must-fix) hardcoded `think:true` broke `LOCAL_REVIEW_MODEL` override for non-reasoning models → auto-retry without think on the server's 400; verified live with llama3.2:1b — `.agent/scripts/local_review.sh`
+- [x] (must-fix) 5f snippet used undefined `$BASE_BRANCH` and diffed local base instead of `origin/$BASE` → matches step 1's diff now — `.claude/skills/review-code/SKILL.md`
+- [x] (must-fix) no post-PR invocation path (default-on in both modes) → `gh pr diff` variant added — `.claude/skills/review-code/SKILL.md`
+- [x] (must-fix) full + Light report templates had no home for the Local Adversarial skip notice → header lines added — `.claude/skills/review-code/SKILL.md`
+- [x] (suggestion) `LOCAL_EXIT=$?` unreachable under errexit → `|| LOCAL_EXIT=$?` form
+- [x] (suggestion) `||` handler misattributed every pipeline failure to curl → body-build and curl separated, per-cause messages
+- [x] (suggestion) missing jq misdiagnosed as "model not pulled" → jq preflight, exit 2
+- [x] (suggestion) exact-match model probe rejected bare names → also matches `<name>:latest`
+- [x] (suggestion) silent truncation when prompt > num_ctx → fail-loud pre-check with required size
+- [x] (suggestion) undocumented exit codes could escape 0/1/2 contract → guarded git/jq calls + documented catch-all
+- [x] (suggestion) fixed `/tmp` stderr path in snippet → mktemp'd + trapped
+- [x] (suggestion) `--help` hardcoded line range → extracts whole header block
+
+### Dogfood calibration (Local Adversarial on its own diff)
+Two failed runs were themselves the most valuable review input — each
+exposed a real defect the fixes above address:
+1. 600s timeout on a ~500-line diff (default was sized to the 104-line
+   calibration diff) → default 900s + guidance.
+2. Empty answer with `done_reason=length`: the model consumed the whole
+   16k window reasoning before answering → default num_ctx 32768,
+   overflow headroom 2048→12288, actionable error message.
+
+Final validation run (fixed script, 32k ctx, full branch diff) was
+interrupted by a host shutdown; rerun with:
+`git diff --merge-base main HEAD | .agent/scripts/local_review.sh --context <ctx>`
+The specialist's mechanics are verified end-to-end regardless (small-diff
+run produced findings; llama3.2:1b fallback run produced findings).

--- a/.agent/work-plans/issue-570/progress.md
+++ b/.agent/work-plans/issue-570/progress.md
@@ -102,3 +102,25 @@ claims at different heads, so not a formal cross-confirmation)
   (mock server reporting ceiling ingestion → exit 1 with actionable
   message) and the happy path (normal ingestion → review printed,
   exit 0) — `.agent/scripts/local_review.sh:189`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-24 13:01 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-570 at `c7d6354`
+**Mode**: pre-push
+**Depth**: Standard (reason: governance files — SKILL.md, knowledge docs, AGENTS.md — plus a new workspace script)
+**Must-fix**: 1 | **Suggestions**: 0
+**Round**: 2 | **Ship**: recommended — single low, mechanical must-fix; count not rising vs. round 1's 5; address and ship
+
+**Specialists**: Static Analysis (shellcheck --severity=warning: clean);
+Governance/consequence pass (script→AGENTS.md row, 5f→roster docs,
+--no-local→templates all present and consistent); Claude Adversarial
+(2 disjoint-lens fresh-context passes — Lens A logic, Lens B
+systemic/safety); Local Adversarial skipped (no Ollama server at
+localhost:11434); Copilot off (default). Plan Drift skipped (no plan.md).
+
+### Findings
+- [ ] (must-fix) mid-answer truncation silently accepted as complete — `done_reason == "length"` is only checked when `$CONTENT` is empty, so a non-empty answer truncated mid-stream (content + `done_reason: length`) prints as a clean review and exits 0; guard it independent of content emptiness — `.agent/scripts/local_review.sh:282`

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -742,22 +742,36 @@ workstation):
 ```bash
 CTX_FILE=$(mktemp /tmp/local_review_ctx.XXXXXX)
 LOCAL_FINDINGS=$(mktemp /tmp/local_review_out.XXXXXX)
-trap 'rm -f "$CTX_FILE" "$LOCAL_FINDINGS"' EXIT
+LOCAL_ERR=$(mktemp /tmp/local_review_err.XXXXXX)
+trap 'rm -f "$CTX_FILE" "$LOCAL_FINDINGS" "$LOCAL_ERR"' EXIT
 echo "<one-line summary: issue #N — what the change does>" > "$CTX_FILE"
 
-git diff --merge-base "$BASE_BRANCH" HEAD \
-    | "$REPO_ROOT/.agent/scripts/local_review.sh" --context "$CTX_FILE" \
-    > "$LOCAL_FINDINGS" 2>/tmp/local_review_err.txt
-LOCAL_EXIT=$?
-# Exit 2 = unavailable (no server / model not pulled): skip with the
-#          one-line reason from stderr — not a failure.
-# Exit 1 = invocation error (timeout, HTTP error, empty answer): skip
-#          with notice; never let a local-model hiccup block the review.
+# Same diff the other specialists reviewed (step 1): origin/$BASE in
+# pre-push mode, the PR diff in post-PR mode — never the local base
+# branch, which may be stale in a worktree.
+LOCAL_EXIT=0
+if [[ "$MODE" == "post-PR" ]]; then
+    gh pr diff "$PR" \
+        | "$REPO_ROOT/.agent/scripts/local_review.sh" --context "$CTX_FILE" \
+        > "$LOCAL_FINDINGS" 2>"$LOCAL_ERR" || LOCAL_EXIT=$?
+else
+    git diff "origin/$BASE...HEAD" \
+        | "$REPO_ROOT/.agent/scripts/local_review.sh" --context "$CTX_FILE" \
+        > "$LOCAL_FINDINGS" 2>"$LOCAL_ERR" || LOCAL_EXIT=$?
+fi
+# The `|| LOCAL_EXIT=$?` form keeps the assignment reachable under an
+# errexit shell — a bare `LOCAL_EXIT=$?` on the next line would never
+# run when the pipeline fails and `set -e` is active.
+# Exit 2 = unavailable (no server / model not pulled / no jq): skip
+#          with the one-line reason from $LOCAL_ERR — not a failure.
+# Exit 1 (or anything else non-zero) = invocation error: skip with
+#          notice; never let a local-model hiccup block the review.
 # Exit 0 = findings in $LOCAL_FINDINGS.
 ```
 
 The helper handles the availability probes, the bounded timeout
-(`LOCAL_REVIEW_TIMEOUT`, default 600 s), and reasoning-model plumbing
+(`LOCAL_REVIEW_TIMEOUT`, default 900 s — raise it for large diffs;
+reasoning time grows with diff size), and reasoning-model plumbing
 (HTTP API with `think: true` — the `ollama run` CLI path can swallow
 the entire answer after a full reasoning pass; see the script header).
 Model and endpoint are overridable via `LOCAL_REVIEW_MODEL` /
@@ -858,6 +872,7 @@ review indefinitely:
 **Static analysis**: <run | skipped (--skip-static)>
 **Claude Adversarial**: <1 pass (Lens A) | 2 passes (Lens A + Lens B)>
 **Copilot Adversarial**: <off (default) | run (--copilot) | skipped (<reason>, --copilot)>
+**Local Adversarial**: <run (<model>) | skipped (<reason>) | off (--no-local)>
 **Context**: <status of review-context.yaml — fresh / stale / not found / N/A>
 
 ### Must-Fix
@@ -915,6 +930,7 @@ Existing Review Comments sections. Use:
 **Static analysis**: skipped (--skip-static)         <!-- include only when SKIP_STATIC=true -->
 **Claude Adversarial**: 1 pass (Lens A)
 **Copilot Adversarial**: <off (default) | run (--copilot) | skipped (<reason>, --copilot)>
+**Local Adversarial**: <run (<model>) | skipped (<reason>) | off (--no-local)>
 
 ### Static Analysis
 

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-code
-description: Lead reviewer that orchestrates specialist sub-reviews (static analysis, governance, plan drift, adversarial) to evaluate a PR or pre-push diff. Scales review depth to change risk. Produces a unified structured report and persists findings to progress.md.
+description: Lead reviewer that orchestrates specialist sub-reviews (static analysis, governance, plan drift, adversarial, local cross-model) to evaluate a PR or pre-push diff. Scales review depth to change risk. Produces a unified structured report and persists findings to progress.md.
 ---
 
 # Review Code
@@ -8,9 +8,9 @@ description: Lead reviewer that orchestrates specialist sub-reviews (static anal
 ## Usage
 
 ```
-/review-code [--base <branch>] [--skip-static] [--no-progress] [--issue <N>] [--copilot] [light|standard|deep]
+/review-code [--base <branch>] [--skip-static] [--no-progress] [--issue <N>] [--copilot] [--no-local] [light|standard|deep]
                                             # pre-push: diff vs default branch
-/review-code <pr-number-or-url> [--skip-static] [--copilot] [--allow-untrusted-copilot] [light|standard|deep]
+/review-code <pr-number-or-url> [--skip-static] [--copilot] [--allow-untrusted-copilot] [--no-local] [light|standard|deep]
                                             # post-PR: diff vs PR base
 ```
 
@@ -42,6 +42,15 @@ Flags:
   in-house Claude adversarial passes (5d) provide the adversarial
   coverage. (`--no-copilot` is accepted as a deprecated no-op, since
   Copilot is already off by default.)
+- **`--no-local`** (both modes) opts out of the Local Model Adversarial
+  Specialist (5f). Local review is **on by default** — it costs no API
+  quota (local Ollama inference), but on current hardware it is the
+  long-pole specialist (~7 min per run; see
+  [#570](https://github.com/rolker/ros2_agent_workspace/issues/570)).
+  Pass `--no-local` for fast iteration loops or when the machine is
+  busy with inference-heavy work. When the Ollama server or the model
+  is unavailable, the specialist skips itself with a one-line notice —
+  no flag needed.
 - **`--allow-untrusted-copilot`** (post-PR only) overrides the
   external-PR safety gate that suppresses Copilot Adversarial when the
   PR head is from a fork or a non-collaborator author. Only meaningful
@@ -86,7 +95,9 @@ post comments or modify the PR unless the user asks.
 
 Copilot Adversarial is **opt-in at every tier** via `--copilot` — when
 passed, it runs as an additional cross-model read on top of the
-in-house Claude passes.
+in-house Claude passes. Local Model Adversarial is the inverse:
+**on by default at every tier** (local inference is quota-free) and
+opted out with `--no-local`.
 
 **Specialists**:
 - **Static Analysis** — runs linters with ament-aligned configs on
@@ -105,6 +116,13 @@ in-house Claude passes.
   second-vendor read. Off by default to avoid the per-run Premium
   request; skipped with a one-line notice when `copilot` is unavailable
   even if opted in.
+- **Local Model Adversarial** — **default-on** (`--no-local` to opt
+  out) cross-model read by a locally served Ollama model (default
+  `qwen3.5:35b`) via `.agent/scripts/local_review.sh`. Quota-free but
+  low-trust: validated at ~50% precision, so its findings need
+  corroboration or spot-checking before they reach must-fix (see 5f).
+  Skips itself with a one-line notice when the server or model is
+  unavailable.
 
 ## Steps
 
@@ -124,7 +142,9 @@ classification step below as a stray argument),
 post-PR only — emit an error if passed in pre-push mode, where the
 gate doesn't apply; with `COPILOT` unset it has no effect, so emit a
 one-line note "`--allow-untrusted-copilot` ignored: no effect without
-`--copilot`" rather than silently dropping it), `--base <branch>`
+`--copilot`" rather than silently dropping it), `--no-local` (sets
+`NO_LOCAL=1`, opts out of the Local Model Adversarial Specialist in
+step 5f — on by default), `--base <branch>`
 (sets `USER_BASE`), then the optional depth keyword (`light` /
 `standard` / `deep` — positional). Classify what remains:
 
@@ -145,6 +165,7 @@ syntax applies in both modes. Examples:
 /review-code --no-progress                  # pre-push, don't write progress.md
 /review-code --issue 460                    # pre-push, override branch-name issue extraction
 /review-code --copilot                      # pre-push, opt in to Copilot Adversarial
+/review-code --no-local                     # pre-push, opt out of Local Model Adversarial
 /review-code 42                             # post-PR, auto-classify
 /review-code 42 standard                    # post-PR, force Standard
 /review-code 42 --skip-static               # post-PR, skip static analysis
@@ -320,6 +341,8 @@ Run:
 - **5d. Claude Adversarial Specialist** — **one pass** (Lens A only)
 - **5e. Copilot Adversarial Specialist** — only if `COPILOT=1`
   (`--copilot`); skipped with notice if `copilot` unavailable
+- **5f. Local Model Adversarial Specialist** — unless `NO_LOCAL=1`
+  (`--no-local`); skipped with notice if Ollama/model unavailable
 
 #### Standard tier
 
@@ -331,6 +354,8 @@ Run all of:
   lenses (Lens A + Lens B; Standard prompt)
 - **5e. Copilot Adversarial Specialist** — only if `COPILOT=1`
   (`--copilot`); skipped with notice if `copilot` unavailable
+- **5f. Local Model Adversarial Specialist** — unless `NO_LOCAL=1`
+  (`--no-local`); skipped with notice if Ollama/model unavailable
 
 #### Deep tier
 
@@ -338,7 +363,9 @@ Same as Standard, but the two **5d. Claude Adversarial** passes run with
 the Deep prompt (broader file horizon plus an explicit security /
 concurrency / lifecycle checklist). If opted in with `--copilot`,
 **5e. Copilot Adversarial** also runs with the Deep prompt as a third,
-cross-model read.
+cross-model read. **5f. Local Model Adversarial** runs as at other
+tiers (its prompt is not tier-differentiated — the diff is the whole
+horizon a local model can reliably handle).
 
 ---
 
@@ -692,6 +719,74 @@ Report findings in the same format as other specialists. The silence
 filter (step 6) deduplicates overlap with 5d and with the other
 specialists.
 
+#### 5f. Local Model Adversarial Specialist
+
+**Activates by default at every tier**; opted out with `--no-local`
+(`NO_LOCAL=1`). When `NO_LOCAL=1`, skip the entire specialist and omit
+it from the report (like un-opted-in Copilot, absence is the requested
+state).
+
+A quota-free cross-model pass served by a **local Ollama model**
+(default `qwen3.5:35b`), dispatched through
+`.agent/scripts/local_review.sh`. Same fresh-context principle as
+5d/5e — the model sees only the diff and a one-line task context, no
+other specialists' findings. Unlike Copilot, the local model gets **no
+tool access** (prompt-only HTTP call), so there is no untrusted-PR
+gate: adversarial diff content can at worst skew its findings, which
+the low-trust weighting below already discounts.
+
+**Invocation** (run in parallel with the other specialists — it is
+typically the wall-clock long pole, ~7 min on the reference
+workstation):
+
+```bash
+CTX_FILE=$(mktemp /tmp/local_review_ctx.XXXXXX)
+LOCAL_FINDINGS=$(mktemp /tmp/local_review_out.XXXXXX)
+trap 'rm -f "$CTX_FILE" "$LOCAL_FINDINGS"' EXIT
+echo "<one-line summary: issue #N — what the change does>" > "$CTX_FILE"
+
+git diff --merge-base "$BASE_BRANCH" HEAD \
+    | "$REPO_ROOT/.agent/scripts/local_review.sh" --context "$CTX_FILE" \
+    > "$LOCAL_FINDINGS" 2>/tmp/local_review_err.txt
+LOCAL_EXIT=$?
+# Exit 2 = unavailable (no server / model not pulled): skip with the
+#          one-line reason from stderr — not a failure.
+# Exit 1 = invocation error (timeout, HTTP error, empty answer): skip
+#          with notice; never let a local-model hiccup block the review.
+# Exit 0 = findings in $LOCAL_FINDINGS.
+```
+
+The helper handles the availability probes, the bounded timeout
+(`LOCAL_REVIEW_TIMEOUT`, default 600 s), and reasoning-model plumbing
+(HTTP API with `think: true` — the `ollama run` CLI path can swallow
+the entire answer after a full reasoning pass; see the script header).
+Model and endpoint are overridable via `LOCAL_REVIEW_MODEL` /
+`LOCAL_REVIEW_URL` for hosts with different local models.
+
+When skipped (either exit code), the report includes one line:
+`Local Adversarial skipped: <stderr reason>`.
+
+**Low-trust weighting.** Calibration on a known-ground-truth diff
+([#570](https://github.com/rolker/ros2_agent_workspace/issues/570)):
+qwen3.5:35b caught 2 of 4 real findings a full review round had
+caught (including one of Copilot's), but ~half its findings were
+speculative. Treat this source accordingly in step 6:
+
+- A local finding **corroborated** by any other specialist is a strong
+  cross-model confirmation — flag it as such (same as a Copilot
+  cross-confirmation).
+- An **uncorroborated** local finding enters the report at
+  **Suggestion severity at most**, and only after the lead reviewer
+  spot-checks it against the diff (its confident tone is not
+  evidence). Discard findings that reference unchanged context lines
+  or environments the code visibly does not target — those are its
+  documented failure modes.
+
+The specialist is default-on despite the noise because the two real
+catches came at zero quota cost, and the same helper is the offline
+field-mode reviewer — keeping it exercised on every dev review keeps
+it trustworthy in the field.
+
 ### 6. Apply silence filter
 
 Collect all findings from all dispatched specialists and filter:
@@ -838,6 +933,15 @@ Existing Review Comments sections. Use:
 <!-- Copilot Adversarial skipped: <reason>   (when opted in but copilot unavailable) -->
 <!-- Omitted entirely by default, when --copilot was not passed. -->
 
+### Local Adversarial (<model>)
+
+| # | File | Line | Finding |
+|---|------|------|---------|
+| 1 | `path` | 23 | Description (cross-model confirmed by <specialist> / uncorroborated — spot-checked) |
+
+<!-- Local Adversarial skipped: <reason>   (when default-on but Ollama/model unavailable or errored) -->
+<!-- Omitted entirely when opted out with --no-local. -->
+
 No governance concerns for a change of this scope.
 ```
 
@@ -855,6 +959,7 @@ since Claude Adversarial is now unconditional at Light.)
 **Review depth**: <tier> (reason: <signal>)
 **Static analysis**: skipped (--skip-static)         <!-- include only when SKIP_STATIC=true -->
 **Copilot Adversarial**: <run (--copilot) | skipped (<reason>, --copilot)>  <!-- include only when COPILOT=1; shows that an opted-in cross-model pass ran-clean vs. was skipped -->
+**Local Adversarial**: <run (<model>) | skipped (<reason>)>  <!-- omit only when --no-local; shows the default-on local pass ran-clean vs. was skipped -->
 No issues found. LGTM.
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,6 +489,7 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/validate_workspace.py` | Validate repos match .repos config |
 | `.agent/scripts/detect_agent_identity.sh` | Auto-detect agent framework + model |
 | `.agent/scripts/fetch_pr_reviews.sh` | Fetch all PR reviews and CI status |
+| `.agent/scripts/local_review.sh` | Cross-model review of a diff via a local Ollama model (default `qwen3.5:35b`); used by review-code specialist 5f, standalone-capable offline/field (#570) |
 | `.agent/scripts/progress_read.py` | Extract `progress.md` entries by type + correlation key as JSON (consumed by `triage-reviews` integrator) |
 | `.agent/scripts/test_check_commit_identity.sh` | Regression test for `check-commit-identity.py` branch+env gate |
 | `.agent/scripts/test_layer_sourcing.sh` | Regression guard for runtime layer chaining (ADR-0016 / #559, #566): static no-baked-chain-source check + built-layer overlay precedence + baked-chain purity + mountpoint ownership; run by `make test-scripts` / `make validate` |


### PR DESCRIPTION
Closes #570

## What

Adds a **Local Model Adversarial Specialist (5f)** to `/review-code`: a default-on, quota-free cross-model review pass served by local Ollama (default `qwen3.5:35b`), opted out per-run with `--no-local`.

- `.agent/scripts/local_review.sh` — standalone helper (diff on stdin or `--base`); availability probes exit 2 = skip-with-notice; bounded timeout; reasoning-model plumbing (HTTP API, `think:true` with auto-fallback for non-reasoning models); fail-loud context-overflow check. Doubles as the offline/field-mode reviewer.
- `SKILL.md` — 5f wired into all tiers, flag plumbing, report templates, **low-trust weighting** in the silence filter (uncorroborated local findings cap at Suggestion after a spot-check).
- Knowledge docs (`review_depth_classification.md`, `skill_workflows.md`) — specialist rosters updated.
- `AGENTS.md` — script-reference table row only (flagging since instruction files are ask-first; content unchanged otherwise).

## Calibration / verification

- Blind test on the pre-review #566 diff: caught 2 of 4 known findings (incl. Copilot's BSD `stat` catch) with ~50% speculative noise → hence default-on but low-trust.
- Pre-push review of this branch: 13 adversarial findings (5 must-fix) — all fixed and re-verified (see `progress.md`); shellcheck clean at full severity.
- Dogfooding the reviewer on its own diff surfaced two real defects (timeout sizing; reasoning consuming the whole context window, `done_reason=length`) — both fixed with fail-loud diagnostics.
- Think-fallback verified live with `llama3.2:1b`; error paths (no server, missing model, missing jq, bad env, oversized prompt, bad base ref) all exercised.
- One loose end: the final full-branch dogfood validation run was interrupted by a host shutdown; mechanics are verified end-to-end on smaller runs. Will rerun and comment the result.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
