### PR TITLE
ci_local.sh: containerized local CI runner with git-note attestation (#573)

### DIFF
--- a/.agent/scripts/ci_local.sh
+++ b/.agent/scripts/ci_local.sh
@@ -89,6 +89,12 @@ done
 [[ -d "$REPO" ]] || { err "repo path not found: $REPO"; exit 1; }
 REPO="$(cd "$REPO" && pwd)"
 REPO_NAME="$(basename "$REPO")"
+# The path is embedded in a docker -v spec (colon/comma-delimited) and the name
+# in the attestation record — whitespace/control chars or mount metacharacters
+# would produce ambiguous mounts or malformed note records.
+if [[ "$REPO" =~ [[:space:]:,] ]]; then
+  err "repo path contains whitespace, ':' or ',' — unsupported for container mounts: $REPO"; exit 1
+fi
 git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1 || { err "$REPO is not a git repository"; exit 1; }
 # Refuse subdirectories: HEAD/attestation belong to the whole repo — attesting
 # the repo's commit while mounting only a subtree would forge full-repo CI.
@@ -106,6 +112,12 @@ if [[ -z "$IMAGE" ]]; then
     warn "agent image $AGENT_IMAGE not found — falling back to clean room ($CLEAN_IMAGE)"
     IMAGE="$CLEAN_IMAGE"
   fi
+fi
+# The image string is written verbatim into the attestation record; embedded
+# whitespace/newlines could inject a spurious 'ci-local: pass' line and fool
+# note consumers.
+if [[ "$IMAGE" =~ [[:space:]] ]]; then
+  err "--image must not contain whitespace: '$IMAGE'"; exit 1
 fi
 
 # ---- package discovery ------------------------------------------------------
@@ -269,12 +281,15 @@ date: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 host: $(hostname)
 log-sha256: $LOG_HASH"
 # Append, never overwrite: a clean-room record must survive later fast-path
-# re-runs on the same commit.
+# re-runs on the same commit. Explicit tool identity: notes need a committer,
+# and fresh hosts/containers/CI runners have no ambient git config — the tool
+# is the attester (the host is already recorded in the note body).
+NOTES_ID=(-c user.name=ci_local -c user.email=ci-local@localhost)
 if git -C "$REPO" notes --ref="$NOTES_REF" show "$HEAD_SHA" >/dev/null 2>&1; then
-  git -C "$REPO" notes --ref="$NOTES_REF" append -m "
+  git -C "$REPO" "${NOTES_ID[@]}" notes --ref="$NOTES_REF" append -m "
 ---
 $NOTE" "$HEAD_SHA"
 else
-  git -C "$REPO" notes --ref="$NOTES_REF" add -m "$NOTE" "$HEAD_SHA"
+  git -C "$REPO" "${NOTES_ID[@]}" notes --ref="$NOTES_REF" add -m "$NOTE" "$HEAD_SHA"
 fi
 echo "=== ci_local: PASS — attested on $HEAD_SHA (refs/notes/$NOTES_REF, scope: $( [[ $PARTIAL -eq 1 ]] && echo partial || echo full )) ==="

--- a/.agent/scripts/ci_local.sh
+++ b/.agent/scripts/ci_local.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+# ci_local.sh — run a project repo's CI equivalent locally in a container and
+# record an auditable attestation (workspace#573, Phase 1 of workspace#572).
+#
+# Mirrors the workspace CI template semantics (.agent/templates/ci_workflow.yml):
+# overlay workspace around the repo, rosdep install, colcon build (BUILD_TESTING),
+# colcon test (overlay sourced), colcon test-result (always, like if: always()) —
+# inside a throwaway container.
+#
+# What gets built:
+#   attestable run (clean HEAD)  a pristine `git archive HEAD` snapshot — the
+#                                exact commit content, no gitignored/untracked
+#                                files — mirroring hosted CI's actions/checkout
+#   dirty tree / --no-attest     the live working tree, mounted READ-ONLY
+#                                (useful for pre-commit iteration; never attested)
+#
+# Images:
+#   default            ros2-agent-workspace-agent:latest if present (rosdep deps
+#                      baked at image build, #520 — fast path), else clean room
+#   --clean-room       force ros:jazzy-ros-core, replicating hosted CI exactly
+#                      (apt-installs ros-dev-tools at runtime; needs network)
+#
+# Per-repo extras beyond the template (e.g. URDF validation): executable hook
+# at <repo>/.agents/ci_local_extra.sh, run inside the container from the
+# workspace root after tests pass, with the overlay sourced.
+#
+# Attestation: on success of an attestable run, a record is added to a git note
+# on the tested commit under refs/notes/ci-local (repo-local; never perturbs
+# branches; push with `git push origin refs/notes/ci-local` if wanted). Records
+# are APPENDED, never overwritten, so a clean-room record survives later
+# agent-image re-runs. A run narrowed with --packages below the discovered set
+# is recorded as `ci-local: pass (partial)` — consumers must check for the
+# unqualified `ci-local: pass`. Inspect with: git notes --ref=ci-local show <commit>
+# Full log: $CI_LOCAL_LOG_DIR (default <workspace>/.agent/scratchpad/ci_local/).
+#
+# Usage:
+#   ci_local.sh <project_repo_path> [options]
+#
+# Options:
+#   --image IMG      container image (overrides the default selection)
+#   --clean-room     use ros:jazzy-ros-core (exact hosted-CI mirror)
+#   --packages "A B" packages to build/test (default: all packages in the repo;
+#                    a narrowed set is attested as partial)
+#   --no-attest      run against the live tree; never write the attestation note
+#   -n, --dry-run    print the run plan (image, packages, steps); run nothing
+#   -h, --help       this help
+#
+# Exit codes: 0 = CI passed (attested if eligible); non-zero = failed/refused.
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    echo "Error: This script should be executed, not sourced."
+    return 1
+fi
+set -euo pipefail
+
+AGENT_IMAGE="ros2-agent-workspace-agent:latest"
+CLEAN_IMAGE="ros:jazzy-ros-core"
+NOTES_REF="ci-local"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LOG_DIR="${CI_LOCAL_LOG_DIR:-$WORKSPACE_ROOT/.agent/scratchpad/ci_local}"
+
+err() { echo "ci_local: ERROR: $*" >&2; }
+warn() { echo "ci_local: WARN: $*" >&2; }
+
+REPO=""
+IMAGE=""
+CLEAN_ROOM=0
+PACKAGES=""
+NO_ATTEST=0
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --image)      IMAGE="${2:?--image needs a value}"; shift 2 ;;
+    --clean-room) CLEAN_ROOM=1; shift ;;
+    --packages)   PACKAGES="${2:?--packages needs a value}"; shift 2 ;;
+    --no-attest)  NO_ATTEST=1; shift ;;
+    -n|--dry-run) DRY_RUN=1; shift ;;
+    -h|--help)    sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*)           err "unknown option: $1 (try --help)"; exit 1 ;;
+    *)            [[ -z "$REPO" ]] || { err "unexpected argument: $1"; exit 1; }
+                  REPO="$1"; shift ;;
+  esac
+done
+
+[[ -n "$REPO" ]] || { err "usage: ci_local.sh <project_repo_path> [options]"; exit 1; }
+[[ -d "$REPO" ]] || { err "repo path not found: $REPO"; exit 1; }
+REPO="$(cd "$REPO" && pwd)"
+REPO_NAME="$(basename "$REPO")"
+git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1 || { err "$REPO is not a git repository"; exit 1; }
+# Refuse subdirectories: HEAD/attestation belong to the whole repo — attesting
+# the repo's commit while mounting only a subtree would forge full-repo CI.
+TOPLEVEL="$(git -C "$REPO" rev-parse --show-toplevel)"
+[[ "$REPO" == "$TOPLEVEL" ]] || { err "$REPO is inside repo $TOPLEVEL — pass the repo root"; exit 1; }
+command -v docker >/dev/null 2>&1 || { err "docker not found on PATH"; exit 1; }
+
+# ---- image selection --------------------------------------------------------
+if [[ -z "$IMAGE" ]]; then
+  if [[ $CLEAN_ROOM -eq 1 ]]; then
+    IMAGE="$CLEAN_IMAGE"
+  elif docker image inspect "$AGENT_IMAGE" >/dev/null 2>&1; then
+    IMAGE="$AGENT_IMAGE"
+  else
+    warn "agent image $AGENT_IMAGE not found — falling back to clean room ($CLEAN_IMAGE)"
+    IMAGE="$CLEAN_IMAGE"
+  fi
+fi
+
+# ---- package discovery ------------------------------------------------------
+# Mirror colcon discovery: skip hidden dirs and any subtree holding a
+# COLCON_IGNORE marker (fixture/template packages colcon itself won't see).
+discover_packages() {
+  local pkgxml dir names=()
+  while IFS= read -r pkgxml; do
+    dir="$(dirname "$pkgxml")"
+    local d="$dir" ignored=0
+    while [[ "$d" == "$REPO"* ]]; do
+      [[ -e "$d/COLCON_IGNORE" ]] && { ignored=1; break; }
+      d="$(dirname "$d")"
+    done
+    [[ $ignored -eq 1 ]] && continue
+    names+=("$(sed -n 's/.*<name>\(.*\)<\/name>.*/\1/p' "$pkgxml" | head -1)")
+  done < <(find "$REPO" -name package.xml -not -path '*/.*' | sort)
+  printf '%s\n' "${names[@]:-}" | sort -u | grep -v '^$' | tr '\n' ' '
+}
+DISCOVERED="$(discover_packages)"; DISCOVERED="${DISCOVERED% }"
+PARTIAL=0
+if [[ -z "$PACKAGES" ]]; then
+  PACKAGES="$DISCOVERED"
+else
+  norm_req="$(tr ' ' '\n' <<<"$PACKAGES" | grep -v '^$' | sort -u | tr '\n' ' ')"
+  norm_disc="$(tr ' ' '\n' <<<"$DISCOVERED" | grep -v '^$' | sort -u | tr '\n' ' ')"
+  [[ "$norm_req" != "$norm_disc" ]] && PARTIAL=1
+fi
+[[ -n "$PACKAGES" ]] || { err "no ROS packages found under $REPO (no package.xml)"; exit 1; }
+
+# Validate names before they are interpolated into the root inner script: a
+# package.xml <name> (or --packages arg) containing shell metacharacters must
+# never reach the container shell (attestation forgery via injection).
+for p in $PACKAGES; do
+  [[ "$p" =~ ^[A-Za-z0-9_-]+$ ]] || { err "invalid package name: '$p'"; exit 1; }
+done
+
+EXTRA_HOOK=""
+[[ -x "$REPO/.agents/ci_local_extra.sh" ]] && EXTRA_HOOK=".agents/ci_local_extra.sh"
+
+# ---- attestation eligibility ------------------------------------------------
+HEAD_SHA="$(git -C "$REPO" rev-parse HEAD)"
+DIRTY=0
+if [[ -n "$(git -C "$REPO" status --porcelain)" ]]; then
+  DIRTY=1
+fi
+ATTEST=1
+[[ $NO_ATTEST -eq 1 || $DIRTY -eq 1 ]] && ATTEST=0
+
+STEPS="template${EXTRA_HOOK:++extra-hook}"
+PASS_LABEL="ci-local: pass"
+[[ $PARTIAL -eq 1 ]] && PASS_LABEL="ci-local: pass (partial)"
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "=== ci_local plan (dry run) ==="
+  echo "repo     : $REPO"
+  echo "commit   : $HEAD_SHA$( [[ $DIRTY -eq 1 ]] && echo ' (DIRTY — will not attest)' )"
+  echo "image    : $IMAGE"
+  echo "packages : $PACKAGES$( [[ $PARTIAL -eq 1 ]] && echo ' (PARTIAL of: '"$DISCOVERED"')' )"
+  echo "steps    : $STEPS"
+  echo "source   : $( [[ $ATTEST -eq 1 ]] && echo "pristine snapshot of $HEAD_SHA" || echo 'live working tree (read-only)' )"
+  echo "attest   : $( [[ $ATTEST -eq 1 ]] && echo "append '$PASS_LABEL' record, refs/notes/$NOTES_REF on $HEAD_SHA" || echo no )"
+  echo "log dir  : $LOG_DIR"
+  exit 0
+fi
+
+# ---- build source: pristine snapshot when attesting -------------------------
+# Attestable runs must test exactly the commit content (hosted CI checks out a
+# pristine tree): a live mount would let mid-run edits and gitignored files
+# leak into an attested result. Dirty/no-attest runs use the live tree.
+INNER="$(mktemp)"
+SNAP=""
+cleanup() { rm -f "$INNER"; if [[ -n "$SNAP" ]]; then rm -rf "$SNAP"; fi; }
+trap cleanup EXIT
+MOUNT_SRC="$REPO"
+if [[ $ATTEST -eq 1 ]]; then
+  SNAP="$(mktemp -d -t ci_local_snap.XXXXXX)"
+  git -C "$REPO" archive "$HEAD_SHA" | tar -x -C "$SNAP"
+  MOUNT_SRC="$SNAP"
+fi
+
+# ---- inner step script ------------------------------------------------------
+# Same step sequence as the CI template; conditionals make it a no-op-fast on
+# the agent image (tools and deps baked) and a faithful mirror on ros-core.
+cat > "$INNER" <<EOF
+# no -u: ROS setup.bash files reference unbound vars (AMENT_TRACE_SETUP_FILES)
+set -eo pipefail
+export DEBIAN_FRONTEND=noninteractive
+if ! command -v colcon >/dev/null 2>&1; then
+  apt-get update
+  apt-get -y install ros-dev-tools
+fi
+source /opt/ros/jazzy/setup.bash
+if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then rosdep init; fi
+# Tolerate rosdep update failure (offline field host with baked deps, #520):
+# rosdep install -r below still resolves against the existing cache/apt state.
+if [ ! -d "\$HOME/.ros/rosdep/sources.cache" ]; then
+  rosdep update || echo "ci_local(inner): WARN: rosdep update failed (offline?) — proceeding with baked/existing deps"
+fi
+cd /ci
+rosdep install --from-paths src --ignore-src -r -y
+colcon build --packages-up-to $PACKAGES --cmake-args -DBUILD_TESTING=ON
+# local_setup (not setup): ROS is already sourced above; ADR-0016
+source install/local_setup.bash
+# Mirror the template's 'if: always()' test-result step: summarize even when
+# tests fail, then propagate the test exit code.
+test_rc=0
+colcon test --packages-select $PACKAGES --event-handlers console_direct+ --return-code-on-test-failure || test_rc=\$?
+colcon test-result --verbose || true
+if [ "\$test_rc" -ne 0 ]; then exit "\$test_rc"; fi
+EOF
+if [[ -n "$EXTRA_HOOK" ]]; then
+  cat >> "$INNER" <<EOF
+bash "src/$REPO_NAME/$EXTRA_HOOK"
+EOF
+fi
+
+# ---- run --------------------------------------------------------------------
+mkdir -p "$LOG_DIR"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+LOG="$LOG_DIR/${REPO_NAME}-${HEAD_SHA:0:7}-${TS}.log"
+IMAGE_ID="$(docker image inspect --format '{{.Id}}' "$IMAGE" 2>/dev/null || echo unknown)"
+
+echo "=== ci_local: $REPO_NAME @ ${HEAD_SHA:0:7} in $IMAGE ==="
+echo "log: $LOG"
+rc=0
+# --entrypoint bash: the agent image's entrypoint is the agent-container
+# harness (mount validation, ROS2_AGENT_WORKSPACE_ROOT guard); CI only needs
+# the baked toolchain. Harmless on plain ros images.
+docker run --rm --user root --entrypoint bash \
+  -v "$MOUNT_SRC:/ci/src/$REPO_NAME:ro" \
+  -v "$INNER:/ci_local_steps.sh:ro" \
+  "$IMAGE" /ci_local_steps.sh 2>&1 | tee "$LOG" || rc=$?
+
+if [[ $rc -ne 0 ]]; then
+  err "CI FAILED (exit $rc) — log: $LOG"
+  exit "$rc"
+fi
+
+# ---- attestation ------------------------------------------------------------
+if [[ $NO_ATTEST -eq 1 ]]; then
+  echo "=== ci_local: PASS (attestation skipped: --no-attest) ==="
+  exit 0
+fi
+if [[ $DIRTY -eq 1 ]]; then
+  warn "working tree dirty — PASS is not attestable (commit first, re-run to attest)"
+  echo "=== ci_local: PASS (unattested) ==="
+  exit 0
+fi
+
+LOG_HASH="$(sha256sum "$LOG" | cut -d' ' -f1)"
+NOTE="$PASS_LABEL
+repo: $REPO_NAME
+commit: $HEAD_SHA
+image: $IMAGE
+image-id: $IMAGE_ID
+packages: $PACKAGES
+scope: $( [[ $PARTIAL -eq 1 ]] && echo partial || echo full )
+steps: $STEPS
+date: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+host: $(hostname)
+log-sha256: $LOG_HASH"
+# Append, never overwrite: a clean-room record must survive later fast-path
+# re-runs on the same commit.
+if git -C "$REPO" notes --ref="$NOTES_REF" show "$HEAD_SHA" >/dev/null 2>&1; then
+  git -C "$REPO" notes --ref="$NOTES_REF" append -m "
+---
+$NOTE" "$HEAD_SHA"
+else
+  git -C "$REPO" notes --ref="$NOTES_REF" add -m "$NOTE" "$HEAD_SHA"
+fi
+echo "=== ci_local: PASS — attested on $HEAD_SHA (refs/notes/$NOTES_REF, scope: $( [[ $PARTIAL -eq 1 ]] && echo partial || echo full )) ==="

