### PR TITLE
fix: make sync throttle off by default, adaptive on dropped connections

### DIFF
--- a/.agent/scripts/lib/remote_utils.py
+++ b/.agent/scripts/lib/remote_utils.py
@@ -21,10 +21,25 @@ TRANSIENT_ERRORS = (
 
 RETRY_BACKOFF = 15  # seconds to wait before retrying a dropped connection
 
+# Set once any network operation in this process hits a dropped-connection
+# signature. Callers use this to enable pacing only when the remote is
+# actually rate-limiting (see sync_repos.py's adaptive throttle).
+_TRANSIENT_STATE = {"seen": False}
+
 
 def is_transient_error(error_text):
     """True if the git error text matches a dropped-connection signature."""
     return any(err in error_text for err in TRANSIENT_ERRORS)
+
+
+def transient_error_seen():
+    """True if any retry_transient call in this process saw a dropped connection."""
+    return _TRANSIENT_STATE["seen"]
+
+
+def reset_transient_error_seen():
+    """Clear the dropped-connection flag (test isolation / long-lived callers)."""
+    _TRANSIENT_STATE["seen"] = False
 
 
 def retry_transient(run_fn, *fn_args):
@@ -36,6 +51,7 @@ def retry_transient(run_fn, *fn_args):
     """
     result = run_fn(*fn_args)
     if not result[0] and is_transient_error(result[-1]):
+        _TRANSIENT_STATE["seen"] = True
         print(f"     ⚠️  Connection dropped; retrying in {RETRY_BACKOFF}s...")
         time.sleep(RETRY_BACKOFF)
         result = run_fn(*fn_args)

--- a/.agent/scripts/sync_repos.py
+++ b/.agent/scripts/sync_repos.py
@@ -11,9 +11,12 @@ Usage:
 
 Options:
     --dry-run    Simulate actions without executing
-    --throttle   Pause between per-repo network operations (default: 2.0s).
-                 Upstream firewalls rate-limit rapid successive SSH
-                 connections; pacing the pulls avoids tripping them.
+    --throttle   Pause between per-repo network operations. Off by default;
+                 if a dropped connection is detected mid-run (an upstream
+                 firewall rate-limiting rapid successive SSH connections),
+                 the remaining repos are automatically paced at 2.0s.
+                 Pass a value to force a fixed pace from the start
+                 (0 disables pacing entirely, including the adaptive one).
 """
 
 import sys
@@ -34,7 +37,41 @@ except ImportError:
     print(f"Error: Could not import list_overlay_repos from {SCRIPT_DIR}", file=sys.stderr)
     sys.exit(1)
 
-from remote_utils import retry_transient  # noqa: E402
+from remote_utils import retry_transient, transient_error_seen  # noqa: E402
+
+# Pace applied to the rest of the run once the remote starts dropping
+# connections (only when --throttle was not given explicitly).
+ADAPTIVE_THROTTLE = 2.0
+
+
+def make_throttler(explicit_throttle, dry_run):
+    """Return a pause() callable implementing the pacing policy.
+
+    explicit_throttle is the --throttle value or None if not given:
+      None -> adaptive: no pause until a dropped connection has been seen,
+              then ADAPTIVE_THROTTLE for the rest of the run.
+      N    -> fixed pace of N seconds (0 disables pacing entirely).
+    Dry runs never pause.
+    """
+    noticed = [False]
+
+    def pause():
+        if dry_run:
+            return
+        if explicit_throttle is not None:
+            if explicit_throttle > 0:
+                time.sleep(explicit_throttle)
+            return
+        if transient_error_seen():
+            if not noticed[0]:
+                noticed[0] = True
+                print(
+                    f"ℹ️  Remote dropped a connection — pacing remaining repos "
+                    f"by {ADAPTIVE_THROTTLE}s."
+                )
+            time.sleep(ADAPTIVE_THROTTLE)
+
+    return pause
 
 
 def run_git_cmd(repo_path, cmd_args, dry_run=False):
@@ -181,8 +218,11 @@ def main():
     parser.add_argument(
         "--throttle",
         type=float,
-        default=2.0,
-        help="Seconds to pause between per-repo network operations (default: 2.0).",
+        default=None,
+        help=f"Seconds to pause between per-repo network operations. "
+        f"Default: none, auto-enabling a {ADAPTIVE_THROTTLE}s pace for the rest "
+        f"of the run if the remote drops a connection. "
+        f"Pass 0 to disable pacing entirely.",
     )
     args = parser.parse_args()
 
@@ -191,9 +231,7 @@ def main():
     # Get repos list using the existing tool
     repos = list_overlay_repos.get_overlay_repos(include_underlay=False)
 
-    def throttle():
-        if not args.dry_run and args.throttle > 0:
-            time.sleep(args.throttle)
+    throttle = make_throttler(args.throttle, args.dry_run)
 
     # Also include the root repo itself
     if sync_repo(root_dir, "ros2_agent_workspace", args.dry_run):

--- a/.agent/scripts/sync_repos.py
+++ b/.agent/scripts/sync_repos.py
@@ -37,7 +37,11 @@ except ImportError:
     print(f"Error: Could not import list_overlay_repos from {SCRIPT_DIR}", file=sys.stderr)
     sys.exit(1)
 
-from remote_utils import retry_transient, transient_error_seen  # noqa: E402
+from remote_utils import (  # noqa: E402
+    reset_transient_error_seen,
+    retry_transient,
+    transient_error_seen,
+)
 
 # Pace applied to the rest of the run once the remote starts dropping
 # connections (only when --throttle was not given explicitly).
@@ -225,6 +229,12 @@ def main():
         f"Pass 0 to disable pacing entirely.",
     )
     args = parser.parse_args()
