### PR TITLE
ci_local.sh: build upstream.repos source deps as an attested underlay

### DIFF
--- a/.agent/scripts/ci_local.sh
+++ b/.agent/scripts/ci_local.sh
@@ -223,7 +223,9 @@ if not isinstance(repos, dict) or not repos:
 for name, ent in repos.items():
     if not isinstance(ent, dict):
         sys.exit(f"upstream.repos: entry {name!r} is not a mapping")
-    rtype = ent.get("type", "git")
+    rtype = ent.get("type")
+    if rtype is None:
+        sys.exit(f"upstream.repos: entry {name!r} has no type (required: type: git)")
     if rtype != "git":
         sys.exit(f"upstream.repos: entry {name!r} has unsupported type {rtype!r} (only git)")
     url, ver = ent.get("url"), ent.get("version")
@@ -312,7 +314,7 @@ if [[ $UPSTREAM_PRESENT -eq 1 ]]; then
         "refs/tags/${UP_VERS[$i]}^{}") sha="$cand" ;;
         "refs/tags/${UP_VERS[$i]}")    [[ -z "$sha" ]] && sha="$cand" ;;
       esac
-    done < <(git ls-remote "${UP_URLS[$i]}" "refs/heads/${UP_VERS[$i]}" "refs/tags/${UP_VERS[$i]}" "refs/tags/${UP_VERS[$i]}^{}" 2>/dev/null)
+    done < <(git ls-remote -- "${UP_URLS[$i]}" "refs/heads/${UP_VERS[$i]}" "refs/tags/${UP_VERS[$i]}" "refs/tags/${UP_VERS[$i]}^{}" 2>/dev/null)
     [[ -n "$sha" ]] || { err "upstream.repos: cannot resolve '${UP_VERS[$i]}' for ${UP_DIRS[$i]} at ${UP_URLS[$i]}"; exit 1; }
     [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || { err "upstream.repos: '${UP_VERS[$i]}' for ${UP_DIRS[$i]} resolved to non-SHA output '$sha' — refusing"; exit 1; }
     UP_SHAS+=("$sha")

--- a/.agent/scripts/ci_local.sh
+++ b/.agent/scripts/ci_local.sh
@@ -42,8 +42,11 @@
 #       COLCON_IGNORE` in upstream subpackages the target doesn't need
 #       (the AFTER_SETUP_UPSTREAM_WORKSPACE analog)
 #   <repo>/.agents/ci_local_rosdep_skip_keys.txt one rosdep key per line
-#       (#-comments allowed) excluded from the combined rosdep install
-#       (the ROSDEP_SKIP_KEYS analog)
+#       (#-comments allowed) excluded from the single rosdep install, which
+#       covers target and upstream deps alike (the ROSDEP_SKIP_KEYS analog).
+#       Honored whether or not upstream.repos is present; applied keys are
+#       recorded in the attestation note (`rosdep-skip-keys:` line and a
+#       `+rosdep-skip-keys` steps token)
 #
 # Attestation: on success of an attestable run, a record is added to a git note
 # on the tested commit under refs/notes/ci-local (repo-local; never perturbs
@@ -261,6 +264,7 @@ STEPS="template"
 [[ $UPSTREAM_PRESENT -eq 1 ]] && STEPS+="+upstream"
 [[ -n "$UPSTREAM_HOOK" ]] && STEPS+="+upstream-hook"
 [[ -n "$EXTRA_HOOK" ]] && STEPS+="+extra-hook"
+[[ -n "$SKIP_KEYS" ]] && STEPS+="+rosdep-skip-keys"
 PASS_LABEL="ci-local: pass"
 [[ $PARTIAL -eq 1 ]] && PASS_LABEL="ci-local: pass (partial)"
 
@@ -275,8 +279,10 @@ if [[ $DRY_RUN -eq 1 ]]; then
     for i in "${!UP_DIRS[@]}"; do
       echo "upstream : ${UP_DIRS[$i]}@${UP_VERS[$i]} ${UP_URLS[$i]} (SHA resolved at run time)"
     done
-    echo "upstream-hook : $( [[ -n "$UPSTREAM_HOOK" ]] && echo yes || echo no ); rosdep-skip-keys: ${SKIP_KEYS:-none}"
+    echo "upstream-hook : $( [[ -n "$UPSTREAM_HOOK" ]] && echo yes || echo no )"
   fi
+  # skip-keys apply to the single combined rosdep install, upstream or not
+  [[ -n "$SKIP_KEYS" ]] && echo "rosdep-skip-keys: $SKIP_KEYS"
   echo "source   : $( [[ $ATTEST -eq 1 ]] && echo "pristine snapshot of $HEAD_SHA" || echo 'live working tree (read-only)' )"
   echo "attest   : $( [[ $ATTEST -eq 1 ]] && echo "append '$PASS_LABEL' record, refs/notes/$NOTES_REF on $HEAD_SHA" || echo no )"
   echo "log dir  : $LOG_DIR"
@@ -288,16 +294,27 @@ fi
 # container runs: the container then checks out exactly the recorded SHA, so
 # the attestation note cannot be desynchronized from what was built (and no
 # container output needs to be trusted for attestation content). A version
-# that is already a full SHA is used as-is. Resolution failure is fatal —
-# never build (or attest) silently-unresolved upstream state.
+# that is already a full SHA is used as-is. A branch match wins; for annotated
+# tags the peeled ^{} line is preferred over the tag object so the note records
+# the commit that actually gets checked out. Resolution failure — including
+# ls-remote output that is not a 40-hex SHA — is fatal: never build (or attest)
+# silently-unresolved upstream state.
 if [[ $UPSTREAM_PRESENT -eq 1 ]]; then
   for i in "${!UP_DIRS[@]}"; do
     if [[ "${UP_VERS[$i]}" =~ ^[0-9a-f]{40}$ ]]; then
       UP_SHAS+=("${UP_VERS[$i]}")
       continue
     fi
-    sha="$(git ls-remote "${UP_URLS[$i]}" "refs/heads/${UP_VERS[$i]}" "refs/tags/${UP_VERS[$i]}" 2>/dev/null | head -1 | cut -f1)"
+    sha=""
+    while IFS=$'\t' read -r cand ref; do
+      case "$ref" in
+        "refs/heads/${UP_VERS[$i]}")   sha="$cand"; break ;;
+        "refs/tags/${UP_VERS[$i]}^{}") sha="$cand" ;;
+        "refs/tags/${UP_VERS[$i]}")    [[ -z "$sha" ]] && sha="$cand" ;;
+      esac
+    done < <(git ls-remote "${UP_URLS[$i]}" "refs/heads/${UP_VERS[$i]}" "refs/tags/${UP_VERS[$i]}" "refs/tags/${UP_VERS[$i]}^{}" 2>/dev/null)
     [[ -n "$sha" ]] || { err "upstream.repos: cannot resolve '${UP_VERS[$i]}' for ${UP_DIRS[$i]} at ${UP_URLS[$i]}"; exit 1; }