--- a/.agent/scripts/tests/test_ci_local.sh
+++ b/.agent/scripts/tests/test_ci_local.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# test_ci_local.sh — hermetic tests for ci_local.sh (workspace#573).
+# Stubs `docker` on PATH (no containers, no network) and exercises argument
+# handling, package discovery (COLCON_IGNORE, name validation), dry-run
+# planning, pass/fail exit codes, snapshot-vs-live mount selection, and
+# attestation-note semantics (clean vs dirty tree, append-not-overwrite,
+# partial scope, --no-attest, failure).
+set -uo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUT="$TESTS_DIR/../ci_local.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+check() {
+  local desc="$1"; shift
+  if "$@"; then echo "  ok: $desc"; ((++PASS))
+  else echo "  FAIL: $desc"; ((++FAIL)); fi
+}
+contains() { grep -qF -- "$2" <<<"$1"; }
+not_contains() { ! grep -qF -- "$2" <<<"$1"; }
+
+# ---- docker stub ------------------------------------------------------------
+mkdir -p "$TMP/bin"
+export DOCKER_STUB_CALLS="$TMP/docker_calls"
+cat > "$TMP/bin/docker" <<'EOF'
+#!/bin/bash
+case "${1:-}" in
+  image)
+    echo "sha256:stub-image-id"
+    exit 0 ;;
+  run)
+    echo "docker-run: $*" >> "$DOCKER_STUB_CALLS"
+    echo "stub container output"
+    exit "${DOCKER_STUB_RUN_RC:-0}" ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$TMP/bin/docker"
+export PATH="$TMP/bin:$PATH"
+export CI_LOCAL_LOG_DIR="$TMP/logs"
+
+# ---- fixture repo -----------------------------------------------------------
+REPO="$TMP/demo_repo"
+mkdir -p "$REPO/demo_pkg" "$REPO/fixtures/ignored_pkg"
+cat > "$REPO/demo_pkg/package.xml" <<'EOF'
+<?xml version="1.0"?>
+<package format="3">
+  <name>demo_pkg</name>
+  <version>0.0.1</version>
+  <description>fixture</description>
+  <maintainer email="t@t">t</maintainer>
+  <license>BSD</license>
+</package>
+EOF
+# A package colcon would not discover: under a COLCON_IGNORE subtree.
+sed 's/demo_pkg/hidden_fixture_pkg/' "$REPO/demo_pkg/package.xml" > "$REPO/fixtures/ignored_pkg/package.xml"
+touch "$REPO/fixtures/COLCON_IGNORE"
+git -C "$REPO" init -q
+git -C "$REPO" -c user.name=t -c user.email=t@t add -A
+git -C "$REPO" -c user.name=t -c user.email=t@t commit -qm fixture
+HEAD_SHA="$(git -C "$REPO" rev-parse HEAD)"
+
+note_of() { git -C "$REPO" notes --ref=ci-local show "$1" 2>/dev/null; }
+
+echo "== dry run =="
+out=$(bash "$SUT" "$REPO" --dry-run 2>&1); rc=$?
+check "exits 0"                    [ "$rc" -eq 0 ]
+check "discovers package"          contains "$out" "packages : demo_pkg"
+check "skips COLCON_IGNORE subtree" not_contains "$out" hidden_fixture_pkg
+check "plans attestation"          contains "$out" "refs/notes/ci-local on $HEAD_SHA"
+check "plans snapshot source"      contains "$out" "pristine snapshot of $HEAD_SHA"
+check "no container run"           bash -c "! grep -qs docker-run '$DOCKER_STUB_CALLS'"
+
+echo "== --packages narrowing is partial; --no-attest plan =="
+out=$(bash "$SUT" "$REPO" --dry-run --packages "demo_pkg extra_pkg" 2>&1); rc=$?
+check "narrowed set flagged partial" contains "$out" "(PARTIAL of: demo_pkg)"
+out=$(bash "$SUT" "$REPO" --dry-run --no-attest 2>&1); rc=$?
+check "no-attest in plan"          contains "$out" "attest   : no"
+check "no-attest uses live tree"   contains "$out" "live working tree"
+
+echo "== successful run attests from snapshot =="
+out=$(bash "$SUT" "$REPO" 2>&1); rc=$?
+check "exits 0"                    [ "$rc" -eq 0 ]
+check "container ran"              grep -qs docker-run "$DOCKER_STUB_CALLS"
+check "snapshot mounted, not live" bash -c "grep -qs 'ci_local_snap.*:/ci/src/demo_repo:ro' '$DOCKER_STUB_CALLS' && ! grep -qs -- '$REPO:/ci/src/demo_repo:ro' '$DOCKER_STUB_CALLS'"
+check "entrypoint bypassed"        grep -qs -- "--entrypoint bash" "$DOCKER_STUB_CALLS"
+note=$(note_of "$HEAD_SHA")
+check "note says pass"             contains "$note" "ci-local: pass"
+check "note scope full"            contains "$note" "scope: full"
+check "note has commit"            contains "$note" "commit: $HEAD_SHA"
+check "note has log hash"          contains "$note" "log-sha256: "
+log_file=$(ls "$CI_LOCAL_LOG_DIR"/demo_repo-*.log 2>/dev/null | head -1)
+check "log file written"           [ -n "$log_file" ]
+check "log hash matches"           bash -c "[ \"\$(sha256sum '$log_file' | cut -d' ' -f1)\" = \"\$(sed -n 's/^log-sha256: //p' <<<'$note' | head -1)\" ]"
+
+echo "== re-run appends a second record (no overwrite) =="
+out=$(bash "$SUT" "$REPO" 2>&1); rc=$?
+check "exits 0"                    [ "$rc" -eq 0 ]
+check "two pass records"           bash -c "[ \"\$(note_sha() { :; }; git -C '$REPO' notes --ref=ci-local show '$HEAD_SHA' | grep -cF 'ci-local: pass')\" -eq 2 ]"
+check "still one note object"      bash -c "[ \"\$(git -C '$REPO' notes --ref=ci-local list | wc -l)\" -eq 1 ]"
+
+echo "== partial run recorded as partial =="
+git -C "$REPO" notes --ref=ci-local remove "$HEAD_SHA" >/dev/null 2>&1
+out=$(bash "$SUT" "$REPO" --packages "demo_pkg other_pkg" 2>&1); rc=$?
+check "exits 0"                    [ "$rc" -eq 0 ]
+note=$(note_of "$HEAD_SHA")
+check "note marked partial"        contains "$note" "ci-local: pass (partial)"
+check "note scope partial"         contains "$note" "scope: partial"
+git -C "$REPO" notes --ref=ci-local remove "$HEAD_SHA" >/dev/null 2>&1
+
+echo "== dirty tree passes but does not attest, uses live tree =="
+: > "$DOCKER_STUB_CALLS"
+echo x > "$REPO/dirty.txt"
+out=$(bash "$SUT" "$REPO" 2>&1); rc=$?
+check "exits 0"                    [ "$rc" -eq 0 ]
+check "reports unattested"         contains "$out" "PASS (unattested)"
+check "live tree mounted"          grep -qs -- "$REPO:/ci/src/demo_repo:ro" "$DOCKER_STUB_CALLS"
+check "no note written"            bash -c "! git -C '$REPO' notes --ref=ci-local show '$HEAD_SHA' >/dev/null 2>&1"
+rm "$REPO/dirty.txt"
+
+echo "== failing container run =="
+out=$(DOCKER_STUB_RUN_RC=3 bash "$SUT" "$REPO" 2>&1); rc=$?
+check "exits non-zero"             [ "$rc" -ne 0 ]
+check "reports failure"            contains "$out" "CI FAILED"
+check "no note written"            bash -c "! git -C '$REPO' notes --ref=ci-local show '$HEAD_SHA' >/dev/null 2>&1"
+
+echo "== --no-attest run =="
+out=$(bash "$SUT" "$REPO" --no-attest 2>&1); rc=$?
+check "exits 0"                    [ "$rc" -eq 0 ]
+check "reports skip"               contains "$out" "attestation skipped"
+check "no note written"            bash -c "! git -C '$REPO' notes --ref=ci-local show '$HEAD_SHA' >/dev/null 2>&1"
+
+echo "== malicious package name rejected =="
+BADREPO="$TMP/bad_repo"
+mkdir -p "$BADREPO/p"
+printf '<package><name>evil; touch /tmp/pwned</name></package>\n' > "$BADREPO/p/package.xml"
+git -C "$BADREPO" init -q
+git -C "$BADREPO" -c user.name=t -c user.email=t@t add -A
+git -C "$BADREPO" -c user.name=t -c user.email=t@t commit -qm bad
+out=$(bash "$SUT" "$BADREPO" --dry-run 2>&1); rc=$?
+check "injection name rejected"    [ "$rc" -ne 0 ]
+check "names the bad package"      contains "$out" "invalid package name"
+out=$(bash "$SUT" "$REPO" --dry-run --packages 'demo_pkg $(reboot)' 2>&1); rc=$?
+check "injection via --packages rejected" [ "$rc" -ne 0 ]
+
+echo "== argument errors =="
+out=$(bash "$SUT" 2>&1); rc=$?
+check "missing repo rejected"      [ "$rc" -ne 0 ]
+out=$(bash "$SUT" "$TMP/nonexistent" 2>&1); rc=$?
+check "bad path rejected"          [ "$rc" -ne 0 ]
+out=$(bash "$SUT" "$REPO/demo_pkg" 2>&1); rc=$?
+check "subdirectory rejected"      [ "$rc" -ne 0 ]
+check "explains repo root"         contains "$out" "pass the repo root"
+out=$(bash "$SUT" "$REPO" --frobnicate 2>&1); rc=$?
+check "unknown option rejected"    [ "$rc" -ne 0 ]
+mkdir -p "$TMP/no_pkgs" && git -C "$TMP/no_pkgs" init -q
+out=$(bash "$SUT" "$TMP/no_pkgs" --dry-run 2>&1); rc=$?
+check "package-less repo rejected" [ "$rc" -ne 0 ]
+
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.agent/scripts/tests/test_ci_local.sh
+++ b/.agent/scripts/tests/test_ci_local.sh
@@ -43,6 +43,13 @@ chmod +x "$TMP/bin/docker"
 export PATH="$TMP/bin:$PATH"
 export CI_LOCAL_LOG_DIR="$TMP/logs"
 
