### PR TITLE
ADR-0018: local-first CI verification + AGENTS.md merge-gate updates (#575)

### DIFF
--- a/.agent/work-plans/issue-575/progress.md
+++ b/.agent/work-plans/issue-575/progress.md
@@ -1,0 +1,21 @@
+---
+issue: 575
+---
+
+# Issue #575 — ADR-0018: local-first CI verification (Phase 1 governance of #572) + AGENTS.md updates
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-22 13:55 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #576 at `e4235bb`
+**Sources**: 2 (Copilot R1 @ `e4235bb`, CI rollup @ `e4235bb`)
+**Cross-source confirmations**: 0
+**CI**: all-pass
+
+### Findings
+- [ ] (trivial, Copilot) `ci_local.sh <repo>` placeholder ambiguous — the script takes a filesystem path; use `<project_repo_path>` per its usage header (Documentation Accuracy) — `AGENTS.md:404`
+
+### False positives
+- (Copilot) "Hosted Actions … remains" flagged as plural-subject agreement error — "Actions" is the GitHub Actions product name, which takes singular agreement (GitHub's own docs: "GitHub Actions is…"); optional rephrase to "Hosted CI" noted as a free clarity win.

--- a/.agent/work-plans/issue-575/progress.md
+++ b/.agent/work-plans/issue-575/progress.md
@@ -15,7 +15,7 @@ issue: 575
 **CI**: all-pass
 
 ### Findings
-- [ ] (trivial, Copilot) `ci_local.sh <repo>` placeholder ambiguous — the script takes a filesystem path; use `<project_repo_path>` per its usage header (Documentation Accuracy) — `AGENTS.md:404`
+- [x] (trivial, Copilot) `ci_local.sh <repo>` placeholder ambiguous — the script takes a filesystem path; use `<project_repo_path>` per its usage header (Documentation Accuracy) — `AGENTS.md:404`
 
 ### False positives
 - (Copilot) "Hosted Actions … remains" flagged as plural-subject agreement error — "Actions" is the GitHub Actions product name, which takes singular agreement (GitHub's own docs: "GitHub Actions is…"); optional rephrase to "Hosted CI" noted as a free clarity win.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,6 +397,17 @@ sourcing lower layers automatically.
 Set `NONINTERACTIVE=1` to suppress all interactive prompts (e.g., the first-run
 bootstrap confirmation). `CI` is also recognized for CI environments.
 
+### Merge verification (ADR-0018)
+
+Project-repo PRs may merge on a **full-scope local CI attestation** instead of
+waiting for hosted Actions: run `.agent/scripts/ci_local.sh <repo>` on the PR
+head, verify `git notes --ref=ci-local show <head-sha>` reports `ci-local: pass`
+with `scope: full`, and push `refs/notes/ci-local` to origin at merge time.
+Partial/dirty/`--no-attest` runs don't satisfy the gate. Hosted CI on project
+repos remains a mirror/backstop — triage its post-merge failures. The
+**workspace repo is exempt**: its hosted checks stay required. See
+[ADR-0018](docs/decisions/0018-local-first-ci-verification.md).
+
 ## Documentation Accuracy
 
 - **Never document from assumptions** — every claim about parameters, topics, services,
@@ -476,6 +487,7 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/stage_rosdep_manifests.sh` | Gather layer `package.xml` manifests (recursive) into the agent-image build context for the rosdep bake (#520); shared by `docker_run_agent.sh --build` and `make agent-build` |
 | `.agent/scripts/dashboard.sh` | Unified workspace status (supports `--quick`) |
 | `.agent/scripts/build.sh` | Build all layers in order |
+| `.agent/scripts/ci_local.sh` | Containerized local CI for a project repo with git-note attestation (`refs/notes/ci-local`); full-scope pass = accepted merge verification (ADR-0018). `--clean-room` mirrors hosted CI exactly; `-n` dry-run |
 | `.agent/scripts/check_branch_updates.sh` | Check if branch is behind default |
 | `.agent/scripts/gh_create_issue.sh` | Create issue with label validation (`GITBUG_CREATE=1` for offline) |
 | `.agent/scripts/git_bug_setup.sh` | Configure git-bug identity + GitHub bridge |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,7 +400,7 @@ bootstrap confirmation). `CI` is also recognized for CI environments.
 ### Merge verification (ADR-0018)
 
 Project-repo PRs may merge on a **full-scope local CI attestation** instead of
-waiting for hosted Actions: run `.agent/scripts/ci_local.sh <repo>` on the PR
+waiting for hosted Actions: run `.agent/scripts/ci_local.sh <project_repo_path>` on the PR
 head, verify `git notes --ref=ci-local show <head-sha>` reports `ci-local: pass`
 with `scope: full`, and push `refs/notes/ci-local` to origin at merge time.
 Partial/dirty/`--no-attest` runs don't satisfy the gate. Hosted CI on project

--- a/docs/decisions/0018-local-first-ci-verification.md
+++ b/docs/decisions/0018-local-first-ci-verification.md
@@ -1,0 +1,120 @@
+# ADR-0018: Local-first CI verification for project-repo merges
+
+## Status
+
+Accepted. Phase 1 governance of the local-first quality gates umbrella
+([#572](https://github.com/rolker/ros2_agent_workspace/issues/572));
+tool delivered in [#573](https://github.com/rolker/ros2_agent_workspace/issues/573)
+(`.agent/scripts/ci_local.sh`).
+
+## Context
+
+Project-repo merges were gated on green GitHub Actions CI. That gate has two
+structural problems and one strategic mismatch:
+
+1. **Latency and fragility we don't control.** Hosted runners rebuild a ROS
+   container from bare `apt-get` on every run. On 2026-07-22 a routine
+   ~4-minute run took 2h21m to pass, and a sibling run failed outright on
+   Ubuntu-mirror connection errors — before ever reaching checkout. The
+   verdicts, when they arrived, matched what local verification had
+   established hours earlier in seconds.
+2. **The gate measures the wrong thing.** What the merge decision needs is
+   "this commit builds and its tests pass in a clean environment" — not
+   "GitHub's runner fleet and Canonical's mirrors were healthy today."
+3. **Strategic mismatch.** Field hosts have no GitHub credentials by design
+   (ADR-0011 field mode), and upcoming operations are fully
+   over-the-horizon. The workspace is converging on offline-capable
+   workflows; a hosted-only merge gate points the other way.
+
+`ci_local.sh` (#573) closes the verification gap locally: it runs the CI
+template steps (rosdep → colcon build → colcon test → test-result, plus
+per-repo extras) in a throwaway container, builds attestable runs from a
+pristine `git archive HEAD` snapshot (the local equivalent of
+`actions/checkout`), and appends an auditable record — image, packages,
+scope, host, log sha256 — to a git note at `refs/notes/ci-local` on the
+tested commit. Three project-repo PRs merged on such attestations on
+2026-07-22 (unh_echoboats_project11 #353, #379, #383).
+
+The same day also demonstrated the counter-case: the **workspace repo's**
+hosted checks are container-free, complete in seconds, and caught a real
+`ci_local.sh` bug (git-notes identity missing on clean runners) that a
+locally-configured machine could not have caught. Hosted CI's value is not
+zero; it is environment diversity.
+
+## Decision
+
+1. **A full-scope ci_local attestation is an accepted merge verification
+   for project-repo PRs.** A PR whose head commit carries a
+   `refs/notes/ci-local` record with `ci-local: pass` and `scope: full`
+   may be merged without waiting for hosted Actions. Verify with:
+
+   ```bash
+   git notes --ref=ci-local show <head-sha>
+   ```
+
+2. **Partial or unattested runs do not satisfy the gate.** `pass (partial)`
+   records (a `--packages`-narrowed run), dirty-tree runs, and `--no-attest`
+   runs are iteration aids, not merge evidence.
+
+3. **Hosted Actions on project repos remains configured, as a mirror and
+   backstop — never a blocker.** Post-merge hosted failures are triaged:
+   infrastructure failures (e.g. mirror outages) are noted and re-run at
+   convenience; genuine code failures are treated as any post-merge
+   regression — the local and hosted environments disagreed, and the
+   disagreement itself is a bug to chase.
+
+4. **The workspace repo (`ros2_agent_workspace`) is exempt: its hosted
+   checks stay required.** They are fast (no ROS container), and they
+   provide the clean-environment diversity that local runs cannot
+   (proven the day this ADR was drafted).
+
+5. **Attestation notes are pushed at merge time** for auditability beyond
+   the merging machine:
+
+   ```bash
+   git push origin refs/notes/ci-local
+   ```
+
+6. **Preference order for the attestation image**: the agent sandbox image
+   (deps baked, #520) for routine merges; `--clean-room` (stock
+   `ros:jazzy-ros-core`, exact hosted mirror) when the change touches
+   dependency declarations or the build environment itself. Records
+   append, so a clean-room record is never destroyed by a later fast-path
+   re-run.
+
+## Consequences
+
+- Merge latency for project repos drops from runner-weather-dependent to
+  seconds-to-minutes, and merging works offline (field mode, OTH ops) —
+  the original #572 motivation.
+- The merge operator's machine becomes part of the trust chain. The
+  attestation records host and log hash, snapshots are built from commit
+  content only, and the note format is injection-guarded — but this is
+  attestation, not proof; the honest-operator assumption is explicit and
+  matches the rest of the workspace's local-first tooling. Server-side
+  enforcement (pre-receive verification of attestations) is Phase 3 of
+  #572, not this ADR.
+- Hosted CI failures on project repos lose their blocking teeth; the
+  discipline of triaging post-merge hosted failures (decision 3) is what
+  keeps the mirror honest. If that triage lapses, environment drift
+  between local images and hosted CI will accumulate silently.
+- `merge_pr.sh` does not yet check for the attestation before merging;
+  wiring that check in (warn or refuse when the head lacks a full-scope
+  record) is a natural hardening follow-up under #572.
+- The hosted-CI speed fix (prebuilt/GHCR image, cube-style) remains worth
+  doing independently — a faster, less fragile mirror is a better mirror.
+
+## Alternatives considered
+
+- **Keep waiting for hosted CI** (status quo): rejected — see Context; the
+  gate primarily measured third-party infrastructure health.
+- **Prebuilt CI image only, keep the hosted gate**: improves latency but
+  not availability (mirror outages still block merges) and does nothing
+  for offline/field operation. Pursued anyway as a mirror improvement,
+  not as the gate.
+- **Self-hosted runners**: keeps the Actions UX but adds standing
+  infrastructure to operate; Phase 3's Forgejo direction (#572) subsumes
+  this more coherently.
+- **Making attestation mandatory for every merge including the workspace
+  repo**: rejected — decision 4; the workspace repo's hosted checks are
+  cheap and provide unique clean-room value.

--- a/docs/decisions/0018-local-first-ci-verification.md
+++ b/docs/decisions/0018-local-first-ci-verification.md
@@ -56,7 +56,7 @@ zero; it is environment diversity.
    records (a `--packages`-narrowed run), dirty-tree runs, and `--no-attest`
    runs are iteration aids, not merge evidence.
 
-3. **Hosted Actions on project repos remains configured, as a mirror and
+3. **Hosted CI on project repos remains configured, as a mirror and
    backstop — never a blocker.** Post-merge hosted failures are triaged:
    infrastructure failures (e.g. mirror outages) are noted and re-run at
    convenience; genuine code failures are treated as any post-merge


### PR DESCRIPTION
Phase 1 governance of #572, codifying the practice proven on 2026-07-22.

Closes #575

## ADR-0018 — local-first CI verification for project-repo merges

Core decisions:
1. A **full-scope `refs/notes/ci-local` attestation** on the PR head is an accepted merge verification for project-repo PRs — no waiting on hosted Actions.
2. Partial / dirty / `--no-attest` runs don't satisfy the gate.
3. Hosted Actions on project repos stays configured as **mirror + backstop**, with explicit post-merge failure triage (infra vs code) — that triage discipline is what keeps the mirror honest.
4. **Workspace repo exempt** — its hosted checks stay required (container-free, fast, and they caught a real ci_local bug the very day this was drafted; clean-room diversity has proven value).
5. Attestation notes **pushed to origin at merge time** for auditability.
6. Image preference: agent sandbox for routine merges, `--clean-room` when the change touches dependency declarations or the build environment.

Consequences section is honest about the trust model (merge operator's machine joins the trust chain; server-side enforcement is Phase 3, not this ADR) and names the follow-ups: `merge_pr.sh` attestation check, prebuilt hosted-CI image.

## AGENTS.md (instruction file — changes pre-approved by operator today)

- New **Merge verification (ADR-0018)** subsection under Build & Test — minimal gate language, points at the ADR.
- **Script Reference row** for `ci_local.sh`.
---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
