### PR TITLE
Field import: ros2_agent_workspace (2026-07-23)

### DIFF
--- a/.agent/scripts/lib/remote_utils.py
+++ b/.agent/scripts/lib/remote_utils.py
@@ -6,8 +6,40 @@ Used by add_remote.py, push_remote.py, and pull_remote.py.
 
 import subprocess
 import sys
+import time
 
 from workspace import get_overlay_repos
+
+# Error fragments that indicate the remote dropped the connection (typically
+# an upstream firewall rate-limiting rapid successive SSH connections).
+TRANSIENT_ERRORS = (
+    "kex_exchange_identification",
+    "Connection reset",
+    "Connection closed by remote host",
+    "Connection timed out",
+)
+
+RETRY_BACKOFF = 15  # seconds to wait before retrying a dropped connection
+
+
+def is_transient_error(error_text):
+    """True if the git error text matches a dropped-connection signature."""
+    return any(err in error_text for err in TRANSIENT_ERRORS)
+
+
+def retry_transient(run_fn, *fn_args):
+    """Call run_fn(*fn_args) -> (success, ..., error_text) and retry once
+    after a backoff if the failure looks like a dropped connection.
+
+    Works for any runner whose result tuple starts with a success flag and
+    ends with the error text (run_git's 3-tuple, sync_repos' 2-tuple).
+    """
+    result = run_fn(*fn_args)
+    if not result[0] and is_transient_error(result[-1]):
+        print(f"     ⚠️  Connection dropped; retrying in {RETRY_BACKOFF}s...")
+        time.sleep(RETRY_BACKOFF)
+        result = run_fn(*fn_args)
+    return result
 
 
 def run_git(repo_path, args, dry_run=False):
@@ -21,6 +53,12 @@ def run_git(repo_path, args, dry_run=False):
         return True, result.stdout.strip(), result.stderr.strip()
     except subprocess.CalledProcessError as e:
         return False, e.stdout.strip(), e.stderr.strip()
+
+
+def run_git_network(repo_path, args, dry_run=False):
+    """run_git for network operations (push/pull/fetch): retries once after a
+    backoff when the connection was dropped (rate-limit style failures)."""
+    return retry_transient(run_git, repo_path, args, dry_run)
 
 
 def remote_exists(repo_path, remote_name):

--- a/.agent/scripts/pull_remote.py
+++ b/.agent/scripts/pull_remote.py
@@ -31,6 +31,7 @@ from remote_utils import (  # noqa: E402
     remote_exists,
     resolve_repo_path,
     run_git,
+    run_git_network,
     run_script,
 )
 
@@ -95,7 +96,7 @@ def _compare_branches(repo_path, branch, remote_ref):
 
 def _fetch_and_report(repo_path, remote_name, version, dry_run):
     """Fetch from remote and report new commits. Returns (status, message)."""
-    success, _, err = run_git(repo_path, ["fetch", remote_name], dry_run)
+    success, _, err = run_git_network(repo_path, ["fetch", remote_name], dry_run)
     if not success:
         return "error", f"fetch failed: {err}"
     if dry_run:
@@ -127,7 +128,7 @@ def _fetch_and_pull(repo_path, remote_name, version, dry_run):
         return "skip", skip_reason
 
     # Fetch
-    success, _, err = run_git(repo_path, ["fetch", remote_name], dry_run)
+    success, _, err = run_git_network(repo_path, ["fetch", remote_name], dry_run)
     if not success:
         return "error", f"fetch failed: {err}"
 
@@ -156,7 +157,7 @@ def _fetch_into_branch(repo_path, remote_name, version, target_branch, dry_run):
     branch = get_default_branch(repo_path, version)
 
     # Fetch
-    success, _, err = run_git(repo_path, ["fetch", remote_name], dry_run)
+    success, _, err = run_git_network(repo_path, ["fetch", remote_name], dry_run)
     if not success:
         return "error", f"fetch failed: {err}"
 
@@ -269,7 +270,7 @@ def main():
         errors = []
 
         # Workspace repo
-        success, _, err = run_git(root_dir, ["fetch", args.remote], args.dry_run)
+        success, _, err = run_git_network(root_dir, ["fetch", args.remote], args.dry_run)
         if not success:
             errors.append(f"ros2_agent_workspace: fetch failed: {err}")
         else:
@@ -284,7 +285,7 @@ def main():
                 continue
             if not remote_exists(repo_path, args.remote):
                 continue
-            success, _, err = run_git(repo_path, ["fetch", args.remote], args.dry_run)
+            success, _, err = run_git_network(repo_path, ["fetch", args.remote], args.dry_run)
             if not success:
                 errors.append(f"{repo['name']}: fetch failed: {err}")
                 continue

--- a/.agent/scripts/push_remote.py
+++ b/.agent/scripts/push_remote.py
@@ -34,6 +34,7 @@ from remote_utils import (
     get_default_branch,
     remote_exists,
     run_git,
+    run_git_network,
     run_script,
 )
 
@@ -129,7 +130,7 @@ def process_repo(repo_path, repo_name, version, args):
     branch = get_default_branch(repo_path, version)
 
     if args.all_branches:
-        success, _, err = run_git(repo_path, ["push", args.remote, "--all"], args.dry_run)
+        success, _, err = run_git_network(repo_path, ["push", args.remote, "--all"], args.dry_run)
         if not success:
             errors.append(f"push --all failed: {err}")
     else:
@@ -140,12 +141,12 @@ def process_repo(repo_path, repo_name, version, args):
             refspec = branch
         else:
             refspec = f"origin/{branch}:{branch}"
-        success, _, err = run_git(repo_path, ["push", args.remote, refspec], args.dry_run)
+        success, _, err = run_git_network(repo_path, ["push", args.remote, refspec], args.dry_run)
         if not success:
             errors.append(f"push {branch} failed: {err}")
 
     # Always push tags
-    success, _, err = run_git(repo_path, ["push", args.remote, "--tags"], args.dry_run)
+    success, _, err = run_git_network(repo_path, ["push", args.remote, "--tags"], args.dry_run)
     if not success:
         errors.append(f"push --tags failed: {err}")
 

--- a/.agent/scripts/sync_repos.py
+++ b/.agent/scripts/sync_repos.py
@@ -26,12 +26,15 @@ from pathlib import Path
 # Add script directory to path to import list_overlay_repos
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.append(str(SCRIPT_DIR))
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 try:
     import list_overlay_repos
 except ImportError:
     print(f"Error: Could not import list_overlay_repos from {SCRIPT_DIR}", file=sys.stderr)
     sys.exit(1)
+
+from remote_utils import retry_transient  # noqa: E402
 
 
 def run_git_cmd(repo_path, cmd_args, dry_run=False):
@@ -50,27 +53,11 @@ def run_git_cmd(repo_path, cmd_args, dry_run=False):
         return False, e.stderr.strip()
 
 