+# Run the whole harness with NO ambient git identity, exactly like a CI
+# runner or fresh host — the attestation path must not depend on it
+# (regression: the #574 Script-tests CI failure). Fixture commits below
+# pass identity per-invocation with -c.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 # ---- fixture repo -----------------------------------------------------------
 REPO="$TMP/demo_repo"
 mkdir -p "$REPO/demo_pkg" "$REPO/fixtures/ignored_pkg"
@@ -100,17 +107,17 @@ check "log hash matches"           bash -c "[ \"\$(sha256sum '$log_file' | cut -
 echo "== re-run appends a second record (no overwrite) =="
 out=$(bash "$SUT" "$REPO" 2>&1); rc=$?
 check "exits 0"                    [ "$rc" -eq 0 ]
-check "two pass records"           bash -c "[ \"\$(note_sha() { :; }; git -C '$REPO' notes --ref=ci-local show '$HEAD_SHA' | grep -cF 'ci-local: pass')\" -eq 2 ]"
+check "two pass records"           bash -c "[ \"\$(git -C '$REPO' notes --ref=ci-local show '$HEAD_SHA' | grep -cF 'ci-local: pass')\" -eq 2 ]"
 check "still one note object"      bash -c "[ \"\$(git -C '$REPO' notes --ref=ci-local list | wc -l)\" -eq 1 ]"
 
 echo "== partial run recorded as partial =="
