### PR TITLE
fix: reject non-finite --throttle values (follow-up to #582)

### DIFF
--- a/.agent/scripts/sync_repos.py
+++ b/.agent/scripts/sync_repos.py
@@ -20,6 +20,7 @@ Options:
 """
 
 import sys
+import math
 import time
 import shutil
 import subprocess
@@ -229,8 +230,8 @@ def main():
         f"Pass 0 to disable pacing entirely.",
     )
     args = parser.parse_args()
-    if args.throttle is not None and args.throttle < 0:
-        parser.error("--throttle must be >= 0")
+    if args.throttle is not None and not (math.isfinite(args.throttle) and args.throttle >= 0):
+        parser.error("--throttle must be a finite value >= 0")
 
     # Each run adapts from a clean slate — matters only for in-process
     # callers, but makes the fresh-process assumption explicit.

--- a/.agent/scripts/tests/test_net_retry.py
+++ b/.agent/scripts/tests/test_net_retry.py
@@ -233,13 +233,17 @@ class TestMakeThrottler:
         pause()
         assert not sleeps
 
-    def test_negative_throttle_rejected(self, monkeypatch, capsys):
-        """A fat-fingered negative would otherwise silently disable even the
-        adaptive safety net — argparse must reject it."""
-        monkeypatch.setattr(sys, "argv", ["sync_repos.py", "--throttle", "-5"])
+    @pytest.mark.parametrize("value", ["-5", "nan", "inf", "-inf"])
+    def test_out_of_domain_throttle_rejected(self, monkeypatch, capsys, value):
+        """Out-of-domain values would otherwise silently disable even the
+        adaptive safety net (negative, nan) or hang time.sleep (inf) —
+        argparse must reject them (pre-push review + Copilot PR#583)."""
+        # --throttle=<value> form: a bare "-inf" argument would be parsed as
+        # an option prefix ("expected one argument") and skip our check.
+        monkeypatch.setattr(sys, "argv", ["sync_repos.py", f"--throttle={value}"])
         with pytest.raises(SystemExit):
             sync_repos.main()
-        assert "--throttle must be >= 0" in capsys.readouterr().err
+        assert "--throttle must be a finite value >= 0" in capsys.readouterr().err
 
     def test_dry_run_never_pauses(self, monkeypatch):
         trip_transient_flag(monkeypatch)

--- a/.agent/work-plans/issue-582/progress.md
+++ b/.agent/work-plans/issue-582/progress.md
@@ -33,8 +33,8 @@ issue: 582
 **CI**: all-pass
 
 ### Findings
-- [ ] (cross-confirmed: Local Review negative-check + Copilot non-finite) `--throttle nan` silently disables all pacing and `inf` hangs time.sleep — extend guard to reject non-finite values — `.agent/scripts/sync_repos.py:233`
-- [ ] (suggestion, Copilot) update rejection test to cover nan/inf and the new error text — `.agent/scripts/tests/test_net_retry.py:242`
+- [x] (cross-confirmed: Local Review negative-check + Copilot non-finite) `--throttle nan` silently disables all pacing and `inf` hangs time.sleep — extend guard to reject non-finite values — `.agent/scripts/sync_repos.py:233`
+- [x] (suggestion, Copilot) update rejection test to cover nan/inf and the new error text — `.agent/scripts/tests/test_net_retry.py:242`
 - [ ] (suggestion, Local Review, deferred-by-design) sync failures still exit 0 — pre-existing, documented in PR body
 - [ ] (suggestion, Local Review, deferred-by-design) push_remote/pull_remote set but don't read the adaptive flag — documented in PR body
 


### PR DESCRIPTION
## Summary

Follow-up to #582 / PR #583. The triage round on PR #583 accepted Copilot's finding that `--throttle` accepts non-finite values: `nan` passes the `< 0` guard (`nan < 0` is False) and silently disables all pacing including the adaptive safety net, and `inf` passes `> 0` and hangs in `time.sleep(inf)`. The commit carrying the fix failed silently during pre-commit (hook reformat aborted it) and PR #583 merged without it — this PR lands it.

- Guard now requires `math.isfinite(value) and value >= 0`, else `parser.error("--throttle must be a finite value >= 0")`.
- Rejection test parametrized over `-5`, `nan`, `inf`, `-inf` (using `--throttle=<value>` form so `-inf` isn't consumed as an option prefix).
- Checks off the two open findings in the #582 `progress.md` Integrated Review entry.

## Tests

`test_net_retry.py`: 22 pass. Full suite ran green pre-merge on the rest of the change.

Part of #582 (already closed by PR #583).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