+    if args.throttle is not None and args.throttle < 0:
+        parser.error("--throttle must be >= 0")
+
+    # Each run adapts from a clean slate — matters only for in-process
+    # callers, but makes the fresh-process assumption explicit.
+    reset_transient_error_seen()
 
     root_dir = SCRIPT_DIR.parent.parent
 

--- a/.agent/scripts/tests/test_net_retry.py
+++ b/.agent/scripts/tests/test_net_retry.py
@@ -233,6 +233,14 @@ class TestMakeThrottler:
         pause()
         assert not sleeps
 
+    def test_negative_throttle_rejected(self, monkeypatch, capsys):
+        """A fat-fingered negative would otherwise silently disable even the
+        adaptive safety net — argparse must reject it."""
+        monkeypatch.setattr(sys, "argv", ["sync_repos.py", "--throttle", "-5"])
+        with pytest.raises(SystemExit):
+            sync_repos.main()
+        assert "--throttle must be >= 0" in capsys.readouterr().err
+
     def test_dry_run_never_pauses(self, monkeypatch):
         trip_transient_flag(monkeypatch)
         sleeps = self._sleeps(monkeypatch)

--- a/.agent/scripts/tests/test_net_retry.py
+++ b/.agent/scripts/tests/test_net_retry.py
@@ -12,8 +12,27 @@ SCRIPTS_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
 
+import pytest  # noqa: E402
+
 import remote_utils  # noqa: E402
 import sync_repos  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def reset_transient_seen():
+    """Isolate the module-level dropped-connection flag between tests."""
+    remote_utils.reset_transient_error_seen()
+    yield
+    remote_utils.reset_transient_error_seen()
+
+
+def trip_transient_flag(monkeypatch):
+    """Set the dropped-connection flag the way production code does: by
+    running a network op through retry_transient that hits a drop."""
+    monkeypatch.setattr(remote_utils.time, "sleep", lambda _s: None)
+    drop = (False, "Connection reset by peer")
+    remote_utils.retry_transient(make_run_stub([drop, drop]), "arg")
+    assert remote_utils.transient_error_seen()
 
 
 def make_run_stub(results):
@@ -78,6 +97,21 @@ class TestRetryTransient:
         assert not success and output == "fatal: repository not found"
         assert len(stub.calls) == 1
         assert not sleeps