-git -C "$REPO" notes --ref=ci-local remove "$HEAD_SHA" >/dev/null 2>&1
+git -C "$REPO" -c user.name=t -c user.email=t@t notes --ref=ci-local remove "$HEAD_SHA" >/dev/null 2>&1
 out=$(bash "$SUT" "$REPO" --packages "demo_pkg other_pkg" 2>&1); rc=$?
 check "exits 0"                    [ "$rc" -eq 0 ]
 note=$(note_of "$HEAD_SHA")
 check "note marked partial"        contains "$note" "ci-local: pass (partial)"
 check "note scope partial"         contains "$note" "scope: partial"
-git -C "$REPO" notes --ref=ci-local remove "$HEAD_SHA" >/dev/null 2>&1
+git -C "$REPO" -c user.name=t -c user.email=t@t notes --ref=ci-local remove "$HEAD_SHA" >/dev/null 2>&1
 
 echo "== dirty tree passes but does not attest, uses live tree =="
 : > "$DOCKER_STUB_CALLS"
@@ -157,6 +164,14 @@ check "subdirectory rejected"      [ "$rc" -ne 0 ]
 check "explains repo root"         contains "$out" "pass the repo root"
 out=$(bash "$SUT" "$REPO" --frobnicate 2>&1); rc=$?
 check "unknown option rejected"    [ "$rc" -ne 0 ]