-# Error fragments that indicate the remote dropped the connection (typically
-# an upstream firewall rate-limiting rapid successive SSH connections).
-TRANSIENT_ERRORS = (
-    "kex_exchange_identification",
-    "Connection reset",
-    "Connection closed by remote host",
-    "Connection timed out",
-)
-
-RETRY_BACKOFF = 15  # seconds to wait before retrying a dropped connection
-
-
 def run_network_cmd(repo_path, cmd_args, dry_run=False):
     """Run a git network command, retrying once after a backoff if the
-    connection was dropped (rate-limit style failures)."""
-    success, output = run_git_cmd(repo_path, cmd_args, dry_run)
-    if not success and any(err in output for err in TRANSIENT_ERRORS):
-        print(f"     ⚠️  Connection dropped; retrying in {RETRY_BACKOFF}s...")
-        time.sleep(RETRY_BACKOFF)
-        success, output = run_git_cmd(repo_path, cmd_args, dry_run)
-    return success, output
+    connection was dropped (rate-limit style failures — signatures and
+    backoff live in lib/remote_utils.py, shared with push/pull_remote)."""
+    return retry_transient(run_git_cmd, repo_path, cmd_args, dry_run)
 
 
 def is_dirty(repo_path, dry_run=False):
@@ -175,13 +162,13 @@ def sync_gitbug(repo_path, dry_run=False):
         return
 
     print(f"  Syncing git-bug issues for {repo_name}...")
-    for cmd in [["git", "bug", "pull"], ["git", "bug", "push"]]:
-        result = subprocess.run(
-            cmd, cwd=str(repo_path), capture_output=True, text=True, check=False
-        )
-        if result.returncode != 0:
-            stderr = result.stderr.strip()
-            print(f"     ⚠️  {' '.join(cmd)} failed: {stderr}")
+    # git-bug pull/push are network operations against the same remote —
+    # route them through the retry wrapper so a rate-limited SSH connection
+    # gets the same second chance as the plain git pulls.
+    for cmd_args in (["bug", "pull"], ["bug", "push"]):
+        success, output = run_network_cmd(repo_path, cmd_args)
+        if not success:
+            print(f"     ⚠️  git {' '.join(cmd_args)} failed: {output}")
             return
     print("     ✅ git-bug synced.")
 

--- a/.agent/scripts/sync_repos.py
+++ b/.agent/scripts/sync_repos.py
@@ -7,13 +7,17 @@ default branches (main/jazzy) and fetching on feature branches. It respects
 dirty working directories and detached HEAD states.
 
 Usage:
-    python3 sync_repos.py [--dry-run]
+    python3 sync_repos.py [--dry-run] [--throttle SECONDS]
 
 Options:
     --dry-run    Simulate actions without executing
+    --throttle   Pause between per-repo network operations (default: 2.0s).
+                 Upstream firewalls rate-limit rapid successive SSH
+                 connections; pacing the pulls avoids tripping them.
 """
 
 import sys
+import time
 import shutil
 import subprocess
 import argparse
@@ -44,6 +48,29 @@ def run_git_cmd(repo_path, cmd_args, dry_run=False):
         return True, result.stdout.strip()
     except subprocess.CalledProcessError as e:
         return False, e.stderr.strip()
+
+
+# Error fragments that indicate the remote dropped the connection (typically
+# an upstream firewall rate-limiting rapid successive SSH connections).
+TRANSIENT_ERRORS = (
+    "kex_exchange_identification",
+    "Connection reset",
+    "Connection closed by remote host",
+    "Connection timed out",
+)
+
+RETRY_BACKOFF = 15  # seconds to wait before retrying a dropped connection
+
+
+def run_network_cmd(repo_path, cmd_args, dry_run=False):
+    """Run a git network command, retrying once after a backoff if the
+    connection was dropped (rate-limit style failures)."""
+    success, output = run_git_cmd(repo_path, cmd_args, dry_run)
+    if not success and any(err in output for err in TRANSIENT_ERRORS):
+        print(f"     ⚠️  Connection dropped; retrying in {RETRY_BACKOFF}s...")
+        time.sleep(RETRY_BACKOFF)
+        success, output = run_git_cmd(repo_path, cmd_args, dry_run)
+    return success, output
 
 
 def is_dirty(repo_path, dry_run=False):
@@ -87,7 +114,7 @@ def sync_repo(repo_path, repo_name, dry_run=False):
     # 2. Sync Logic
     if branch in ["main", "jazzy", "rolling"]:
         print(f"  On default branch '{branch}'. Pulling updates...")
-        success, output = run_git_cmd(repo_path, ["pull", "--rebase"], dry_run)
+        success, output = run_network_cmd(repo_path, ["pull", "--rebase"], dry_run)
         if success:
             if dry_run:
                 print("     (Dry run successful)")
@@ -100,7 +127,7 @@ def sync_repo(repo_path, repo_name, dry_run=False):
 
     else:
         print(f"  On feature branch '{branch}'. Fetching only...")
-        success, output = run_git_cmd(repo_path, ["fetch"], dry_run)
+        success, output = run_network_cmd(repo_path, ["fetch"], dry_run)
 
         if success:
             if dry_run:
@@ -164,6 +191,12 @@ def main():
     parser.add_argument(
         "--dry-run", action="store_true", help="Simulate actions without executing."
     )
+    parser.add_argument(
+        "--throttle",
+        type=float,
+        default=2.0,
+        help="Seconds to pause between per-repo network operations (default: 2.0).",
+    )
     args = parser.parse_args()
 
     root_dir = SCRIPT_DIR.parent.parent