+
+    def test_transient_failure_sets_seen_flag(self, monkeypatch):
+        monkeypatch.setattr(remote_utils.time, "sleep", lambda _s: None)
+        assert not remote_utils.transient_error_seen()
+        stub = make_run_stub([(False, "Connection reset by peer"), (True, "recovered")])
+        remote_utils.retry_transient(stub, "arg")
+        # Flag stays set even though the retry recovered — the remote IS
+        # rate-limiting, so subsequent operations should be paced.
+        assert remote_utils.transient_error_seen()
+
+    def test_success_and_ordinary_failure_leave_flag_clear(self, monkeypatch):
+        monkeypatch.setattr(remote_utils.time, "sleep", lambda _s: None)
+        remote_utils.retry_transient(make_run_stub([(True, "ok")]), "arg")
+        remote_utils.retry_transient(make_run_stub([(False, "fatal: repository not found")]), "arg")
+        assert not remote_utils.transient_error_seen()
 
     def test_three_tuple_runner_uses_stderr(self, monkeypatch):
         """run_git returns (success, stdout, stderr) — the LAST element is the
@@ -156,3 +190,51 @@ class TestSyncReposDelegation:
         monkeypatch.setattr(sync_repos, "run_network_cmd", fake_network_cmd)
         sync_repos.sync_gitbug(tmp_path)
         assert network_calls == [["bug", "pull"]]
+
+
+class TestMakeThrottler:
+    """Pacing policy (issue #582): off by default, adaptive after a dropped
+    connection, fixed when --throttle is given explicitly."""
+
+    def _sleeps(self, monkeypatch):
+        sleeps = []
+        monkeypatch.setattr(sync_repos.time, "sleep", sleeps.append)
+        return sleeps
+
+    def test_default_no_pause_without_transient_error(self, monkeypatch):
+        sleeps = self._sleeps(monkeypatch)
+        pause = sync_repos.make_throttler(None, dry_run=False)
+        pause()
+        pause()
+        assert not sleeps
+
+    def test_default_paces_after_transient_error(self, monkeypatch):
+        sleeps = self._sleeps(monkeypatch)
+        pause = sync_repos.make_throttler(None, dry_run=False)
+        pause()
+        trip_transient_flag(monkeypatch)
+        pause()
+        pause()
+        assert sleeps == [sync_repos.ADAPTIVE_THROTTLE] * 2
+
+    def test_explicit_throttle_paces_from_the_start(self, monkeypatch):
+        sleeps = self._sleeps(monkeypatch)
+        pause = sync_repos.make_throttler(5.0, dry_run=False)
+        pause()
+        pause()
+        assert sleeps == [5.0, 5.0]
+
+    def test_explicit_zero_disables_pacing_even_after_transient(self, monkeypatch):
+        sleeps = self._sleeps(monkeypatch)
+        trip_transient_flag(monkeypatch)
+        pause = sync_repos.make_throttler(0.0, dry_run=False)
+        pause()
+        assert not sleeps
+
+    def test_dry_run_never_pauses(self, monkeypatch):
+        sleeps = self._sleeps(monkeypatch)
+        trip_transient_flag(monkeypatch)
+        for explicit in (None, 5.0):
+            pause = sync_repos.make_throttler(explicit, dry_run=True)
+            pause()
+        assert not sleeps

--- a/.agent/scripts/tests/test_net_retry.py
+++ b/.agent/scripts/tests/test_net_retry.py
@@ -197,6 +197,9 @@ class TestMakeThrottler:
     connection, fixed when --throttle is given explicitly."""
 
     def _sleeps(self, monkeypatch):
+        """Record throttle pauses. Must be installed AFTER trip_transient_flag —
+        sync_repos.time and remote_utils.time are the same module, so the trip
+        helper's sleep patch would otherwise replace the recorder."""
         sleeps = []
         monkeypatch.setattr(sync_repos.time, "sleep", sleeps.append)
         return sleeps
@@ -209,10 +212,9 @@ class TestMakeThrottler:
         assert not sleeps
 
     def test_default_paces_after_transient_error(self, monkeypatch):
-        sleeps = self._sleeps(monkeypatch)
         pause = sync_repos.make_throttler(None, dry_run=False)
-        pause()
         trip_transient_flag(monkeypatch)
+        sleeps = self._sleeps(monkeypatch)
         pause()
         pause()
         assert sleeps == [sync_repos.ADAPTIVE_THROTTLE] * 2
@@ -225,15 +227,15 @@ class TestMakeThrottler:
         assert sleeps == [5.0, 5.0]
 
     def test_explicit_zero_disables_pacing_even_after_transient(self, monkeypatch):
-        sleeps = self._sleeps(monkeypatch)
         trip_transient_flag(monkeypatch)
+        sleeps = self._sleeps(monkeypatch)
         pause = sync_repos.make_throttler(0.0, dry_run=False)
         pause()
         assert not sleeps
 
     def test_dry_run_never_pauses(self, monkeypatch):
-        sleeps = self._sleeps(monkeypatch)
         trip_transient_flag(monkeypatch)
+        sleeps = self._sleeps(monkeypatch)
         for explicit in (None, 5.0):
             pause = sync_repos.make_throttler(explicit, dry_run=True)
             pause()

--- a/.agent/work-plans/issue-582/progress.md
+++ b/.agent/work-plans/issue-582/progress.md
@@ -21,3 +21,22 @@ issue: 582
 - [x] (suggestion) module-level flag never reset at main() entry — `sync_repos.py`/`lib/remote_utils.py` (fixed: reset_transient_error_seen() at entry)
 - [ ] (suggestion) sync failures still exit 0 — pre-existing; raised odds in firewall scenario noted in PR body, not changed here
 - [ ] (suggestion) push_remote/pull_remote set but never read the adaptive flag — scoped gap noted in PR body
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-23 23:06 -0400
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #583 at `0e48ff0`
+**Sources**: 3 (Copilot @ `0e48ff0`, Local Review (Pre-Push) @ `b0ebe6f`, CI rollup)
+**Cross-source confirmations**: 1
+**CI**: all-pass
+
+### Findings
+- [ ] (cross-confirmed: Local Review negative-check + Copilot non-finite) `--throttle nan` silently disables all pacing and `inf` hangs time.sleep — extend guard to reject non-finite values — `.agent/scripts/sync_repos.py:233`
+- [ ] (suggestion, Copilot) update rejection test to cover nan/inf and the new error text — `.agent/scripts/tests/test_net_retry.py:242`
+- [ ] (suggestion, Local Review, deferred-by-design) sync failures still exit 0 — pre-existing, documented in PR body
+- [ ] (suggestion, Local Review, deferred-by-design) push_remote/pull_remote set but don't read the adaptive flag — documented in PR body
+
+### False positives
+- none — both Copilot comments valid

--- a/.agent/work-plans/issue-582/progress.md
+++ b/.agent/work-plans/issue-582/progress.md
@@ -1,0 +1,23 @@
+---
+issue: 582
+---
+
+# Issue #582 — make sync: throttle should be off by default, enabled only when the remote drops connections
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-23 22:59 -0400
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: approved
+
+**Branch**: feature/issue-582 at `b0ebe6f`
+**Mode**: pre-push
+**Depth**: Standard (reason: 156 changed lines, 50–199 band)
+**Must-fix**: 0 | **Suggestions**: 4 (2 applied in-branch)
+**Round**: 1 | **Ship**: recommended — no must-fix findings; both actionable suggestions applied before push
+
+### Findings
+- [x] (suggestion) negative --throttle silently disabled adaptive pacing — `sync_repos.py` argparse (fixed: parser.error)
+- [x] (suggestion) module-level flag never reset at main() entry — `sync_repos.py`/`lib/remote_utils.py` (fixed: reset_transient_error_seen() at entry)
+- [ ] (suggestion) sync failures still exit 0 — pre-existing; raised odds in firewall scenario noted in PR body, not changed here
+- [ ] (suggestion) push_remote/pull_remote set but never read the adaptive flag — scoped gap noted in PR body


### PR DESCRIPTION
## Summary

The field fix imported in #580 paced `make sync` with a fixed 2.0s `--throttle` default between per-repo network operations. That pacing is only needed behind the rate-limiting firewall, but every sync everywhere paid ~70s of dead time. This PR makes pacing off by default and adaptive:

- **Default (no flag)**: no pacing. If a dropped-connection signature (`remote_utils.TRANSIENT_ERRORS`) is seen mid-run, the remaining repos are automatically paced at 2.0s (`ADAPTIVE_THROTTLE`), with a one-time notice.
- **`--throttle N`**: fixed pace from the start (unchanged semantics). Negative values are now rejected by argparse.
- **`--throttle 0`**: disables pacing entirely, including adaptive.
- The retry-once-after-15s-backoff behavior in `retry_transient` is unchanged; it now also records the drop in a module flag (`transient_error_seen()`), reset at `main()` entry.

## Tests

`test_net_retry.py`: 19 pass (8 new — flag set/clear semantics, adaptive/fixed/zero/dry-run pacing policy, negative rejection). Full script suite: 69 pytest + all shell suites green.

## Review notes (pre-push, Standard depth, 2 adversarial passes)

No must-fix findings. Two suggestions applied in-branch (negative `--throttle` rejection, flag reset at entry). Two observations left as-is deliberately:
- **Sync failures still exit 0** — pre-existing behavior; in the firewall scenario the first drop's single retry can fail and leave a repo unsynced with only a stdout `❌`. Changing `main()` to exit non-zero would also change `make sync` / `merge_pr.sh` behavior, so left for a separate decision.
- **`push_remote.py` / `pull_remote.py`** now set the adaptive flag via the shared helper but don't read it (no pacing there, same as before). Wiring them up is a possible follow-up if the firewall bites those paths.

Closes #582

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