+out=$(bash "$SUT" "$REPO" --dry-run --image "evil
+ci-local: pass" 2>&1); rc=$?
+check "whitespace image rejected"  [ "$rc" -ne 0 ]
+mkdir -p "$TMP/bad dir/space_repo"
+git -C "$TMP/bad dir/space_repo" init -q
+out=$(bash "$SUT" "$TMP/bad dir/space_repo" --dry-run 2>&1); rc=$?
+check "whitespace repo path rejected" [ "$rc" -ne 0 ]
+check "explains mount hazard"      contains "$out" "unsupported for container mounts"
 mkdir -p "$TMP/no_pkgs" && git -C "$TMP/no_pkgs" init -q
 out=$(bash "$SUT" "$TMP/no_pkgs" --dry-run 2>&1); rc=$?
 check "package-less repo rejected" [ "$rc" -ne 0 ]

--- a/.agent/work-plans/issue-573/progress.md
+++ b/.agent/work-plans/issue-573/progress.md
@@ -1,0 +1,24 @@
+---
+issue: 573
+---
+
+# Issue #573 — ci_local.sh: containerized local CI runner with git-note attestation (Phase 1 of #572)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-22 13:15 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #574 at `d44e7b3`
+**Sources**: 3 (Copilot R1 @ `d44e7b3`, CI rollup @ `d44e7b3`, session pre-push workflow review — 10 findings all fixed pre-push, not re-listed)
+**Cross-source confirmations**: 0 strict (Copilot's two attestation-format comments thematically continue the pre-push review's attestation-integrity findings, distinct locations)
+**CI**: failures-noted — Script tests failed ×2 (real, finding 1); all other checks pass
+
+### Findings
+- [ ] (must-fix, CI) `git notes add/append` fails without ambient git identity (GitHub runner, fresh container/host) — attestation dies after a successful run; use explicit tool identity `-c user.name=ci_local -c user.email=ci-local@localhost` — `.agent/scripts/ci_local.sh`
+- [ ] (low, Copilot) `--image` value written verbatim into note record; whitespace/newlines could inject a spurious `ci-local: pass` line — reject whitespace in `--image` — `.agent/scripts/ci_local.sh:76`
+- [ ] (low, Copilot) `REPO_NAME`/repo path embedded in docker `-v` spec and note text; whitespace/control/`:`/`,` produce ambiguous mounts or malformed records — validate early — `.agent/scripts/ci_local.sh:92`
+- [ ] (trivial, Copilot) unused `note_sha() { :; }` stub inside command substitution — delete — `.agent/scripts/tests/test_ci_local.sh:103`
+
+### False positives
+- (none)

--- a/.agent/work-plans/issue-573/progress.md
+++ b/.agent/work-plans/issue-573/progress.md
@@ -15,10 +15,27 @@ issue: 573
 **CI**: failures-noted — Script tests failed ×2 (real, finding 1); all other checks pass
 
 ### Findings
-- [ ] (must-fix, CI) `git notes add/append` fails without ambient git identity (GitHub runner, fresh container/host) — attestation dies after a successful run; use explicit tool identity `-c user.name=ci_local -c user.email=ci-local@localhost` — `.agent/scripts/ci_local.sh`
-- [ ] (low, Copilot) `--image` value written verbatim into note record; whitespace/newlines could inject a spurious `ci-local: pass` line — reject whitespace in `--image` — `.agent/scripts/ci_local.sh:76`
-- [ ] (low, Copilot) `REPO_NAME`/repo path embedded in docker `-v` spec and note text; whitespace/control/`:`/`,` produce ambiguous mounts or malformed records — validate early — `.agent/scripts/ci_local.sh:92`
-- [ ] (trivial, Copilot) unused `note_sha() { :; }` stub inside command substitution — delete — `.agent/scripts/tests/test_ci_local.sh:103`
+- [x] (must-fix, CI) `git notes add/append` fails without ambient git identity (GitHub runner, fresh container/host) — attestation dies after a successful run; use explicit tool identity `-c user.name=ci_local -c user.email=ci-local@localhost` — `.agent/scripts/ci_local.sh`
+- [x] (low, Copilot) `--image` value written verbatim into note record; whitespace/newlines could inject a spurious `ci-local: pass` line — reject whitespace in `--image` — `.agent/scripts/ci_local.sh:76`
+- [x] (low, Copilot) `REPO_NAME`/repo path embedded in docker `-v` spec and note text; whitespace/control/`:`/`,` produce ambiguous mounts or malformed records — validate early — `.agent/scripts/ci_local.sh:92`
+- [x] (trivial, Copilot) unused `note_sha() { :; }` stub inside command substitution — delete — `.agent/scripts/tests/test_ci_local.sh:103`
 
 ### False positives
 - (none)
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-22 13:30 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**Commit**: `c5d7c0e` on `feature/issue-573`
+
+All four Integrated Review findings addressed in one commit: explicit tool
+identity (`ci_local` / `ci-local@localhost`) on the notes add/append path;
+whitespace rejected in `--image`; whitespace/`:`/`,` rejected in repo paths
+(docker `-v` spec + note-format hazard); leftover `note_sha` stub removed.
+Test harness now exports `GIT_CONFIG_GLOBAL/SYSTEM=/dev/null` so every local
+run reproduces the identity-less CI environment (the regression that CI
+caught), with per-invocation `-c` identity on fixture commits and note
+cleanup; two new validation tests. 47 checks green; full script-test suite
+green.


### PR DESCRIPTION
Phase 1 tool of the local-first quality gates umbrella (#572) — **tool only**: no governance, merge-gate, or AGENTS.md changes (those await the ADR).

Closes #573

## What

`.agent/scripts/ci_local.sh` — run a project repo's CI equivalent locally in a container and record an auditable attestation:

- Mirrors the CI template (`.agent/templates/ci_workflow.yml`): rosdep → colcon build (BUILD_TESTING) → colcon test (overlay sourced, ADR-0016 `local_setup`) → `colcon test-result` always (like `if: always()`), plus a per-repo `.agents/ci_local_extra.sh` hook after tests pass.
- **Attestable runs build a pristine `git archive HEAD` snapshot** (the moral equivalent of `actions/checkout`), not the live tree — kills mid-run-edit TOCTOU and gitignored-file leakage. Dirty-tree / `--no-attest` runs use the live tree read-only and are never attested.
- Attestation = a record **appended** (never overwritten) to a git note at `refs/notes/ci-local` on the tested commit: image + image-id, packages, scope (full/partial), timestamp, host, log sha256. `--packages`-narrowed runs are marked `pass (partial)`.
- Image: agent sandbox (`ros2-agent-workspace-agent`, deps baked #520) by default; `--clean-room` forces `ros:jazzy-ros-core` for an exact hosted mirror. `rosdep update` is skipped when a cache is baked and tolerated on failure (offline field hosts).
- Package discovery honors `COLCON_IGNORE`; package names are validated (`[A-Za-z0-9_-]+`) before interpolation into the root inner script (attestation-forgery injection guard); subdirectory paths are refused (attestation belongs to the repo root's HEAD).

`.agent/scripts/tests/test_ci_local.sh` — 44 hermetic checks (stubbed docker; no containers or network) covering discovery, injection rejection, snapshot-vs-live mount selection, append/partial/dirty/failure attestation semantics, and argument validation. Runs in `make test-scripts`.

## Verification

- Full script-test suite: all green (17 shell + 51 python).
- Real run against `unh_echoboats_project11` in the agent image: full pipeline (rosdep, build of both packages, 37 tests) in **4.2 s** — the same repo's hosted CI run today spent >80 min in dependency install on a degraded runner.
- Pre-push review: high-effort workflow review produced 10 confirmed findings (injection, TOCTOU, snapshot fidelity, note-overwrite, template divergences); all 10 fixed and covered by tests.

## Not in this PR

- AGENTS.md Script Reference table row (instruction files are ask-first — add on approval).
- Any change to the merge gate or `merge_pr.sh` (gated on the #572 ADR).
---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