@@ -171,11 +204,16 @@ def main():
     # Get repos list using the existing tool
     repos = list_overlay_repos.get_overlay_repos(include_underlay=False)
 
+    def throttle():
+        if not args.dry_run and args.throttle > 0:
+            time.sleep(args.throttle)
+
     # Also include the root repo itself
     if sync_repo(root_dir, "ros2_agent_workspace", args.dry_run):
         sync_gitbug(root_dir, args.dry_run)
 
     for repo in repos:
+        throttle()
         # Determine workspace directory from source file (e.g. core.repos -> core_ws)
         ws_name = repo["source_file"].replace(".repos", "_ws")
         candidate_path = root_dir / "layers" / "main" / ws_name / "src" / repo["name"]

--- a/.agent/scripts/tests/test_net_retry.py
+++ b/.agent/scripts/tests/test_net_retry.py
@@ -1,0 +1,158 @@
+"""Tests for the transient-network retry logic (issue #579 field import).
+
+Covers lib/remote_utils.py (TRANSIENT_ERRORS, retry_transient, run_git_network)
+and sync_repos.py's delegation (run_network_cmd, sync_gitbug routing). All
+subprocess/network activity is stubbed; time.sleep is patched out.
+"""
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import remote_utils  # noqa: E402
+import sync_repos  # noqa: E402
+
+
+def make_run_stub(results):
+    """Callable standing in for run_git / run_git_cmd; returns queued results
+    and records every call on the returned function's .calls attribute."""
+    queue = list(results)
+    calls = []
+
+    def stub(*args):
+        calls.append(args)
+        return queue.pop(0)
+
+    stub.calls = calls
+    return stub
+
+
+class TestIsTransientError:
+    def test_matches_every_signature(self):
+        for fragment in remote_utils.TRANSIENT_ERRORS:
+            assert remote_utils.is_transient_error(f"blah: {fragment}: blah")
+
+    def test_rejects_ordinary_errors(self):
+        assert not remote_utils.is_transient_error("fatal: not a git repository")
+        assert not remote_utils.is_transient_error("")
+
+
+class TestRetryTransient:
+    def test_success_first_try_no_retry(self, monkeypatch):
+        sleeps = []
+        monkeypatch.setattr(remote_utils.time, "sleep", sleeps.append)
+        stub = make_run_stub([(True, "ok")])
+        assert remote_utils.retry_transient(stub, "arg") == (True, "ok")
+        assert len(stub.calls) == 1
+        assert not sleeps
+
+    def test_transient_failure_retries_once_after_backoff(self, monkeypatch):
+        sleeps = []
+        monkeypatch.setattr(remote_utils.time, "sleep", sleeps.append)
+        stub = make_run_stub(
+            [
+                (False, "kex_exchange_identification: read: Connection reset by peer"),
+                (True, "recovered"),
+            ]
+        )
+        assert remote_utils.retry_transient(stub, "arg") == (True, "recovered")
+        assert len(stub.calls) == 2
+        assert stub.calls[0] == stub.calls[1] == ("arg",)
+        assert sleeps == [remote_utils.RETRY_BACKOFF]
+
+    def test_transient_failure_retries_only_once(self, monkeypatch):
+        monkeypatch.setattr(remote_utils.time, "sleep", lambda _s: None)
+        drop = (False, "Connection closed by remote host")
+        stub = make_run_stub([drop, drop])
+        assert remote_utils.retry_transient(stub, "arg") == drop
+        assert len(stub.calls) == 2
+
+    def test_non_transient_failure_no_retry(self, monkeypatch):
+        sleeps = []
+        monkeypatch.setattr(remote_utils.time, "sleep", sleeps.append)
+        stub = make_run_stub([(False, "fatal: repository not found")])
+        success, output = remote_utils.retry_transient(stub, "arg")
+        assert not success and output == "fatal: repository not found"
+        assert len(stub.calls) == 1
+        assert not sleeps
+
+    def test_three_tuple_runner_uses_stderr(self, monkeypatch):
+        """run_git returns (success, stdout, stderr) — the LAST element is the
+        error text the transient check must read."""
+        monkeypatch.setattr(remote_utils.time, "sleep", lambda _s: None)
+        stub = make_run_stub(
+            [
+                (False, "some stdout", "ssh: Connection timed out"),
+                (True, "out", ""),
+            ]
+        )
+        assert remote_utils.retry_transient(stub, "repo", ["fetch"]) == (True, "out", "")
+        assert len(stub.calls) == 2
+
+
+def test_run_git_network_delegates_to_run_git_with_retry(monkeypatch):
+    monkeypatch.setattr(remote_utils.time, "sleep", lambda _s: None)
+    stub = make_run_stub(
+        [
+            (False, "", "kex_exchange_identification: Connection reset"),
+            (True, "fetched", ""),
+        ]
+    )
+    monkeypatch.setattr(remote_utils, "run_git", stub)
+    result = remote_utils.run_git_network("repo", ["fetch", "gitcloud"], False)
+    assert result == (True, "fetched", "")
+    assert stub.calls == [("repo", ["fetch", "gitcloud"], False)] * 2
+
+
+class TestSyncReposDelegation:
+    def test_run_network_cmd_retries_via_shared_helper(self, monkeypatch):
+        monkeypatch.setattr(remote_utils.time, "sleep", lambda _s: None)
+        stub = make_run_stub(
+            [
+                (False, "Connection reset by peer"),
+                (True, "Already up to date."),
+            ]
+        )
+        monkeypatch.setattr(sync_repos, "run_git_cmd", stub)
+        success, output = sync_repos.run_network_cmd("repo", ["pull", "--rebase"])
+        assert success and output == "Already up to date."
+        assert len(stub.calls) == 2
+
+    def test_sync_gitbug_routes_through_retry_wrapper(self, monkeypatch, tmp_path):
+        """git-bug pull/push must go through run_network_cmd (issue #579
+        pre-review finding: they previously bypassed the retry path)."""
+        monkeypatch.setattr(sync_repos.shutil, "which", lambda _cmd: "/usr/bin/git-bug")
+        monkeypatch.setattr(
+            sync_repos.subprocess,
+            "run",
+            lambda *a, **k: type("R", (), {"returncode": 0, "stdout": "bridge", "stderr": ""})(),
+        )
+        network_calls = []
+
+        def fake_network_cmd(repo_path, cmd_args, dry_run=False):
+            network_calls.append(cmd_args)
+            return True, ""
+
+        monkeypatch.setattr(sync_repos, "run_network_cmd", fake_network_cmd)
+        sync_repos.sync_gitbug(tmp_path)
+        assert network_calls == [["bug", "pull"], ["bug", "push"]]
+
+    def test_sync_gitbug_stops_after_failed_pull(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sync_repos.shutil, "which", lambda _cmd: "/usr/bin/git-bug")
+        monkeypatch.setattr(
+            sync_repos.subprocess,
+            "run",
+            lambda *a, **k: type("R", (), {"returncode": 0, "stdout": "bridge", "stderr": ""})(),
+        )
+        network_calls = []
+
+        def fake_network_cmd(repo_path, cmd_args, dry_run=False):
+            network_calls.append(cmd_args)
+            return False, "permission denied"
+
+        monkeypatch.setattr(sync_repos, "run_network_cmd", fake_network_cmd)
+        sync_repos.sync_gitbug(tmp_path)
+        assert network_calls == [["bug", "pull"]]


### PR DESCRIPTION
Closes #579

Imports one field commit from `gitcloud` (preserved SHA, branched from `gitcloud/main` — not cherry-picked):

- `0839692` fix(sync): throttle per-repo pulls and retry dropped SSH connections

`sync_repos.py` gains `run_network_cmd()` (single retry after 15 s backoff on connection-drop error signatures) and `--throttle` (default 2.0 s between per-repo network operations), fixing the `kex_exchange_identification: read: Connection reset by peer` cascade that an upstream firewall's SSH rate limit inflicts on rapid `make sync` runs. Independently reproduced on the dev workstation today.

**Divergence note**: branch is 20 behind local `main` (today's #577/#578 work); `sync_repos.py` is untouched by those commits, so this merges cleanly. Gitcloud resync via `push_remote.py` after merge.

Pre-review findings (advisory, in #579): no test for the retry/throttle logic; `sync_gitbug` + `push_remote.py`/`pull_remote.py` still bypass the retry path.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