+    [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || { err "upstream.repos: '${UP_VERS[$i]}' for ${UP_DIRS[$i]} resolved to non-SHA output '$sha' — refusing"; exit 1; }
     UP_SHAS+=("$sha")
   done
 fi
@@ -430,19 +447,21 @@ fi
 LOG_HASH="$(sha256sum "$LOG" | cut -d' ' -f1)"
 # upstream-repo lines record the host-resolved SHAs the container was told to
 # check out — required for scope: full validity on upstream.repos repos
-# (ADR-0018); absent entirely for repos without upstream.repos (byte-identical
-# note format to pre-#577).
-UPSTREAM_NOTE=""
+# (ADR-0018); a rosdep-skip-keys line records deps the verified environment
+# deliberately did not install. Both absent for repos without the respective
+# files (byte-identical note format to pre-#577).
+NOTE_EXTRA=""
 for i in "${!UP_DIRS[@]}"; do
-  UPSTREAM_NOTE+=$'\n'"upstream-repo: ${UP_DIRS[$i]}@${UP_SHAS[$i]}"
+  NOTE_EXTRA+=$'\n'"upstream-repo: ${UP_DIRS[$i]}@${UP_SHAS[$i]}"
 done
+[[ -n "$SKIP_KEYS" ]] && NOTE_EXTRA+=$'\n'"rosdep-skip-keys: $SKIP_KEYS"
 NOTE="$PASS_LABEL
 repo: $REPO_NAME
 commit: $HEAD_SHA
 image: $IMAGE
 image-id: $IMAGE_ID
 packages: $PACKAGES
-scope: $( [[ $PARTIAL -eq 1 ]] && echo partial || echo full )$UPSTREAM_NOTE
+scope: $( [[ $PARTIAL -eq 1 ]] && echo partial || echo full )$NOTE_EXTRA
 steps: $STEPS
 date: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 host: $(hostname)

--- a/.agent/scripts/ci_local.sh
+++ b/.agent/scripts/ci_local.sh
@@ -24,6 +24,27 @@
 # at <repo>/.agents/ci_local_extra.sh, run inside the container from the
 # workspace root after tests pass, with the overlay sourced.
 #
+# Upstream source dependencies (#577): when the repo carries an
+# `upstream.repos` file (vcstool format, as consumed by hosted industrial_ci's
+# UPSTREAM_WORKSPACE), the entries are parsed and validated on the HOST, each
+# floating ref is resolved to a commit SHA host-side (`git ls-remote`) BEFORE
+# the container runs, and the container clones + checks out exactly those SHAs
+# into /ci/upstream_ws/src, builds them as an underlay, and sources it before
+# the target build. The resolved SHAs are recorded in the attestation note
+# (`upstream-repo: <dir>@<sha>` lines) so `scope: full` stays self-describing
+# merge evidence even though upstream.repos pins floating branches (ADR-0018).
+# For attestable runs the upstream.repos / hook files are read from the
+# pristine HEAD commit content, not the live tree. Two optional per-repo hook
+# files generalize industrial_ci's pruning mechanisms (both live in the target
+# repo, read at HEAD for attestable runs):
+#   <repo>/.agents/ci_local_upstream_extra.sh    run (via bash) inside the
+#       container after the upstream clones, cwd /ci/upstream_ws — e.g. `touch
+#       COLCON_IGNORE` in upstream subpackages the target doesn't need
+#       (the AFTER_SETUP_UPSTREAM_WORKSPACE analog)
+#   <repo>/.agents/ci_local_rosdep_skip_keys.txt one rosdep key per line
+#       (#-comments allowed) excluded from the combined rosdep install
+#       (the ROSDEP_SKIP_KEYS analog)
+#
 # Attestation: on success of an attestable run, a record is added to a git note
 # on the tested commit under refs/notes/ci-local (repo-local; never perturbs
 # branches; push with `git push origin refs/notes/ci-local` if wanted). Records
@@ -167,7 +188,79 @@ fi
 ATTEST=1
 [[ $NO_ATTEST -eq 1 || $DIRTY -eq 1 ]] && ATTEST=0
 
-STEPS="template${EXTRA_HOOK:++extra-hook}"
+# ---- upstream.repos detection + validation (#577) ---------------------------
+# Attestable runs read repo-carried CI inputs from the pristine HEAD commit
+# content (what the snapshot will contain) — a live-tree read could attest
+# content that differs from the recorded commit. Dirty/no-attest runs read the
+# live tree they are about to mount.
+repo_file_exists() {
+  if [[ $ATTEST -eq 1 ]]; then git -C "$REPO" cat-file -e "$HEAD_SHA:$1" 2>/dev/null
+  else [[ -f "$REPO/$1" ]]; fi
+}
+repo_file_content() {
+  if [[ $ATTEST -eq 1 ]]; then git -C "$REPO" show "$HEAD_SHA:$1" 2>/dev/null
+  else cat "$REPO/$1" 2>/dev/null; fi
+}
+
+UPSTREAM_PRESENT=0
+UP_DIRS=(); UP_URLS=(); UP_VERS=(); UP_SHAS=()
+if repo_file_exists "upstream.repos"; then
+  UPSTREAM_PRESENT=1
+  # Parse with the yaml module rosdep/vcstool already depend on; emit
+  # dir<TAB>url<TAB>version. Structural errors surface with the entry name.
+  UPSTREAM_TSV="$(repo_file_content "upstream.repos" | python3 -c '
+import sys, yaml
+try:
+    data = yaml.safe_load(sys.stdin.read())
+except yaml.YAMLError as e:
+    sys.exit(f"upstream.repos: not valid YAML: {e}")
+repos = (data or {}).get("repositories")
+if not isinstance(repos, dict) or not repos:
+    sys.exit("upstream.repos: no repositories mapping")
+for name, ent in repos.items():
+    if not isinstance(ent, dict):
+        sys.exit(f"upstream.repos: entry {name!r} is not a mapping")
+    rtype = ent.get("type", "git")
+    if rtype != "git":
+        sys.exit(f"upstream.repos: entry {name!r} has unsupported type {rtype!r} (only git)")
+    url, ver = ent.get("url"), ent.get("version")
+    if not url:
+        sys.exit(f"upstream.repos: entry {name!r} has no url")
+    if not ver:
+        sys.exit(f"upstream.repos: entry {name!r} has no version (required: attestation must resolve a concrete ref)")
+    print(f"{name}\t{url}\t{ver}")
+')" || { err "failed to parse upstream.repos"; exit 1; }
+  # Validate every field before it is interpolated anywhere (same threat model
+  # as the package-name check: attestation forgery via injection).
+  while IFS=$'\t' read -r u_dir u_url u_ver; do
+    [[ "$u_dir" =~ ^[A-Za-z0-9_-]+$ ]] || { err "upstream.repos: invalid repo dir name: '$u_dir'"; exit 1; }
+    [[ "$u_ver" =~ ^[A-Za-z0-9_./-]+$ ]] || { err "upstream.repos: invalid version for '$u_dir': '$u_ver'"; exit 1; }
+    [[ "$u_url" =~ ^[A-Za-z0-9_.:/@+~-]+$ ]] || { err "upstream.repos: invalid url for '$u_dir': '$u_url'"; exit 1; }
+    UP_DIRS+=("$u_dir"); UP_URLS+=("$u_url"); UP_VERS+=("$u_ver")
+  done <<<"$UPSTREAM_TSV"
+fi
+
+UPSTREAM_HOOK=""
+if [[ $UPSTREAM_PRESENT -eq 1 ]] && repo_file_exists ".agents/ci_local_upstream_extra.sh"; then
+  UPSTREAM_HOOK=".agents/ci_local_upstream_extra.sh"
+fi
+
+SKIP_KEYS=""
+if repo_file_exists ".agents/ci_local_rosdep_skip_keys.txt"; then
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    # trim surrounding whitespace
+    line="${line#"${line%%[![:space:]]*}"}"; line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" ]] && continue
+    [[ "$line" =~ ^[A-Za-z0-9_-]+$ ]] || { err "ci_local_rosdep_skip_keys.txt: invalid rosdep key: '$line'"; exit 1; }
+    SKIP_KEYS="${SKIP_KEYS:+$SKIP_KEYS }$line"
+  done < <(repo_file_content ".agents/ci_local_rosdep_skip_keys.txt")
+fi
+
+STEPS="template"
+[[ $UPSTREAM_PRESENT -eq 1 ]] && STEPS+="+upstream"
+[[ -n "$UPSTREAM_HOOK" ]] && STEPS+="+upstream-hook"
+[[ -n "$EXTRA_HOOK" ]] && STEPS+="+extra-hook"
 PASS_LABEL="ci-local: pass"
 [[ $PARTIAL -eq 1 ]] && PASS_LABEL="ci-local: pass (partial)"
 
@@ -178,10 +271,35 @@ if [[ $DRY_RUN -eq 1 ]]; then
   echo "image    : $IMAGE"
   echo "packages : $PACKAGES$( [[ $PARTIAL -eq 1 ]] && echo ' (PARTIAL of: '"$DISCOVERED"')' )"
   echo "steps    : $STEPS"
+  if [[ $UPSTREAM_PRESENT -eq 1 ]]; then
+    for i in "${!UP_DIRS[@]}"; do
+      echo "upstream : ${UP_DIRS[$i]}@${UP_VERS[$i]} ${UP_URLS[$i]} (SHA resolved at run time)"
+    done
+    echo "upstream-hook : $( [[ -n "$UPSTREAM_HOOK" ]] && echo yes || echo no ); rosdep-skip-keys: ${SKIP_KEYS:-none}"
+  fi
   echo "source   : $( [[ $ATTEST -eq 1 ]] && echo "pristine snapshot of $HEAD_SHA" || echo 'live working tree (read-only)' )"
   echo "attest   : $( [[ $ATTEST -eq 1 ]] && echo "append '$PASS_LABEL' record, refs/notes/$NOTES_REF on $HEAD_SHA" || echo no )"
   echo "log dir  : $LOG_DIR"
   exit 0
+fi
+
+# ---- upstream ref resolution (host-side, pre-run) ---------------------------
+# Resolve each floating version to a commit SHA on the HOST before the
+# container runs: the container then checks out exactly the recorded SHA, so
+# the attestation note cannot be desynchronized from what was built (and no
+# container output needs to be trusted for attestation content). A version
+# that is already a full SHA is used as-is. Resolution failure is fatal —
+# never build (or attest) silently-unresolved upstream state.
+if [[ $UPSTREAM_PRESENT -eq 1 ]]; then
+  for i in "${!UP_DIRS[@]}"; do
+    if [[ "${UP_VERS[$i]}" =~ ^[0-9a-f]{40}$ ]]; then
+      UP_SHAS+=("${UP_VERS[$i]}")
+      continue
+    fi
+    sha="$(git ls-remote "${UP_URLS[$i]}" "refs/heads/${UP_VERS[$i]}" "refs/tags/${UP_VERS[$i]}" 2>/dev/null | head -1 | cut -f1)"
+    [[ -n "$sha" ]] || { err "upstream.repos: cannot resolve '${UP_VERS[$i]}' for ${UP_DIRS[$i]} at ${UP_URLS[$i]}"; exit 1; }
+    UP_SHAS+=("$sha")
+  done
 fi
 
 # ---- build source: pristine snapshot when attesting -------------------------
@@ -202,6 +320,14 @@ fi
 # ---- inner step script ------------------------------------------------------
 # Same step sequence as the CI template; conditionals make it a no-op-fast on
 # the agent image (tools and deps baked) and a faithful mirror on ros-core.
+# With upstream sources, target build/test are pinned to --base-paths src so
+# colcon's cwd discovery never re-includes the underlay's packages.
+ROSDEP_FROM_PATHS="src"
+TARGET_BASE_PATHS=""
+if [[ $UPSTREAM_PRESENT -eq 1 ]]; then
+  ROSDEP_FROM_PATHS="src upstream_ws/src"
+  TARGET_BASE_PATHS="--base-paths src "
+fi
 cat > "$INNER" <<EOF
 # no -u: ROS setup.bash files reference unbound vars (AMENT_TRACE_SETUP_FILES)
 set -eo pipefail
@@ -210,6 +336,28 @@ if ! command -v colcon >/dev/null 2>&1; then
   apt-get update
   apt-get -y install ros-dev-tools
 fi
+EOF
+if [[ $UPSTREAM_PRESENT -eq 1 ]]; then
+  cat >> "$INNER" <<EOF
+if ! command -v git >/dev/null 2>&1; then
+  apt-get update
+  apt-get -y install git
+fi
+mkdir -p /ci/upstream_ws/src
+EOF
+  for i in "${!UP_DIRS[@]}"; do
+    cat >> "$INNER" <<EOF
+git clone -- '${UP_URLS[$i]}' '/ci/upstream_ws/src/${UP_DIRS[$i]}'
+git -C '/ci/upstream_ws/src/${UP_DIRS[$i]}' checkout --detach '${UP_SHAS[$i]}'
+EOF
+  done
+  if [[ -n "$UPSTREAM_HOOK" ]]; then
+    cat >> "$INNER" <<EOF
+( cd /ci/upstream_ws && bash "/ci/src/$REPO_NAME/$UPSTREAM_HOOK" )
+EOF
+  fi
+fi
+cat >> "$INNER" <<EOF
 source /opt/ros/jazzy/setup.bash
 if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then rosdep init; fi
 # Tolerate rosdep update failure (offline field host with baked deps, #520):
@@ -218,14 +366,25 @@ if [ ! -d "\$HOME/.ros/rosdep/sources.cache" ]; then
   rosdep update || echo "ci_local(inner): WARN: rosdep update failed (offline?) — proceeding with baked/existing deps"
 fi
 cd /ci
-rosdep install --from-paths src --ignore-src -r -y
-colcon build --packages-up-to $PACKAGES --cmake-args -DBUILD_TESTING=ON
+rosdep install --from-paths $ROSDEP_FROM_PATHS --ignore-src -r -y${SKIP_KEYS:+ --skip-keys "$SKIP_KEYS"}
+EOF
+if [[ $UPSTREAM_PRESENT -eq 1 ]]; then
+  cat >> "$INNER" <<EOF
+# Underlay build (mirrors industrial_ci's two-workspace model): upstream built
+# separately, sourced before the target build so its packages resolve as
+# installed dependencies, never as target-workspace members.
+colcon build --base-paths upstream_ws/src --build-base upstream_ws/build --install-base upstream_ws/install
+source upstream_ws/install/local_setup.bash
+EOF
+fi
+cat >> "$INNER" <<EOF
+colcon build ${TARGET_BASE_PATHS}--packages-up-to $PACKAGES --cmake-args -DBUILD_TESTING=ON
 # local_setup (not setup): ROS is already sourced above; ADR-0016
 source install/local_setup.bash
 # Mirror the template's 'if: always()' test-result step: summarize even when
 # tests fail, then propagate the test exit code.
 test_rc=0
-colcon test --packages-select $PACKAGES --event-handlers console_direct+ --return-code-on-test-failure || test_rc=\$?
+colcon test ${TARGET_BASE_PATHS}--packages-select $PACKAGES --event-handlers console_direct+ --return-code-on-test-failure || test_rc=\$?
 colcon test-result --verbose || true
 if [ "\$test_rc" -ne 0 ]; then exit "\$test_rc"; fi
 EOF
@@ -269,13 +428,21 @@ if [[ $DIRTY -eq 1 ]]; then
 fi
 
 LOG_HASH="$(sha256sum "$LOG" | cut -d' ' -f1)"
+# upstream-repo lines record the host-resolved SHAs the container was told to
+# check out — required for scope: full validity on upstream.repos repos
+# (ADR-0018); absent entirely for repos without upstream.repos (byte-identical
+# note format to pre-#577).
+UPSTREAM_NOTE=""
+for i in "${!UP_DIRS[@]}"; do
+  UPSTREAM_NOTE+=$'\n'"upstream-repo: ${UP_DIRS[$i]}@${UP_SHAS[$i]}"
+done
 NOTE="$PASS_LABEL
 repo: $REPO_NAME
 commit: $HEAD_SHA
 image: $IMAGE
 image-id: $IMAGE_ID
 packages: $PACKAGES
-scope: $( [[ $PARTIAL -eq 1 ]] && echo partial || echo full )
+scope: $( [[ $PARTIAL -eq 1 ]] && echo partial || echo full )$UPSTREAM_NOTE
 steps: $STEPS
 date: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 host: $(hostname)

--- a/.agent/scripts/tests/test_ci_local.sh
+++ b/.agent/scripts/tests/test_ci_local.sh
@@ -4,7 +4,11 @@
 # handling, package discovery (COLCON_IGNORE, name validation), dry-run
 # planning, pass/fail exit codes, snapshot-vs-live mount selection, and
 # attestation-note semantics (clean vs dirty tree, append-not-overwrite,
-# partial scope, --no-attest, failure).
+# partial scope, --no-attest, failure). The upstream.repos path (#577) is
+# exercised against a local fixture upstream git repo (file-path URL, so the
+# host-side ls-remote resolution runs for real with no network), covering
+# dry-run planning, hook/skip-keys detection, injection rejection, the
+# upstream-repo: note lines, and the no-upstream byte-compat regression.
 set -uo pipefail
 
 TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -175,6 +179,111 @@ check "explains mount hazard"      contains "$out" "unsupported for container mo
 mkdir -p "$TMP/no_pkgs" && git -C "$TMP/no_pkgs" init -q
 out=$(bash "$SUT" "$TMP/no_pkgs" --dry-run 2>&1); rc=$?
 check "package-less repo rejected" [ "$rc" -ne 0 ]
+
+# ---- upstream.repos fixtures (#577) -----------------------------------------
+# A local git repo serves as the upstream source: its path is the url, so the
+# host-side ls-remote branch->SHA resolution runs for real without network.
+UPDEP_SRC="$TMP/updep_src"
+mkdir -p "$UPDEP_SRC"
+echo upstream > "$UPDEP_SRC/marker.txt"
+git -C "$UPDEP_SRC" init -q -b jazzy
+git -C "$UPDEP_SRC" -c user.name=t -c user.email=t@t add -A
+git -C "$UPDEP_SRC" -c user.name=t -c user.email=t@t commit -qm upstream
+UPDEP_SHA="$(git -C "$UPDEP_SRC" rev-parse HEAD)"
+
+UPREPO="$TMP/up_repo"
+mkdir -p "$UPREPO/up_pkg" "$UPREPO/.agents"
+sed 's/demo_pkg/up_pkg/' "$REPO/demo_pkg/package.xml" > "$UPREPO/up_pkg/package.xml"
+cat > "$UPREPO/upstream.repos" <<EOF
+repositories:
+  updep:
+    type: git
+    url: $UPDEP_SRC
+    version: jazzy
+EOF
+cat > "$UPREPO/.agents/ci_local_upstream_extra.sh" <<'EOF'
+#!/bin/bash
+touch some_subpkg/COLCON_IGNORE 2>/dev/null || true
+EOF
+chmod +x "$UPREPO/.agents/ci_local_upstream_extra.sh"
+cat > "$UPREPO/.agents/ci_local_rosdep_skip_keys.txt" <<'EOF'
+# keys the combined rosdep install must skip
+skip_key_a
+skip_key_b  # trailing comment
+EOF
+git -C "$UPREPO" init -q
+git -C "$UPREPO" -c user.name=t -c user.email=t@t add -A
+git -C "$UPREPO" -c user.name=t -c user.email=t@t commit -qm upfixture
+UPREPO_SHA="$(git -C "$UPREPO" rev-parse HEAD)"
+
+echo "== upstream.repos dry run =="
+: > "$DOCKER_STUB_CALLS"
+out=$(bash "$SUT" "$UPREPO" --dry-run 2>&1); rc=$?
+check "exits 0"                       [ "$rc" -eq 0 ]
+check "shows parsed upstream entry"   contains "$out" "upstream : updep@jazzy $UPDEP_SRC"
+check "steps gains upstream tokens"   contains "$out" "steps    : template+upstream+upstream-hook"
+check "upstream hook detected"        contains "$out" "upstream-hook : yes"
+check "skip keys parsed"              contains "$out" "rosdep-skip-keys: skip_key_a skip_key_b"
+check "no container run"              bash -c "! grep -qs docker-run '$DOCKER_STUB_CALLS'"
+
+echo "== upstream.repos successful run attests with resolved SHAs =="
+out=$(bash "$SUT" "$UPREPO" 2>&1); rc=$?
+check "exits 0"                       [ "$rc" -eq 0 ]
+unote=$(git -C "$UPREPO" notes --ref=ci-local show "$UPREPO_SHA" 2>/dev/null)
+check "note says pass"                contains "$unote" "ci-local: pass"
+check "note scope full"               contains "$unote" "scope: full"
+check "note records resolved SHA"     contains "$unote" "upstream-repo: updep@$UPDEP_SHA"
+check "note steps include upstream"   contains "$unote" "steps: template+upstream+upstream-hook"
+
+echo "== upstream.repos injection / validation rejection =="
+# Live-tree reads (untracked upstream.repos => dirty tree) let each bad case
+# run without committing; every rejection must happen before any container run.
+BADUP="$TMP/up_bad"
+mkdir -p "$BADUP/p"
+sed 's/demo_pkg/badup_pkg/' "$REPO/demo_pkg/package.xml" > "$BADUP/p/package.xml"
+git -C "$BADUP" init -q
+git -C "$BADUP" -c user.name=t -c user.email=t@t add -A
+git -C "$BADUP" -c user.name=t -c user.email=t@t commit -qm badup
+: > "$DOCKER_STUB_CALLS"
+printf 'repositories:\n  "evil; touch pwned":\n    type: git\n    url: %s\n    version: jazzy\n' "$UPDEP_SRC" > "$BADUP/upstream.repos"
+out=$(bash "$SUT" "$BADUP" --dry-run 2>&1); rc=$?
+check "metachar dir name rejected"    [ "$rc" -ne 0 ]
+check "names the bad dir"             contains "$out" "invalid repo dir name"
+printf 'repositories:\n  updep:\n    type: git\n    url: %s\n    version: "jazzy; rm -rf /"\n' "$UPDEP_SRC" > "$BADUP/upstream.repos"
+out=$(bash "$SUT" "$BADUP" --dry-run 2>&1); rc=$?
+check "metachar version rejected"     [ "$rc" -ne 0 ]
+check "names the bad version"         contains "$out" "invalid version"
+printf 'repositories:\n  updep:\n    type: git\n    url: "%s evil"\n    version: jazzy\n' "$UPDEP_SRC" > "$BADUP/upstream.repos"
+out=$(bash "$SUT" "$BADUP" --dry-run 2>&1); rc=$?
+check "whitespace url rejected"       [ "$rc" -ne 0 ]
+check "names the bad url"             contains "$out" "invalid url"
+printf 'repositories:\n  updep:\n    type: git\n    url: %s\n' "$UPDEP_SRC" > "$BADUP/upstream.repos"
+out=$(bash "$SUT" "$BADUP" --dry-run 2>&1); rc=$?
+check "missing version rejected"      [ "$rc" -ne 0 ]
+check "explains version requirement"  contains "$out" "has no version"
+rm "$BADUP/upstream.repos"
+mkdir -p "$BADUP/.agents"
+printf 'good_key\nbad key; rm -rf /\n' > "$BADUP/.agents/ci_local_rosdep_skip_keys.txt"
+out=$(bash "$SUT" "$BADUP" --dry-run 2>&1); rc=$?
+check "bad skip-key rejected"         [ "$rc" -ne 0 ]
+check "names the bad key"             contains "$out" "invalid rosdep key"
+check "no container run for any bad case" bash -c "! grep -qs docker-run '$DOCKER_STUB_CALLS'"
+
+echo "== unresolvable upstream version fails before the container runs =="
+: > "$DOCKER_STUB_CALLS"
+printf 'repositories:\n  updep:\n    type: git\n    url: %s\n    version: no_such_branch\n' "$UPDEP_SRC" > "$BADUP/upstream.repos"
+rm "$BADUP/.agents/ci_local_rosdep_skip_keys.txt"
+out=$(bash "$SUT" "$BADUP" --no-attest 2>&1); rc=$?
+check "unresolvable ref rejected"     [ "$rc" -ne 0 ]
+check "names the unresolvable ref"    contains "$out" "cannot resolve 'no_such_branch'"
+check "no container run"              bash -c "! grep -qs docker-run '$DOCKER_STUB_CALLS'"
+
+echo "== no upstream.repos stays byte-compatible (regression) =="
+out=$(bash "$SUT" "$REPO" 2>&1); rc=$?
+check "exits 0"                       [ "$rc" -eq 0 ]
+note=$(note_of "$HEAD_SHA")
+check "no upstream-repo lines"        not_contains "$note" "upstream-repo:"
+check "steps unchanged"               contains "$note" "steps: template"
 
 echo
 echo "$PASS passed, $FAIL failed"

--- a/.agent/scripts/tests/test_ci_local.sh
+++ b/.agent/scripts/tests/test_ci_local.sh
@@ -276,6 +276,10 @@ printf 'repositories:\n  updep:\n    type: git\n    url: %s\n' "$UPDEP_SRC" > "$
 out=$(bash "$SUT" "$BADUP" --dry-run 2>&1); rc=$?
 check "missing version rejected"      [ "$rc" -ne 0 ]
 check "explains version requirement"  contains "$out" "has no version"
+printf 'repositories:\n  updep:\n    url: %s\n    version: jazzy\n' "$UPDEP_SRC" > "$BADUP/upstream.repos"
+out=$(bash "$SUT" "$BADUP" --dry-run 2>&1); rc=$?
+check "missing type rejected"         [ "$rc" -ne 0 ]
+check "explains type requirement"     contains "$out" "has no type"
 rm "$BADUP/upstream.repos"
 mkdir -p "$BADUP/.agents"
 printf 'good_key\nbad key; rm -rf /\n' > "$BADUP/.agents/ci_local_rosdep_skip_keys.txt"

--- a/.agent/scripts/tests/test_ci_local.sh
+++ b/.agent/scripts/tests/test_ci_local.sh
@@ -221,7 +221,7 @@ echo "== upstream.repos dry run =="
 out=$(bash "$SUT" "$UPREPO" --dry-run 2>&1); rc=$?
 check "exits 0"                       [ "$rc" -eq 0 ]
 check "shows parsed upstream entry"   contains "$out" "upstream : updep@jazzy $UPDEP_SRC"
-check "steps gains upstream tokens"   contains "$out" "steps    : template+upstream+upstream-hook"
+check "steps gains upstream tokens"   contains "$out" "steps    : template+upstream+upstream-hook+rosdep-skip-keys"
 check "upstream hook detected"        contains "$out" "upstream-hook : yes"
 check "skip keys parsed"              contains "$out" "rosdep-skip-keys: skip_key_a skip_key_b"
 check "no container run"              bash -c "! grep -qs docker-run '$DOCKER_STUB_CALLS'"
@@ -233,7 +233,22 @@ unote=$(git -C "$UPREPO" notes --ref=ci-local show "$UPREPO_SHA" 2>/dev/null)
 check "note says pass"                contains "$unote" "ci-local: pass"
 check "note scope full"               contains "$unote" "scope: full"
 check "note records resolved SHA"     contains "$unote" "upstream-repo: updep@$UPDEP_SHA"
-check "note steps include upstream"   contains "$unote" "steps: template+upstream+upstream-hook"
+check "note steps include upstream"   contains "$unote" "steps: template+upstream+upstream-hook+rosdep-skip-keys"
+check "note records skip keys"        contains "$unote" "rosdep-skip-keys: skip_key_a skip_key_b"
+
+echo "== annotated tag resolves to the peeled commit SHA =="
+# The note must record the commit that gets checked out, not the tag object.
+git -C "$UPDEP_SRC" -c user.name=t -c user.email=t@t tag -a v_test -m "annotated"
+TAG_OBJ="$(git -C "$UPDEP_SRC" rev-parse v_test)"
+check "fixture tag is annotated"      bash -c "[ '$TAG_OBJ' != '$UPDEP_SHA' ]"
+sed -i 's/version: jazzy/version: v_test/' "$UPREPO/upstream.repos"
+git -C "$UPREPO" -c user.name=t -c user.email=t@t commit -qam "pin annotated tag"
+TAGPIN_SHA="$(git -C "$UPREPO" rev-parse HEAD)"
+out=$(bash "$SUT" "$UPREPO" 2>&1); rc=$?
+check "exits 0"                       [ "$rc" -eq 0 ]
+tnote=$(git -C "$UPREPO" notes --ref=ci-local show "$TAGPIN_SHA" 2>/dev/null)
+check "note records peeled commit"    contains "$tnote" "upstream-repo: updep@$UPDEP_SHA"
+check "tag object sha not recorded"   not_contains "$tnote" "$TAG_OBJ"
 
 echo "== upstream.repos injection / validation rejection =="
 # Live-tree reads (untracked upstream.repos => dirty tree) let each bad case
@@ -283,6 +298,7 @@ out=$(bash "$SUT" "$REPO" 2>&1); rc=$?
 check "exits 0"                       [ "$rc" -eq 0 ]
 note=$(note_of "$HEAD_SHA")
 check "no upstream-repo lines"        not_contains "$note" "upstream-repo:"
+check "no rosdep-skip-keys line"      not_contains "$note" "rosdep-skip-keys:"
 check "steps unchanged"               contains "$note" "steps: template"
 
 echo

--- a/.agent/work-plans/issue-577/plan.md
+++ b/.agent/work-plans/issue-577/plan.md
@@ -1,0 +1,223 @@
+# Plan: ci_local.sh: support upstream.repos source dependencies (blocks ADR-0018 attestation for repos like cube_bathymetry)
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/577
+
+## Context
+
+`ci_local.sh` (#573, ADR-0018) mounts only the target repo into `/ci/src/<repo>`
+and never reads an `upstream.repos` file, so any repo with unreleased source
+dependencies (today: `cube_bathymetry`, depending on `unh_marine_autonomy`,
+`mru_transform`, `geographic_info`) fails immediately at rosdep/CMake
+resolution and can never produce a `ci-local: pass` attestation. Hosted CI for
+these repos uses `industrial_ci`'s `UPSTREAM_WORKSPACE` mechanism, plus
+repo-specific `ROSDEP_SKIP_KEYS` and `AFTER_SETUP_UPSTREAM_WORKSPACE` env vars
+to prune the upstream monorepo down to what's actually needed.
+
+**Operator checkpoint decisions (settled, not reopened by this plan):**
+1. Strategy = `vcs import`, not industrial_ci delegation. When
+   `<repo>/upstream.repos` exists, `ci_local.sh` vcs-imports it into an
+   upstream workspace inside the container, builds it, and sources it before
+   building the target — with pruning expressed via a hook generalized from
+   the existing `<repo>/.agents/ci_local_extra.sh` precedent.
+2. The `ci-local` attestation note format is extended in this PR to record
+   resolved upstream commit SHAs per `upstream.repos` entry, so `scope: full`
+   attestations stay self-describing merge evidence per ADR-0018 even though
+   `upstream.repos` entries pin to floating branches, not SHAs.
+
+## Approach
+
+1. **Detect `upstream.repos`.** After repo-root/mount validation, check for
+   `$REPO/upstream.repos`. If absent, behavior is unchanged (today's
+   single-repo path). If present, parse it with `python3 -c` + `yaml` (already
+   a rosdep/vcstool runtime dependency, avoids a new hand-rolled YAML parser)
+   into a list of `(local_dir, url, version)` tuples — this happens on the
+   **host**, before the container runs, so injection-unsafe values are caught
+   before they reach any shell.
+
+2. **Validate parsed fields before interpolation.** Mirror the existing
+   package-name validation: each `local_dir` must match
+   `^[A-Za-z0-9_-]+$`; each `version` must match a conservative git-ref
+   charset (`^[A-Za-z0-9_./-]+$`); each `url` must not contain whitespace or
+   shell metacharacters that would break out of a single-quoted argument.
+   Reject with a clear error (naming the offending repo) rather than passing
+   anything unsanitized into the inner container script — same threat model
+   as the existing package-name check (attestation forgery via injection).
+
+3. **Generalize the per-repo hook.** Add
+   `<repo>/.agents/ci_local_upstream_extra.sh` (executable, optional) as the
+   upstream-side analog of `ci_local_extra.sh`: run inside the container
+   after `vcs import` of the upstream workspace but before `rosdep install`/
+   `colcon build` of it, with the upstream workspace as cwd. This is where a
+   repo like cube_bathymetry expresses its
+   `AFTER_SETUP_UPSTREAM_WORKSPACE`-equivalent pruning (`touch
+   COLCON_IGNORE` in subpackages it doesn't need) — imperative, per-repo,
+   never baked into the generic script (ADR-0003).
+
+   Add `<repo>/.agents/ci_local_rosdep_skip_keys.txt` (optional, one key per
+   line, comments with `#`) as the declarative analog of `ROSDEP_SKIP_KEYS`:
+   read on the host, validated against `^[A-Za-z0-9_-]+$` per line (same
+   injection threat as package names), and passed to the single combined
+   `rosdep install --from-paths src --ignore-src -r -y --skip-keys "..."`
+   call that covers both the upstream and target workspaces.
+
+4. **Extend the inner container script.** When upstream is present:
+   - `vcs import upstream_ws/src < upstream.repos` (host writes the validated
+     repos file into the snapshot/live tree copy that's mounted, or the
+     parsed+re-validated tuples are passed as env/args — see step 7 on the
+     snapshot boundary).
+   - run `ci_local_upstream_extra.sh` if present.
+   - `rosdep install --from-paths src --ignore-src -r -y` across
+     `/ci/upstream_ws/src` and `/ci/src` together (single call, matching
+     industrial_ci's combined resolution and avoiding order-dependent
+     partial installs), with `--skip-keys` from step 3.
+   - `colcon build` the upstream workspace first (`--base-paths upstream_ws`
+     or a merged workspace layout — pick whichever keeps target-repo
+     `--packages-up-to` semantics intact; see Open Questions), `source
+     upstream_ws/install/local_setup.bash`, then proceed with the existing
+     target-repo build/test steps unchanged.
+
+5. **Capture resolved upstream SHAs for the attestation.** After `vcs
+   import`, the inner script writes one line per upstream repo (`<local_dir>
+   <resolved-sha>`) to a small file in a directory the host bind-mounts
+   read-write for this purpose only (e.g. `$LOG_DIR/.upstream-<ts>/`,
+   cleaned up after the run) — the rest of the container's mounts stay
+   read-only, unchanged. The host reads this file after a successful run and
+   folds it into the note (step 6). If the file is missing/malformed after a
+   run that used `upstream.repos`, treat it as a hard failure (never attest
+   silently-unresolved upstream state).
+
+6. **Extend the attestation note format.** Add one `upstream-repo:` line per
+   entry, appended after `packages:`:
+
+   ```
+   ci-local: pass
+   repo: cube_bathymetry
+   commit: <sha>
+   image: ...
+   packages: ...
+   scope: full
+   upstream-repo: unh_marine_autonomy@<resolved-sha>
+   upstream-repo: mru_transform@<resolved-sha>
+   upstream-repo: geographic_info@<resolved-sha>
+   steps: template+upstream+extra-hook
+   date: ...
+   host: ...
+   log-sha256: ...
+   ```
+
+   `steps:` gains an `upstream` token (and keeps `+extra-hook` when
+   `ci_local_extra.sh` — the *target*-repo hook — also ran) so a note reader
+   can tell at a glance whether upstream sources were part of the attested
+   build. No `upstream.repos` in the repo → note format is byte-identical to
+   today (no regression for existing attested repos).
+
+7. **`--dry-run` plan output.** Add a section showing the parsed upstream
+   repos (dir/url/version), whether `ci_local_upstream_extra.sh` and
+   `ci_local_rosdep_skip_keys.txt` were found, and the `steps` value —
+   mirroring the existing dry-run detail level for packages/image/scope.
+
+8. **ADR-0018 doc update.** Add a Consequences-section note (or a short
+   "Decision 1a" style addendum — whichever reads better once drafted)
+   stating that `scope: full` attestations on repos with `upstream.repos`
+   also require `upstream-repo:` lines resolving every entry, and that a
+   note lacking them for a repo that has `upstream.repos` is not valid merge
+   evidence even if it says `ci-local: pass`/`scope: full`. This is a note
+   **format extension**, not a redefinition of what already-recorded notes
+   (repos without `upstream.repos`) mean.
+
+9. **AGENTS.md reference-line update.** Extend the `ci_local.sh` row in the
+   Script Reference table to mention `upstream.repos` support in one clause.
+
+10. **Tests.** Extend `.agent/scripts/tests/test_ci_local.sh` (docker still
+    fully stubbed — no real container/network/vcs execution in the test
+    harness, consistent with existing coverage):
+    - Fixture repo gains a sibling fixture with an `upstream.repos` file;
+      dry-run shows the parsed upstream entries and `steps` includes
+      `upstream`.
+    - Injection-safety: malformed `local_dir` (shell metacharacters),
+      malformed `version`, and a `url` with embedded whitespace/newline are
+      each rejected before any container run, with a message naming the bad
+      field — mirroring the existing malicious-package-name case.
+    - `ci_local_upstream_extra.sh` presence is detected and reflected in
+      `steps`; absence leaves `steps` unchanged from today's format (no
+      `upstream.repos` case stays byte-identical — regression guard).
+    - `ci_local_rosdep_skip_keys.txt` parsing: valid file accepted; a line
+      failing the key-name charset is rejected.
+    - Note-format case: docker stub is extended to fake-write the
+      resolved-upstream-SHA output file (mirroring how it already fakes
+      `docker image inspect`), so the full success path can assert the note
+      gains the expected `upstream-repo:` lines and `steps: ...+upstream`.
+    - Regression case: a repo *without* `upstream.repos` produces a note
+      with no `upstream-repo:` lines and unchanged `steps` value — pins
+      backward compatibility.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/ci_local.sh` | Detect/parse/validate `upstream.repos`; extend inner container script (vcs import, upstream hook, combined rosdep with skip-keys, upstream build+source); capture resolved upstream SHAs; extend dry-run output and the attestation note format |
+| `.agent/scripts/tests/test_ci_local.sh` | New fixture + cases per Approach step 10 |
+| `docs/decisions/0018-local-first-ci-verification.md` | Consequences note: `upstream-repo:` lines required for `scope: full` validity on repos carrying `upstream.repos` |
+| `AGENTS.md` | Extend the `ci_local.sh` Script Reference row to mention upstream.repos support |
+| `.agent/scripts/ci_local.sh` (help text / header comment) | Document the new `<repo>/.agents/ci_local_upstream_extra.sh` and `<repo>/.agents/ci_local_rosdep_skip_keys.txt` hook files, same style as the existing `ci_local_extra.sh` doc comment |
+
+No changes needed in `cube_bathymetry` itself for this PR — adopting the new
+hooks there (splitting its industrial_ci `ROSDEP_SKIP_KEYS`/
+`AFTER_SETUP_UPSTREAM_WORKSPACE` into the new files) is a natural follow-up
+once the mechanism lands, tracked separately (see Consequences), not required
+to close this issue (the issue only requires that `ci_local.sh` *can*
+support `upstream.repos`, verified against the test fixtures).
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Workspace vs. project separation | Mechanism keyed off a well-known filename (`upstream.repos`) and optional hook files under `.agents/`, not a cube_bathymetry special-case; no repo name appears in `ci_local.sh` |
+| Enforcement over documentation | Extends the existing enforced attestation tool rather than documenting a manual workaround |
+| A change includes its consequences | ADR-0018 doc, AGENTS.md reference line, and test coverage are in this same plan, not deferred |
+| Test what breaks | New parsing/validation/note-format logic gets stub-based tests before/alongside implementation, including a backward-compatibility regression case |
+| Only what's needed | Two hook files (imperative prune + declarative skip-keys) mirror industrial_ci's two real mechanisms exactly — no speculative generality beyond what cube_bathymetry's actual CI config demonstrates is needed |
+| Improve incrementally | Single PR; cube_bathymetry's own adoption of the new hooks is left as a follow-up, not bundled in |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0003 — Project-agnostic workspace | Yes | Generic filename-keyed detection; per-repo specifics (pruning, skip-keys) live in the project repo's own `.agents/` files, never in workspace script logic |
+| 0018 — Local-first CI verification | Yes | Closes the Phase-1 tool gap for `upstream.repos` repos; note format extended (step 6) with a doc addendum (step 8) so the `scope: full` merge-evidence guarantee (Decision 1) is preserved rather than silently weakened |
+| 0009 — Python package management | Watch | `vcs` (python3-vcstool) confirmed present on this dev host via `ros-dev-tools`; before implementation, confirm it's baked into `ros2-agent-workspace-agent:latest` (fast path) — if missing, the inner script's existing `ros-dev-tools` apt-install fallback (already present for `colcon`) covers `ros:jazzy-ros-core`, so no new dependency-provisioning step is needed either way |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `ci_local.sh` note format | ADR-0018 doc (Consequences section) | Yes — step 8 |
+| `ci_local.sh` capability surface | `AGENTS.md` Script Reference | Yes — step 9 |
+| `ci_local.sh` parsing/build logic | `test_ci_local.sh` | Yes — step 10 |
+| New hook file convention (`ci_local_upstream_extra.sh`, `ci_local_rosdep_skip_keys.txt`) | cube_bathymetry adopts them, replacing its industrial_ci env vars | No — follow-up issue in `rolker/cube_bathymetry`, filed after this PR merges (adoption is optional; industrial_ci config keeps working independently as the hosted mirror per ADR-0018 Decision 3) |
+| Upstream workspace build added to the local run | Wall-clock cost of `ci_local.sh` runs on `upstream.repos` repos | No code change — flagged as an accepted tradeoff in Open Questions; caching (ccache-equivalent) is out of scope for this PR |
+
+## Open Questions
+
+- [ ] Upstream + target workspace layout inside the container: build upstream
+      as a separate underlay sourced before the target build (simpler,
+      mirrors industrial_ci's two-workspace model), vs. a single merged
+      `src/` tree built together (lets one `colcon build --packages-up-to`
+      call cover both, but changes what "target repo only" build output
+      means). Recommend the underlay approach — closer to industrial_ci
+      semantics the hosted CI already validates, and keeps the existing
+      target-repo build/test invocation unchanged.
+- [ ] Whether to cache the built upstream workspace across repeated
+      `ci_local.sh` runs on the same `upstream.repos` content (the issue
+      flags this as dominating wall-clock, mirroring hosted CI's ccache
+      use). Recommend deferring to a follow-up issue — this PR should land
+      the correctness fix (attestable runs succeed at all) before optimizing
+      repeat-run latency.
+
+## Estimated Scope
+
+Single PR. The change is additive and backward-compatible (no
+`upstream.repos` → identical behavior/note format to today), concentrated in
+one script plus its test file and two doc updates.

--- a/.agent/work-plans/issue-577/plan.md
+++ b/.agent/work-plans/issue-577/plan.md
@@ -28,13 +28,18 @@ to prune the upstream monorepo down to what's actually needed.
 
 ## Approach
 
-1. **Detect `upstream.repos`.** After repo-root/mount validation, check for
-   `$REPO/upstream.repos`. If absent, behavior is unchanged (today's
-   single-repo path). If present, parse it with `python3 -c` + `yaml` (already
-   a rosdep/vcstool runtime dependency, avoids a new hand-rolled YAML parser)
-   into a list of `(local_dir, url, version)` tuples — this happens on the
-   **host**, before the container runs, so injection-unsafe values are caught
-   before they reach any shell.
+1. **Detect `upstream.repos`.** After attestation eligibility is computed,
+   check for `upstream.repos` — read from the **pristine HEAD commit content**
+   (`git show HEAD:...`) for attestable runs, from the live tree for
+   dirty/`--no-attest` runs, so an attested run can never consume inputs that
+   differ from the recorded commit (same rule for the two hook files in step
+   3). If absent, behavior is unchanged (today's single-repo path). If
+   present, parse it with `python3 -c` + `yaml` (already a rosdep runtime
+   dependency, avoids a new hand-rolled YAML parser) into a list of
+   `(local_dir, url, version)` tuples — on the **host**, before the container
+   runs, so injection-unsafe values are caught before they reach any shell.
+   Entries must be `type: git` and carry an explicit `version` (attestation
+   must resolve a concrete ref).
 
 2. **Validate parsed fields before interpolation.** Mirror the existing
    package-name validation: each `local_dir` must match
@@ -62,31 +67,33 @@ to prune the upstream monorepo down to what's actually needed.
    `rosdep install --from-paths src --ignore-src -r -y --skip-keys "..."`
    call that covers both the upstream and target workspaces.
 
-4. **Extend the inner container script.** When upstream is present:
-   - `vcs import upstream_ws/src < upstream.repos` (host writes the validated
-     repos file into the snapshot/live tree copy that's mounted, or the
-     parsed+re-validated tuples are passed as env/args — see step 7 on the
-     snapshot boundary).
-   - run `ci_local_upstream_extra.sh` if present.
-   - `rosdep install --from-paths src --ignore-src -r -y` across
-     `/ci/upstream_ws/src` and `/ci/src` together (single call, matching
-     industrial_ci's combined resolution and avoiding order-dependent
-     partial installs), with `--skip-keys` from step 3.
-   - `colcon build` the upstream workspace first (`--base-paths upstream_ws`
-     or a merged workspace layout — pick whichever keeps target-repo
-     `--packages-up-to` semantics intact; see Open Questions), `source
-     upstream_ws/install/local_setup.bash`, then proceed with the existing
-     target-repo build/test steps unchanged.
+4. **Resolve upstream refs host-side, then extend the inner container
+   script.** Before the container runs, the host resolves each entry's
+   floating `version` to a commit SHA via `git ls-remote <url>
+   refs/heads/<v> refs/tags/<v>` (a 40-hex `version` is used as-is);
+   resolution failure is fatal. The inner script then, when upstream is
+   present:
+   - `git clone` each validated url into `/ci/upstream_ws/src/<dir>` and
+     `git checkout --detach <resolved-sha>` — generated from the validated
+     tuples, so no repos file and no `vcs`/vcstool are needed in the
+     container at all (see Implementation Notes).
+   - run `ci_local_upstream_extra.sh` (via bash, cwd `/ci/upstream_ws`) if
+     present.
+   - `rosdep install --from-paths src upstream_ws/src --ignore-src -r -y`
+     (single combined call, matching industrial_ci's resolution and avoiding
+     order-dependent partial installs), with `--skip-keys` from step 3.
+   - `colcon build` the upstream workspace as a **separate underlay**
+     (`--base-paths upstream_ws/src`, its own build/install bases — the
+     resolved Open Question), `source upstream_ws/install/local_setup.bash`,
+     then run the existing target-repo build/test steps pinned with
+     `--base-paths src` so cwd discovery never re-includes the underlay.
 
-5. **Capture resolved upstream SHAs for the attestation.** After `vcs
-   import`, the inner script writes one line per upstream repo (`<local_dir>
-   <resolved-sha>`) to a small file in a directory the host bind-mounts
-   read-write for this purpose only (e.g. `$LOG_DIR/.upstream-<ts>/`,
-   cleaned up after the run) — the rest of the container's mounts stay
-   read-only, unchanged. The host reads this file after a successful run and
-   folds it into the note (step 6). If the file is missing/malformed after a
-   run that used `upstream.repos`, treat it as a hard failure (never attest
-   silently-unresolved upstream state).
+5. **Attestation carries the host-resolved SHAs.** Because resolution happens
+   on the host before the run (step 4), the note is written from values the
+   host chose and the container was *told* to check out — no container
+   output is trusted for attestation content, and every mount stays
+   read-only, unchanged. Unresolvable upstream state fails the run before
+   the container starts (never attest silently-unresolved upstream state).
 
 6. **Extend the attestation note format.** Add one `upstream-repo:` line per
    entry, appended after `packages:`:
@@ -118,14 +125,15 @@ to prune the upstream monorepo down to what's actually needed.
    `ci_local_rosdep_skip_keys.txt` were found, and the `steps` value —
    mirroring the existing dry-run detail level for packages/image/scope.
 
-8. **ADR-0018 doc update.** Add a Consequences-section note (or a short
-   "Decision 1a" style addendum — whichever reads better once drafted)
-   stating that `scope: full` attestations on repos with `upstream.repos`
-   also require `upstream-repo:` lines resolving every entry, and that a
-   note lacking them for a repo that has `upstream.repos` is not valid merge
-   evidence even if it says `ci-local: pass`/`scope: full`. This is a note
-   **format extension**, not a redefinition of what already-recorded notes
-   (repos without `upstream.repos`) mean.
+8. **ADR-0018 doc update.** Add a Consequences-section note stating that
+   `scope: full` attestations on repos with `upstream.repos` also require
+   `upstream-repo:` lines resolving every entry, and that a note lacking
+   them for a repo that has `upstream.repos` is not valid merge evidence
+   even if it says `ci-local: pass`/`scope: full`. This is a note **format
+   extension**, not a redefinition of what already-recorded notes (repos
+   without `upstream.repos`) mean. Also note `--clean-room` as the natural
+   mode for `upstream.repos` repos (clones need network anyway; agent-image
+   deps for upstream sources aren't baked).
 
 9. **AGENTS.md reference-line update.** Extend the `ci_local.sh` row in the
    Script Reference table to mention `upstream.repos` support in one clause.
@@ -145,10 +153,12 @@ to prune the upstream monorepo down to what's actually needed.
       `upstream.repos` case stays byte-identical — regression guard).
     - `ci_local_rosdep_skip_keys.txt` parsing: valid file accepted; a line
       failing the key-name charset is rejected.
-    - Note-format case: docker stub is extended to fake-write the
-      resolved-upstream-SHA output file (mirroring how it already fakes
-      `docker image inspect`), so the full success path can assert the note
-      gains the expected `upstream-repo:` lines and `steps: ...+upstream`.
+    - Note-format case: the fixture's `upstream.repos` points at a **local
+      fixture git repo** (file-path url), so the host-side `ls-remote`
+      resolution runs for real with no network and no docker-stub changes;
+      the full success path asserts the note gains the expected
+      `upstream-repo: <dir>@<real-sha>` line and `steps: ...+upstream`.
+      An unresolvable-version case asserts failure before any container run.
     - Regression case: a repo *without* `upstream.repos` produces a note
       with no `upstream-repo:` lines and unchanged `steps` value — pins
       backward compatibility.
@@ -157,11 +167,10 @@ to prune the upstream monorepo down to what's actually needed.
 
 | File | Change |
 |------|--------|
-| `.agent/scripts/ci_local.sh` | Detect/parse/validate `upstream.repos`; extend inner container script (vcs import, upstream hook, combined rosdep with skip-keys, upstream build+source); capture resolved upstream SHAs; extend dry-run output and the attestation note format |
-| `.agent/scripts/tests/test_ci_local.sh` | New fixture + cases per Approach step 10 |
-| `docs/decisions/0018-local-first-ci-verification.md` | Consequences note: `upstream-repo:` lines required for `scope: full` validity on repos carrying `upstream.repos` |
+| `.agent/scripts/ci_local.sh` | Detect/parse/validate `upstream.repos` (pristine-at-HEAD for attestable runs); host-side ref→SHA resolution; extend inner container script (generated clones, upstream hook, combined rosdep with skip-keys, underlay build+source, `--base-paths src` pinning); extend dry-run output, the attestation note format, and the header doc comment (hook files) |
+| `.agent/scripts/tests/test_ci_local.sh` | New fixtures + cases per Approach step 10 |
+| `docs/decisions/0018-local-first-ci-verification.md` | Consequences note: `upstream-repo:` lines required for `scope: full` validity on repos carrying `upstream.repos`; `--clean-room` preference |
 | `AGENTS.md` | Extend the `ci_local.sh` Script Reference row to mention upstream.repos support |
-| `.agent/scripts/ci_local.sh` (help text / header comment) | Document the new `<repo>/.agents/ci_local_upstream_extra.sh` and `<repo>/.agents/ci_local_rosdep_skip_keys.txt` hook files, same style as the existing `ci_local_extra.sh` doc comment |
 
 No changes needed in `cube_bathymetry` itself for this PR — adopting the new
 hooks there (splitting its industrial_ci `ROSDEP_SKIP_KEYS`/
@@ -187,7 +196,7 @@ support `upstream.repos`, verified against the test fixtures).
 |---|---|---|
 | 0003 — Project-agnostic workspace | Yes | Generic filename-keyed detection; per-repo specifics (pruning, skip-keys) live in the project repo's own `.agents/` files, never in workspace script logic |
 | 0018 — Local-first CI verification | Yes | Closes the Phase-1 tool gap for `upstream.repos` repos; note format extended (step 6) with a doc addendum (step 8) so the `scope: full` merge-evidence guarantee (Decision 1) is preserved rather than silently weakened |
-| 0009 — Python package management | Watch | `vcs` (python3-vcstool) confirmed present on this dev host via `ros-dev-tools`; before implementation, confirm it's baked into `ros2-agent-workspace-agent:latest` (fast path) — if missing, the inner script's existing `ros-dev-tools` apt-install fallback (already present for `colcon`) covers `ros:jazzy-ros-core`, so no new dependency-provisioning step is needed either way |
+| 0009 — Python package management | Resolved | The implementation generates plain `git clone`/`git checkout` commands from host-validated tuples, so `vcs`/vcstool is **not needed at all** (host or container); the inner script gains only a `git` apt fallback beside the existing `ros-dev-tools` one |
 
 ## Consequences
 
@@ -201,23 +210,35 @@ support `upstream.repos`, verified against the test fixtures).
 
 ## Open Questions
 
-- [ ] Upstream + target workspace layout inside the container: build upstream
-      as a separate underlay sourced before the target build (simpler,
-      mirrors industrial_ci's two-workspace model), vs. a single merged
-      `src/` tree built together (lets one `colcon build --packages-up-to`
-      call cover both, but changes what "target repo only" build output
-      means). Recommend the underlay approach — closer to industrial_ci
-      semantics the hosted CI already validates, and keeps the existing
-      target-repo build/test invocation unchanged.
+- [x] Upstream + target workspace layout: **resolved — separate underlay**
+      (`upstream_ws` with its own build/install bases, sourced before the
+      target build; target build/test pinned to `--base-paths src`). Mirrors
+      industrial_ci's two-workspace model the hosted CI already validates.
 - [ ] Whether to cache the built upstream workspace across repeated
       `ci_local.sh` runs on the same `upstream.repos` content (the issue
       flags this as dominating wall-clock, mirroring hosted CI's ccache
-      use). Recommend deferring to a follow-up issue — this PR should land
-      the correctness fix (attestable runs succeed at all) before optimizing
-      repeat-run latency.
+      use). Deferred to a follow-up issue — this PR lands the correctness
+      fix (attestable runs succeed at all) before optimizing repeat-run
+      latency.
 
 ## Estimated Scope
 
 Single PR. The change is additive and backward-compatible (no
 `upstream.repos` → identical behavior/note format to today), concentrated in
 one script plus its test file and two doc updates.
+
+## Implementation Notes
+
+- **`vcs import` replaced by generated `git clone` + `checkout --detach`**:
+  since every `(dir, url, version)` tuple is already host-validated, emitting
+  explicit git commands removes the vcstool dependency entirely (host and
+  container) and shrinks the container's parsing surface to zero — the
+  container never reads `upstream.repos` at all. Same strategy (the
+  workspace imports the upstream workspace itself), simpler mechanism.
+- **Container log-marker SHA capture replaced by host-side pre-run
+  `ls-remote` resolution**: the plan-review suggestion (parseable log marker,
+  no RW mount) still left the note's upstream SHAs derived from container
+  *output*, which the repo-under-test's own build/tests could forge. Resolving
+  on the host *before* the run and telling the container which SHA to check
+  out makes the note tamper-proof, keeps every mount read-only, and turns
+  "unresolvable upstream" into a pre-container hard failure.

--- a/.agent/work-plans/issue-577/plan.md
+++ b/.agent/work-plans/issue-577/plan.md
@@ -242,3 +242,12 @@ one script plus its test file and two doc updates.
   on the host *before* the run and telling the container which SHA to check
   out makes the note tamper-proof, keeps every mount read-only, and turns
   "unresolvable upstream" into a pre-container hard failure.
+- **Pre-push review round hardening** (0 must-fix, 3 suggestions — all
+  applied): resolved SHAs are re-validated against `^[0-9a-f]{40}$` before
+  interpolation, and the ls-remote patterns now include `refs/tags/<v>^{}`
+  with the peeled commit preferred over the annotated-tag object (the note
+  records the commit that is checked out, never a tag object); applied
+  rosdep skip-keys are recorded persistently (`rosdep-skip-keys:` note line
+  plus a `+rosdep-skip-keys` steps token, dry-run display made unconditional);
+  the header comment no longer frames skip-keys as upstream-only — they apply
+  to the single combined rosdep install regardless.

--- a/.agent/work-plans/issue-577/progress.md
+++ b/.agent/work-plans/issue-577/progress.md
@@ -104,3 +104,16 @@ being exempted as "only exercised against real cube_bathymetry."
 - [ ] Add stub-based tests to `test_ci_local.sh` for the new upstream.repos path (dry-run plan output, injection-safety on parsed repo name/URL/version fields).
 - [ ] Confirm `vcs`/`vcstool` availability in the agent sandbox / clean-room images (ADR-0009 dev-tool provisioning, not bare pip).
 - [ ] Update `AGENTS.md`'s ci_local.sh reference line once the capability lands.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-22 20:15 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-577/plan.md` at `1dc9627`
+**Branch**: feature/issue-577 at `1dc9627`
+**Phases**: single
+
+### Open questions
+- [ ] Upstream/target workspace layout inside the container: separate underlay build (recommended, mirrors industrial_ci) vs. single merged src/ tree.
+- [ ] Whether to cache the built upstream workspace across repeated runs (recommend deferring to a follow-up issue; this PR lands correctness first).

--- a/.agent/work-plans/issue-577/progress.md
+++ b/.agent/work-plans/issue-577/progress.md
@@ -153,3 +153,20 @@ Strong, source-verified plan that addresses every review-issue finding and both 
 - [ ] During implementation, resolve step-4/step-5 so upstream.repos is read from the pristine snapshot and resolved-SHA capture preserves attestation integrity (log marker preferred over rw mount).
 - [ ] Commit to the underlay layout (plan's own recommendation) before writing the inner-script changes.
 - [ ] Add the `--clean-room`-preferred-for-upstream.repos note to the ADR-0018 update.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-22 17:22 -04:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-577 at `1345aec`
+**Mode**: pre-push
+**Depth**: Deep (reason: command-injection surface parsing upstream.repos + shelling out to a generated container script; substantive ADR-0018 edit)
+**Must-fix**: 0 | **Suggestions**: 3
+**Round**: 1 | **Ship**: recommended — no must-fix; static analysis clean, 75/75 tests pass, attestation-integrity design sound
+
+### Findings
+- [ ] (suggestion) Re-validate the `git ls-remote`-resolved SHA against `^[0-9a-f]{40}$` before interpolating into the container `git checkout` and the `upstream-repo:` note line (defense-in-depth; also handles annotated-tag object-vs-peeled-commit) — `.agent/scripts/ci_local.sh:299-301`
+- [ ] (suggestion) Record `ci_local_rosdep_skip_keys.txt` usage in the persistent `steps:` note field (only dry-run surfaces it today), so a skip-keys-pruned rosdep resolution is reflected in the merge evidence — `.agent/scripts/ci_local.sh:248-263`
+- [ ] (suggestion) Header doc comment frames skip-keys as upstream-only pruning, but the code applies it unconditionally (unlike the UPSTREAM_PRESENT-gated hook); reconcile comment vs. gating — `.agent/scripts/ci_local.sh:44-46,248`

--- a/.agent/work-plans/issue-577/progress.md
+++ b/.agent/work-plans/issue-577/progress.md
@@ -182,8 +182,8 @@ Strong, source-verified plan that addresses every review-issue finding and both 
 **CI**: all-pass (after `6f747b6` added pyyaml to the script-tests job — setup-python lacks the yaml module the upstream.repos parser imports)
 
 ### Findings
-- [ ] (minor, Copilot R1) `upstream.repos` parser defaults a missing `type` to `git` (`ent.get("type", "git")`), contradicting the documented "requires `type: git`" contract and weakening fail-loud validation — require an explicit `type: git`, error when absent; add a rejection test — `.agent/scripts/ci_local.sh:226`
-- [ ] (minor, Copilot R2) host-side `git ls-remote` lacks the `--` separator, so a charset-valid URL beginning with `-` would parse as an option; the generated container-side `git clone --` is already guarded — add `--` for consistency of the injection-hardening model — `.agent/scripts/ci_local.sh:315`
+- [x] (minor, Copilot R1) `upstream.repos` parser defaults a missing `type` to `git` (`ent.get("type", "git")`), contradicting the documented "requires `type: git`" contract and weakening fail-loud validation — require an explicit `type: git`, error when absent; add a rejection test — `.agent/scripts/ci_local.sh:226`
+- [x] (minor, Copilot R2) host-side `git ls-remote` lacks the `--` separator, so a charset-valid URL beginning with `-` would parse as an option; the generated container-side `git clone --` is already guarded — add `--` for consistency of the injection-hardening model — `.agent/scripts/ci_local.sh:315`
 
 ### False positives
 - none — both bot comments verified valid against current head

--- a/.agent/work-plans/issue-577/progress.md
+++ b/.agent/work-plans/issue-577/progress.md
@@ -117,3 +117,39 @@ being exempted as "only exercised against real cube_bathymetry."
 ### Open questions
 - [ ] Upstream/target workspace layout inside the container: separate underlay build (recommended, mirrors industrial_ci) vs. single merged src/ tree.
 - [ ] Whether to cache the built upstream workspace across repeated runs (recommend deferring to a follow-up issue; this PR lands correctness first).
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-22 17:04 -04:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-577/plan.md` at `1dc9627`
+**PR**: PR-less (--issue mode; feature/issue-577)
+**Verdict**: approve-with-suggestions
+
+### Evaluation
+| Dimension | Verdict | Notes |
+|---|---|---|
+| Scope | Good | 4 files (ci_local.sh + its help text, test_ci_local.sh, ADR-0018, AGENTS.md); additive and backward-compatible. Well under split threshold. |
+| Issue alignment | Good | Implements vcs-import strategy (settled), pruning via hooks, and resolved-SHA note extension (settled in-scope). Both operator checkpoint decisions honored. |
+| review-issue alignment | Good | All six review-issue action items addressed: strategy choice, pruning-hook design, note-format extension, stub tests, vcstool availability, AGENTS.md line. |
+| File targeting | Good | Correct files. cube_bathymetry confirmed the only repo with `upstream.repos`; no cube-specific change bundled (correct — follow-up). Verified against source: single-repo mount + `ci_local_extra.sh` hook precedent both exist as the plan describes. |
+| Consequences | Good | Consequences table covers ADR-0018 doc, AGENTS.md, tests, cube follow-up, and wall-clock tradeoff. Nothing material missing. |
+| Principle alignment | Good | Filename-keyed generic mechanism (ADR-0003), enforcement-over-docs, tests included, incremental. Two-hook design justified by demonstrated industrial_ci parity (not speculative). |
+| ADR compliance | Good | 0003, 0018, 0009 all triggered and addressed. Note-format change framed as an extension, not a redefinition — preserves ADR-0018 Decision 1 merge-evidence guarantee. |
+| ROS conventions | N/A | Workspace-infra plan (shell + docker + vcstool); no ROS package code. |
+
+### Findings
+- [ ] (suggestion) Attestation integrity — make explicit that for attestable runs the `vcs import` consumes `upstream.repos` **from the pristine snapshot** (it is committed content, already in the `git archive HEAD` tree), not a host-rewritten copy. Host-side parse stays validation/dry-run only. The plan floats both options and the step-4→step-7 cross-reference is muddled (`plan.md:68-69` points at "step 7" which is dry-run output, not the snapshot boundary). Reading from the snapshot keeps the "tests exactly the commit content" guarantee intact. — `plan.md:65-79`
+- [ ] (suggestion) Consider capturing resolved upstream SHAs via a parseable stdout marker in the inner script (extracted by the host from the tee'd `$LOG`) instead of a new read-write bind mount. This preserves the current all-mounts-read-only invariant, and the SHAs then fall under the existing `log-sha256` integrity hash for free. If the rw mount is kept, the plan's hard-fail-on-missing handling is the right call. — `plan.md:81-89`
+- [ ] (suggestion) The underlay-vs-merged-src layout open question is the highest-impact implementation decision (it determines whether `--packages-up-to` target semantics stay unchanged). Recommend committing to the plan's own recommended underlay approach before implementation rather than deferring, since it shapes the rosdep/build/source wiring in steps 4. — `plan.md:204-211`
+- [ ] (suggestion) Per ADR-0018 Decision 6, `--clean-room` is the recommended image when a change touches dependency declarations/build environment — which `upstream.repos` repos inherently do, and clean-room's `ros-dev-tools` install guarantees `vcstool`. Worth a one-line note in the ADR-0018 doc update (step 8) that clean-room is preferred for `upstream.repos` repos, resolving the ADR-0009 vcstool-availability watch in the same stroke. — `plan.md:190`
+- [ ] (nit) Files-to-Change table lists `.agent/scripts/ci_local.sh` twice (logic row + help-text row). Intentional (separates the header-comment doc change) but reads as a duplicate; fold or annotate. — `plan.md:160,164`
+
+### Summary
+Strong, source-verified plan that addresses every review-issue finding and both settled operator decisions. It is ready for implementation. The suggestions are refinements — two of them (read `upstream.repos` from the snapshot; capture SHAs via a log marker rather than a rw mount) touch the ADR-0018 attestation-integrity guarantee and are worth resolving as the implementer wires up steps 4–5, but none block starting.
+
+### Recommended Actions
+- [ ] During implementation, resolve step-4/step-5 so upstream.repos is read from the pristine snapshot and resolved-SHA capture preserves attestation integrity (log marker preferred over rw mount).
+- [ ] Commit to the underlay layout (plan's own recommendation) before writing the inner-script changes.
+- [ ] Add the `--clean-room`-preferred-for-upstream.repos note to the ADR-0018 update.

--- a/.agent/work-plans/issue-577/progress.md
+++ b/.agent/work-plans/issue-577/progress.md
@@ -170,3 +170,23 @@ Strong, source-verified plan that addresses every review-issue finding and both 
 - [ ] (suggestion) Re-validate the `git ls-remote`-resolved SHA against `^[0-9a-f]{40}$` before interpolating into the container `git checkout` and the `upstream-repo:` note line (defense-in-depth; also handles annotated-tag object-vs-peeled-commit) — `.agent/scripts/ci_local.sh:299-301`
 - [ ] (suggestion) Record `ci_local_rosdep_skip_keys.txt` usage in the persistent `steps:` note field (only dry-run surfaces it today), so a skip-keys-pruned rosdep resolution is reflected in the merge evidence — `.agent/scripts/ci_local.sh:248-263`
 - [ ] (suggestion) Header doc comment frames skip-keys as upstream-only pruning, but the code applies it unconditionally (unlike the UPSTREAM_PRESENT-gated hook); reconcile comment vs. gating — `.agent/scripts/ci_local.sh:44-46,248`
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-23 08:46 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #578 at `6f747b6`
+**Sources**: 3 (Copilot R1 @ `2c7d53b`, Copilot R2 @ `6f747b6`, Local Review (Pre-Push) @ `1345aec`, CI rollup)
+**Cross-source confirmations**: 0
+**CI**: all-pass (after `6f747b6` added pyyaml to the script-tests job — setup-python lacks the yaml module the upstream.repos parser imports)
+
+### Findings
+- [ ] (minor, Copilot R1) `upstream.repos` parser defaults a missing `type` to `git` (`ent.get("type", "git")`), contradicting the documented "requires `type: git`" contract and weakening fail-loud validation — require an explicit `type: git`, error when absent; add a rejection test — `.agent/scripts/ci_local.sh:226`
+- [ ] (minor, Copilot R2) host-side `git ls-remote` lacks the `--` separator, so a charset-valid URL beginning with `-` would parse as an option; the generated container-side `git clone --` is already guarded — add `--` for consistency of the injection-hardening model — `.agent/scripts/ci_local.sh:315`
+
+### False positives
+- none — both bot comments verified valid against current head
+
+### Notes
+- The 3 Local Review (Pre-Push) suggestions @ `1345aec` were all applied in `2c7d53b` (SHA re-validation + peeled-tag preference; persistent rosdep-skip-keys note line + steps token; header comment reconciliation) — closed, not re-raised by any GitHub-side source.

--- a/.agent/work-plans/issue-577/progress.md
+++ b/.agent/work-plans/issue-577/progress.md
@@ -1,0 +1,106 @@
+---
+issue: 577
+---
+
+# Issue #577 — ci_local.sh: support upstream.repos source dependencies (blocks ADR-0018 attestation for repos like cube_bathymetry)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-22 18:57 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #577
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: needs-more-detail
+
+### Findings
+
+**Confirmed against source.** Read `.agent/scripts/ci_local.sh` (295 lines):
+it mounts only the target repo into `/ci/src/<repo_name>`, runs
+`rosdep install --from-paths src` and `colcon build --packages-up-to` against
+that single-repo source tree, with zero handling of `<repo>/upstream.repos`.
+The issue's reproduction (rosdep-key resolution failure on
+`marine_mbes_backscatter_store`, then a CMake `find_package(marine_autonomy)`
+failure) is exactly the failure mode the current script's single-repo mount
+would produce. Confirmed `layers/main/sensors_ws/src/cube_bathymetry/upstream.repos`
+exists and lists `unh_marine_autonomy`, `mru_transform`, `geographic_info` as
+floating-branch (`version: jazzy`) git deps. A repo-wide search of currently
+checked-out project repos found no other `upstream.repos` file — cube_bathymetry
+is the only affected repo today, but the mechanism is correctly scoped as
+generic workspace infra (ADR-0003), not a cube-specific patch.
+
+**cube_bathymetry's actual hosted CI is industrial_ci, not the workspace's
+generic `ci_workflow.yml` template.** `.github/workflows/ci.yml` uses
+`ros-industrial/industrial_ci@master` with `UPSTREAM_WORKSPACE`,
+`ROSDEP_SKIP_KEYS` (prunes `marine_nav_interfaces`/`marine_nav_tasks` from
+rosdep resolution even though the packages are never built), and
+`AFTER_SETUP_UPSTREAM_WORKSPACE` (touches `COLCON_IGNORE` in three upstream
+subpackages to scope the monorepo build to what cube actually needs). This
+means the issue's option 2 ("delegate to the repo's own industrial_ci
+config") is not a thin wrapper — it requires either parsing/replicating these
+env vars generically, or cube_bathymetry-specific logic that would violate
+the project-agnostic-workspace principle (ADR-0003). Option 1 (`vcs import`
++ generic build) is simpler and stays generic, but as written would not
+reproduce the pruning behavior — an unpruned build may fail or diverge from
+what hosted CI actually verifies. The issue text already flags this
+("honoring per-repo pruning hooks if feasible") but doesn't resolve it; the
+script already has a generic per-repo hook precedent
+(`<repo>/.agents/ci_local_extra.sh`) that plan-task should consider extending
+to an equivalent upstream-side hook, rather than inventing industrial_ci-env
+parsing.
+
+**Attestation semantics gap (ADR-0018).** The `upstream.repos` entries here
+pin to floating branches (`version: jazzy`), not SHAs. The current
+`ci-local: pass` note format records `repo`/`commit`/`image`/`packages`/`scope`
+but nothing about resolved dependency state. An attestation built by cloning
+a floating upstream branch is not reproducible from the note alone — a repeat
+run on the same target-repo commit could silently build against a different
+`unh_marine_autonomy` state. ADR-0018 decision 1 treats a `scope: full`
+`ci-local: pass` record as sufficient standalone merge evidence; that
+guarantee weakens once "full" build state includes an unpinned external input
+the note doesn't capture. Recommend the plan record resolved upstream SHAs in
+the note (e.g. an `upstream:` field per repo/commit) so the attestation stays
+self-describing, and treat this as a note-format extension under ADR-0018
+rather than a silent behavior change to what "scope: full" already means to
+existing consumers (`merge_pr.sh` future wiring, human readers of
+`git notes --ref=ci-local show`).
+
+**Test coverage precedent exists.** `.agent/scripts/tests/test_ci_local.sh`
+already stubs `docker`/`vcs`-adjacent calls and drives the script through
+dry-run, package-discovery, and injection-safety cases. The upstream.repos
+path should get equivalent stub-based coverage (dry-run plan showing the
+upstream clone step; injection-safety on repo names/URLs/versions parsed from
+`upstream.repos`, mirroring the existing package-name validation) rather than
+being exempted as "only exercised against real cube_bathymetry."
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Workspace vs. project separation | OK | Fix belongs in `.agent/scripts/ci_local.sh` (workspace infra); mechanism (`vcs import` on a well-known filename) is generic, not cube-specific |
+| Enforcement over documentation | OK | Extends the existing enforced tool (ci_local.sh + attestation), not a docs-only fix |
+| A change includes its consequences | Action needed | ADR-0018's attestation note format (and its "scope: full" guarantee) needs an explicit extension for upstream dependency state — see Findings above |
+| Test what breaks | Action needed | New `upstream.repos` code path needs stub-based tests in `test_ci_local.sh` (dry-run + injection-safety), mirroring existing coverage patterns |
+| Only what's needed / Improve incrementally | Watch | Issue proposes two alternative implementation strategies (vcs-import vs. industrial_ci delegation) and leaves the full-scope/caching question open by design — plan-task should pick the minimal option (vcs-import, reusing the `ci_local_extra.sh` hook precedent for pruning) rather than replicating industrial_ci's env-var surface |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| 0003 — Project-agnostic workspace | Yes | Fix must stay generic (any repo with `upstream.repos`); option 2 (industrial_ci delegation) risks cube-specific logic leaking into workspace infra unless generalized |
+| 0018 — Local-first CI verification | Yes | This closes a real gap in ADR-0018's stated Phase-1 tool; attestation note format likely needs a documented extension (see Findings) — plan-task should decide whether that's a note change under this ADR or needs a superseding addendum |
+| 0009 — Python package management | Watch | `vcs import` may need `vcs`/`vcstool` available in the container image; confirm it's already present in the agent sandbox / rosdep-baked image rather than requiring an ad hoc pip install |
+
+### Consequences
+
+- ADR-0018 doc itself may need a Consequences-section note once the note format is extended (per Findings).
+- `AGENTS.md`'s `ci_local.sh` script-reference line (currently silent on upstream.repos) should be updated to mention the new capability once implemented.
+- `test_ci_local.sh` needs new cases (see Findings).
+
+### Actions
+- [ ] Decide implementation strategy: vcs-import (generic, reuses `ci_local_extra.sh`-style hook precedent) vs. delegating to per-repo industrial_ci config (risks project-specific logic in workspace infra) — recommend vcs-import as the minimal, ADR-0003-aligned choice.
+- [ ] Design how per-repo pruning (cube's `ROSDEP_SKIP_KEYS`/`AFTER_SETUP_UPSTREAM_WORKSPACE`-equivalent) is expressed generically, likely via an upstream-side hook analogous to `ci_local_extra.sh`.
+- [ ] Extend the `ci-local` git-note format to record resolved upstream dependency state (repo/commit per `upstream.repos` entry) so `scope: full` attestations stay self-describing per ADR-0018's merge-evidence guarantee.
+- [ ] Add stub-based tests to `test_ci_local.sh` for the new upstream.repos path (dry-run plan output, injection-safety on parsed repo name/URL/version fields).
+- [ ] Confirm `vcs`/`vcstool` availability in the agent sandbox / clean-room images (ADR-0009 dev-tool provisioning, not bare pip).
+- [ ] Update `AGENTS.md`'s ci_local.sh reference line once the capability lands.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -62,7 +62,9 @@ jobs:
           python-version: '3.10'
 
       - name: Install pytest
-        run: python3 -m pip install --upgrade pip pytest
+        # pyyaml: ci_local.sh's upstream.repos parser imports the yaml module
+        # (present on ROS dev hosts via rosdep/vcstool, absent in setup-python)
+        run: python3 -m pip install --upgrade pip pytest pyyaml
 
       # Runs .agent/scripts/tests/ (shell via bash, python via pytest). These are
       # hermetic (temp git sandboxes, stubbed gh, no network/ROS), so no build or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,7 +487,7 @@ include a guard that prints an error if accidentally sourced.
 | `.agent/scripts/stage_rosdep_manifests.sh` | Gather layer `package.xml` manifests (recursive) into the agent-image build context for the rosdep bake (#520); shared by `docker_run_agent.sh --build` and `make agent-build` |
 | `.agent/scripts/dashboard.sh` | Unified workspace status (supports `--quick`) |
 | `.agent/scripts/build.sh` | Build all layers in order |
-| `.agent/scripts/ci_local.sh` | Containerized local CI for a project repo with git-note attestation (`refs/notes/ci-local`); full-scope pass = accepted merge verification (ADR-0018). `--clean-room` mirrors hosted CI exactly; `-n` dry-run |
+| `.agent/scripts/ci_local.sh` | Containerized local CI for a project repo with git-note attestation (`refs/notes/ci-local`); full-scope pass = accepted merge verification (ADR-0018). Builds `upstream.repos` source deps as an underlay with host-resolved SHAs recorded as `upstream-repo:` note lines (#577; per-repo pruning via `.agents/ci_local_upstream_extra.sh` + `.agents/ci_local_rosdep_skip_keys.txt`). `--clean-room` mirrors hosted CI exactly (preferred for `upstream.repos` repos); `-n` dry-run |
 | `.agent/scripts/check_branch_updates.sh` | Check if branch is behind default |
 | `.agent/scripts/gh_create_issue.sh` | Create issue with label validation (`GITBUG_CREATE=1` for offline) |
 | `.agent/scripts/git_bug_setup.sh` | Configure git-bug identity + GitHub bridge |

--- a/docs/decisions/0018-local-first-ci-verification.md
+++ b/docs/decisions/0018-local-first-ci-verification.md
@@ -104,7 +104,10 @@ zero; it is environment diversity.
 - **Repos with `upstream.repos` source dependencies (#577)**: `ci_local.sh`
   builds the upstream sources as an underlay (entries parsed, validated, and
   resolved to commit SHAs host-side before the container runs) and records one
-  `upstream-repo: <dir>@<sha>` line per entry in the note. For such repos a
+  `upstream-repo: <dir>@<sha>` line per entry in the note; rosdep keys skipped
+  via `.agents/ci_local_rosdep_skip_keys.txt` are likewise recorded
+  (`rosdep-skip-keys:` line) so the note shows deps the verified environment
+  deliberately did not install. For such repos a
   note lacking `upstream-repo:` lines that resolve every `upstream.repos`
   entry is **not valid merge evidence**, even if it says `ci-local: pass` /
   `scope: full` — the upstream state that was built would be unrecorded. This

--- a/docs/decisions/0018-local-first-ci-verification.md
+++ b/docs/decisions/0018-local-first-ci-verification.md
@@ -101,6 +101,19 @@ zero; it is environment diversity.
 - `merge_pr.sh` does not yet check for the attestation before merging;
   wiring that check in (warn or refuse when the head lacks a full-scope
   record) is a natural hardening follow-up under #572.
+- **Repos with `upstream.repos` source dependencies (#577)**: `ci_local.sh`
+  builds the upstream sources as an underlay (entries parsed, validated, and
+  resolved to commit SHAs host-side before the container runs) and records one
+  `upstream-repo: <dir>@<sha>` line per entry in the note. For such repos a
+  note lacking `upstream-repo:` lines that resolve every `upstream.repos`
+  entry is **not valid merge evidence**, even if it says `ci-local: pass` /
+  `scope: full` — the upstream state that was built would be unrecorded. This
+  is a format extension only: notes on repos without `upstream.repos` are
+  byte-identical to before and their meaning is unchanged. Since upstream
+  clones need network anyway, `--clean-room` is the natural mode for these
+  repos — it replicates hosted CI exactly and avoids relying on the agent
+  image having the upstream sources' rosdep deps baked (the #520 bake covers
+  layer manifests, not upstream workspaces).
 - The hosted-CI speed fix (prebuilt/GHCR image, cube-style) remains worth
   doing independently — a faster, less fragile mirror is a better mirror.
 


### PR DESCRIPTION
Closes #577

## What

`ci_local.sh` now supports project repos that declare `upstream.repos` source dependencies (vcstool format, as consumed by hosted industrial_ci's `UPSTREAM_WORKSPACE`) — previously such repos (e.g. cube_bathymetry) failed rosdep resolution in seconds because their source deps were never brought into the workspace.

## How

- **Host-side parse + validation** of `upstream.repos` (python3+yaml, strict charset regexes on dir/url/version; requires `type: git` and an explicit `version`). For attestable runs the file is read from pristine HEAD content (`git show`), not the live tree.
- **Host-side ref→SHA resolution** (`git ls-remote`) *before* the container runs: the note records SHAs the host chose and the container was told to check out — no container output is trusted for attestation content, all mounts stay read-only, and unresolvable upstream state fails closed pre-container. Resolved SHAs are re-validated against `^[0-9a-f]{40}$`, and annotated tags resolve to the peeled commit (`refs/tags/<v>^{}`), never the tag object.
- **Container side**: generated `git clone` + `checkout --detach <sha>` per entry (no vcstool anywhere), built as a **separate underlay** (`upstream_ws`) sourced before the target build; target build/test pinned with `--base-paths src`.
- **Per-repo hooks** generalizing industrial_ci's pruning mechanisms: `.agents/ci_local_upstream_extra.sh` (`AFTER_SETUP_UPSTREAM_WORKSPACE` analog) and `.agents/ci_local_rosdep_skip_keys.txt` (`ROSDEP_SKIP_KEYS` analog — applies to the single combined rosdep install whether or not upstream.repos is present).
- **Attestation note extension** (ADR-0018 Consequences updated): one `upstream-repo: <dir>@<sha>` line per entry plus a `rosdep-skip-keys:` line and steps tokens when applicable. For upstream.repos repos a note lacking these lines is not valid merge evidence. Notes on repos without these files are **byte-identical** to before (regression-tested).

## Testing

- `.agent/scripts/tests/test_ci_local.sh`: **81/81** (34 new for this feature), hermetic — local fixture upstream repo exercises real `ls-remote` resolution with no network or docker: dry-run planning, resolved-SHA + skip-keys note content, annotated-tag peeling, five injection/validation rejections (all pre-container), unresolvable-ref hard failure, byte-compat regression.
- cube_bathymetry end-to-end verified in dry-run mode; a real run needs cube to adopt the two hook files (follow-up issue after merge).

## Review

Pre-push `/review-code` (fresh-context sub-agent): **approved, round 1, 0 must-fix**; all 3 optional suggestions applied in `2c7d53b`.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
