### PR TITLE
docs: promote agent-memory process rules into AGENTS.md, WORKFORCE_PROTOCOL, and knowledge docs

### DIFF
--- a/.agent/WORKFORCE_PROTOCOL.md
+++ b/.agent/WORKFORCE_PROTOCOL.md
@@ -74,6 +74,10 @@ GitHub Issues are the **Source of Truth** for what is being worked on.
 *   **Before Starting**:
     *   Search for open issues or projects.
     *   **Check for draft PRs** - they indicate active work
+    *   **Check for an existing worktree** on the issue — a **dirty worktree
+        means in-flight work by another session: hands off** unless the user
+        explicitly hands it over. Don't infer "abandoned" from stale file
+        mtimes; sessions idle for long stretches.
     *   **Verify the issue number**: Run `gh issue view <N> --json title --jq '.title'` and confirm the title matches your task. If it doesn't, stop — you may have inherited the wrong issue copied from a plan or status report.
     *   **Do not** pick up an issue assigned to another user/agent unless explicitly instructed to "Join" or "Collaborate".
 *   **During Work**:
@@ -102,3 +106,30 @@ If you discover you are modifying a file that has uncommitted changes from anoth
 1.  **Stop**.
 2.  **Diff** the changes.
 3.  **Notify User**: "I see uncommitted changes in `foo.cpp`. Should I include them, revert them, or stash them?"
+
+In a **handed-over worktree**, re-check `git status` / `git log` immediately
+before committing — another agent may have advanced the branch since you
+last looked; don't clobber or double-commit.
+
+## 7. Shared-Host Etiquette
+
+Multiple agents (and the user) share dev hosts. Rules:
+
+*   **Never kill containers or processes you didn't launch** — another
+    agent's dispatch or the user's run may be behind them. If a resource is
+    contended, surface it.
+*   **Don't churn the user's GUI during hands-on testing** — no
+    kill/relaunch of an interactive app the user is testing, and no
+    disruptive headless launches beside it.
+*   **Set a unique `ROS_DOMAIN_ID`** whenever another agent or the user may
+    run ROS nodes/sim on the same machine — cross-talk between two agents'
+    node graphs produces baffling test failures.
+
+## 8. Decision Fidelity Across Agent Chains
+
+Multi-agent handoffs accumulate misinterpretation:
+
+*   When a plan or progress entry records a user decision, **verify it
+    against the user's original words**, not a prior agent's paraphrase.
+*   When driving a remote agent session (tmux/container), **show the user
+    the prompt text before sending it**.

--- a/.agent/knowledge/README.md
+++ b/.agent/knowledge/README.md
@@ -13,8 +13,12 @@ checked out in `layers/`.
 ## IDE Setup
 - **[VS Code Setup Guide](vscode_setup.md)**: Multi-root workspace configuration, Makefile tasks, C++/Python IntelliSense, and Claude Code extension integration.
 
+## Analysis & Diagnosis
+- **[Bag & Deployment Data Analysis](bag_analysis.md)**: Standard bag-analysis pipeline, time discipline, unit gotchas, and deployment-review conventions.
+- **[Diagnosis Discipline](diagnosis_discipline.md)**: Verification rules for root-causing field failures without plausible-but-wrong narratives.
+
 ## Agent Workflows
-- **[Skill Workflows](skill_workflows.md)**: Per-issue lifecycle sequence, governance skill index, and utility skill catalog.
+- **[Skill Workflows](skill_workflows.md)**: Per-issue lifecycle sequence, governance skill index, utility skill catalog, and sub-agent dispatch practices.
 - **[Principles Review Guide](principles_review_guide.md)**: Evaluation criteria for workspace principles and ADRs. Used by lifecycle skills (triage, planning, review) and as a manual checklist.
 - **[Documentation Verification](documentation_verification.md)**: Mandatory verification workflow for writing accurate ROS 2 package documentation. Includes command cookbook and hallucination anti-patterns.
 - **[Field Mode Hotfix Walkthrough](field_mode_hotfix.md)**: Step-by-step flow for making a hotfix on a field machine (non-GitHub origin) and reconciling back to GitHub via the import skill.

--- a/.agent/knowledge/bag_analysis.md
+++ b/.agent/knowledge/bag_analysis.md
@@ -1,0 +1,46 @@
+# Bag & Deployment Data Analysis
+
+Conventions for analyzing recorded deployment data (rosbags, router stats,
+deployment logs). Field-earned; each rule exists because its violation
+produced a wrong conclusion at least once.
+
+## Pipeline
+
+- **Use the standard `bag_analysis` pipeline**: `bag_to_sqlite` → SQLite DB →
+  analysis scripts. Don't hand-roll ad-hoc mcap readers per question — the
+  pipeline handles topic extraction, typing, and indexing once, and
+  downstream scripts stay comparable across analyses.
+- **Read bags offline for batch data products** — never replay a bag through
+  a live ROS node to regenerate products. Offline reads are faster,
+  deterministic, and can't cross-contaminate a live graph.
+
+## Time discipline
+
+- **Derive event times from the data, not from logs**: dock departure/return
+  and other physical events come from bag GPS (and battery/actuator
+  signals), not from launch/log timestamps.
+- **Agent-log timestamps are unreliable while the operator is away** — an
+  idle field agent's log lines cluster on wake-ups, not on events. Confirm
+  any operationally meaningful time against the bag.
+- **Exclude launch settling**: drop the first ~30 s after a stack launch
+  (and a buffer after recoveries) when analyzing estimator-derived values —
+  estimates haven't converged and will skew statistics.
+- **Stamp retrieval time** on any fetched, time-sensitive data you record
+  (weather forecasts, tide predictions, API pulls) — the fetch time is part
+  of the datum.
+
+## Units & sources
+
+- **MikroTik and udp_bridge `*_bytes_per_second` counters are bytes/s** —
+  multiply by 8 for Mbps. **Starlink reports bits/s.** Mixing these up
+  produces 8× link-utilization errors (it has happened).
+
+## Deployment review products
+
+- **Review videos**: build one synchronized multi-panel video (all cameras +
+  segmentation + costmap) rather than per-topic clips; verify event timing
+  against the bag before annotating.
+- **Recording is selective and split across locations** — see the
+  platform's data-locations doc (for BizzyBoat:
+  `unh_echoboats_project11/docs/logs/README.md`) before concluding
+  something "wasn't recorded".

--- a/.agent/knowledge/diagnosis_discipline.md
+++ b/.agent/knowledge/diagnosis_discipline.md
@@ -1,0 +1,42 @@
+# Diagnosis Discipline
+
+Rules for root-causing failures in a field-robotics workspace, where
+partial data, multi-host systems, and human actions make plausible-but-wrong
+narratives cheap to construct. Each rule traces to a real misdiagnosis.
+
+## Verify before narrating
+
+- **Check the suspect component's *current* state before declaring "same
+  bug as last time"** — precedent plus a similar symptom is a hypothesis,
+  not a diagnosis. The config/code may have changed since the precedent.
+- **Identical observations prove identity, not causation.** Two matching
+  values/artifacts don't establish that one derived from the other; say
+  "these match", not "A caused B", until you have a mechanism.
+- **Verify "X is missing from Y" against a known-good case first.** Tooling
+  artifacts (filters, truncation, wrong query) masquerade as data gaps;
+  reproduce a case where X is known present through the same tooling before
+  claiming absence.
+- **Only verified-deployed components belong on a suspect list.** Naming a
+  component that isn't actually in the running stack sends the
+  investigation down a dead end; check what's deployed or ask.
+
+## Respect the observer
+
+- **A repeated operator eyewitness observation outranks a partial-data
+  conclusion.** If the operator saw it twice and your analysis says it
+  can't happen, the analysis is missing data — reproduce the observation
+  before dismissing it.
+
+## Human actions first
+
+- **A `SIGKILL`/-9 in a launch log usually means an operator restart** (plus
+  rmw_zenoh's slow close making the supervisor escalate), **not a crash or
+  OOM.** Before narrating a failure from process exits, confirm what humans
+  did at that time and whether shutdown ordering explains the signals.
+
+## Measured data is looked up, never estimated
+
+- **Never estimate a quantity the project has measured** — mounting offsets
+  live in the URDF and `/tf_static`; rates, limits, and calibrations live in
+  configs. Fabricating a "reasonable" value for known data is a serious
+  error even when it's close.

--- a/.agent/knowledge/field_mode_hotfix.md
+++ b/.agent/knowledge/field_mode_hotfix.md
@@ -170,6 +170,23 @@ field mode otherwise permits it. Check the repo's
 branch, remove that entry or drop the hook entirely for field-mode
 repos. Don't bypass with `--no-verify` — fix the config.
 
+**gitcloud may be unreachable from the UNH/CCOM campus network** (its
+private ZeroTier address gets "No route to host"; observed 2026-07-22). The
+same Forgejo server is reachable as `gitcloudap` (public address; both names
+are in `/etc/hosts`). Redirect a single git invocation without touching repo
+remotes or `~/.ssh/config`:
+
+```bash
+GIT_SSH_COMMAND="ssh -o HostName=gitcloudap -o HostKeyAlias=gitcloud" \
+  python3 .agent/scripts/pull_remote.py --remote gitcloud --json
+```
+
+`HostKeyAlias=gitcloud` keeps `known_hosts` matching. Caveat: the override
+redirects **every** ssh connection in that invocation — only use it on
+commands that talk exclusively to gitcloud (`pull_remote.py` /
+`push_remote.py --remote gitcloud` are safe). Field-side hosts on the
+boat/operator networks are unaffected.
+
 ## Related
 
 - [`AGENTS.md § Field Mode`](../../AGENTS.md#field-mode-origin-not-on-a-github-host) — canonical rule

--- a/.agent/knowledge/field_mode_hotfix.md
+++ b/.agent/knowledge/field_mode_hotfix.md
@@ -191,6 +191,6 @@ boat/operator networks are unaffected.
 
 - [`AGENTS.md § Field Mode`](../../AGENTS.md#field-mode-origin-not-on-a-github-host) — canonical rule
 - [`.agent/scripts/field_mode.sh`](../scripts/field_mode.sh) — mode detection helper
-- [`.claude/skills/import-field-changes/content.md`](../../.claude/skills/import-field-changes/content.md) — the import skill
+- [`.claude/skills/import-field-changes/SKILL.md`](../../.claude/skills/import-field-changes/SKILL.md) — the import skill
 - Issue [#445](https://github.com/rolker/ros2_agent_workspace/issues/445) — field-mode design and decisions
 - Issue [#247](https://github.com/rolker/ros2_agent_workspace/issues/247) — dev-mode worktree hardening

--- a/.agent/knowledge/launch_tooling.md
+++ b/.agent/knowledge/launch_tooling.md
@@ -143,3 +143,13 @@ ros2 launch --help | grep -q '\-g'
 
 If either check fails, add the missing package to the project's
 `underlay.repos` file.
+
+## Launch Argument Gotchas
+
+- **Argument case is load-bearing in `PythonExpression`**: a boolean launch
+  arg spelled `True`/`true` inconsistently evaluates differently once it
+  reaches a `PythonExpression`. Prefer `IfCondition`/`UnlessCondition`
+  (case-tolerant) over hand-built expressions.
+- **Debug from the launch/config files first** — trace the argument and
+  parameter flow by reading the launch tree before burning iterations on
+  exploratory sim relaunches; most "mystery behavior" is visible statically.

--- a/.agent/knowledge/ros2_cli_best_practices.md
+++ b/.agent/knowledge/ros2_cli_best_practices.md
@@ -106,3 +106,9 @@ This guide outlines how to use the `ros2` command-line interface (CLI) effective
 1.  **Discovery**: `ros2 topic list -t` -> find `/battery_state` [sensor_msgs/msg/BatteryState].
 2.  **Introspection**: `ros2 interface show sensor_msgs/msg/BatteryState` -> see `float32 percentage`.
 3.  **Action**: `ros2 topic echo /battery_state --field percentage --once` -> get `0.85`.
+
+## Parameter File Gotchas
+
+*   **Empty YAML arrays load as `PARAMETER_NOT_SET`**: a param file line
+    `foo: []` does not produce an empty array — omit the line entirely and
+    handle the unset default in code/launch.

--- a/.agent/knowledge/ros2_development_patterns.md
+++ b/.agent/knowledge/ros2_development_patterns.md
@@ -214,3 +214,54 @@ make test
 3. **Build incrementally** - test packages individually before full builds
 4. **Keep package.xml updated** - ensure all dependencies are listed
 5. **Follow ROS2 coding standards** - use rclcpp/rclpy idioms
+
+## Workspace-Wide Change Discipline
+
+- **Public API changes**: before changing a message field, service
+  signature, or exported class, grep the **entire workspace** (all layers)
+  for consumers — the owning package's callers are a subset. Fix all sites
+  in the same change.
+- **Renames**: an as-you-go rename must be completed workspace-wide in the
+  same commit series — a half-applied rename is worse than none.
+
+## Sensor Driver Conventions
+
+- **Read the `.msg` spec and existing precedents** before populating
+  fields — don't invent conventions a consumer can't predict (units,
+  half- vs full-angles, axis assignments). Document any producer
+  convention the message type can't express.
+- **Orientation belongs in TF (URDF), not driver parameters** — mounting,
+  including non-traditional installs, lives entirely in the TF tree.
+- **No trademarked product names in identifiers** — package/topic/type
+  names outlive the specific hardware.
+- **Marine platform rates default to ~10 Hz** — nav/sensor/controller
+  loops here run at marine-vessel rates, not Nav2's small-indoor-robot
+  20+ Hz defaults. Don't "fix" a 10 Hz loop to match upstream examples.
+
+## Runtime Gotchas (field-earned)
+
+- **Symlink-install means `install/` files ARE the source** — editing an
+  installed config through the symlink edits the tracked file in the main
+  tree. Use `ros2 param set` for experiments, or a worktree for real
+  changes.
+- **FastDDS late-join hazard**: create publishers at node
+  configure/startup, not lazily on first use — late-created publishers
+  can miss discovery with already-running subscribers.
+- **rmw_zenoh `SubscriberCallback` type errors** usually trace to a ROS 1
+  → ROS 2 port using a one-shot timer idiom; check timer callback
+  signatures first.
+- **Slow shutdown under rmw_zenoh**: a supervisor escalating to SIGKILL on
+  shutdown is commonly zenoh's close-hang, not a hung node — see
+  [diagnosis_discipline.md](diagnosis_discipline.md).
+
+## Lint Environment Notes
+
+- **Local uncrustify 0.78.1 mass-fails colcon test** — that wall of
+  formatting errors is environment noise, not your change. For a
+  CI-accurate check, run bare-jazzy `ament_uncrustify` on just the files
+  you touched.
+- **Ubuntu 24.04+ blocks `unshare -Urn`** (AppArmor
+  `apparmor_restrict_unprivileged_userns`). Netns-based test harnesses
+  need the one-time host knob
+  `sysctl kernel.apparmor_restrict_unprivileged_userns=0` — a host
+  setting; get approval before changing it on shared machines.

--- a/.agent/knowledge/skill_workflows.md
+++ b/.agent/knowledge/skill_workflows.md
@@ -122,3 +122,20 @@ checkpoints between them. A skill's `### Next step` block is a prompt for
 the operator or orchestrator to act on — not an instruction for the skill to
 execute autonomously. This keeps each step's entry independently attributed and
 prevents a single runaway sub-agent from racing through the whole lifecycle.
+
+## Dispatch Practices
+
+Field-earned rules for sub-agent dispatch (`dispatch_subagent.sh`,
+`docker_run_agent.sh`):
+
+- **Fan-out goes to containers, not in-process agents.** Review/exploration
+  fan-out via in-process Agent-tool sub-agents floods the operator with
+  permission prompts; container dispatch runs sandboxed and prompt-free.
+- **Run container dispatches in the background** so the host session stays
+  responsive to the operator; check results on completion.
+- **Never give a sub-agent filesystem-wide search scope** — scope prompts to
+  the workspace/worktree. Broad-access agents wander into cloud/bucket
+  mounts and burn minutes (and money) on filesystem walks.
+- **Container OOM (exit 137) gates on *free* RAM** — below roughly 3 GiB
+  free on the dev host, dispatches get killed. Check `free -g` before heavy
+  fan-out; stagger dispatches when memory is tight.

--- a/.agent/work-plans/issue-586/progress.md
+++ b/.agent/work-plans/issue-586/progress.md
@@ -1,0 +1,22 @@
+---
+issue: 586
+---
+
+# Issue #586 — docs: promote agent-memory process rules into AGENTS.md, WORKFORCE_PROTOCOL, and knowledge docs
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-24 15:42 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: approved
+
+**Branch**: feature/issue-586 at `70895a3`
+**Mode**: pre-push
+**Depth**: Standard (instruction files touched; 10 files +~300)
+**Must-fix**: 0 | **Suggestions**: 2 (both fixed pre-push)
+**Round**: 1 | **Ship**: recommended — two disjoint-lens adversarial passes; cross-pass-confirmed ADR-0018 wording collision and deployment-mode over-breadth both fixed; anchors/commands/links verified (incl. merge_pr.sh --issue behavior)
+
+### Findings
+- [x] (suggestion, cross-pass confirmed) 'never merge while pending' collided with ADR-0018 local-attestation merges — scoped per-repo-type — `AGENTS.md` Merging
+- [x] (suggestion) field-host hard stop broad enough to forbid deployment-mode in-session mitigations — narrowed to host sysadmin — `AGENTS.md` Never
+- [ ] (nit, user's call) timestamp/attribution rules now stated in AGENTS.md + deployment_mode.md + new knowledge docs — consistent today; consider one canonical home + cross-refs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,10 +54,13 @@ setup (environment, identity, features), see your framework's adapter file:
 - Modify or delete raw survey data (bags, `~/data/logs` — data-of-record)
   without explicit per-action approval. Describing a plan is not consent;
   state the exact operation and stop for a yes.
-- Change system state on remote/field hosts (salmon, gabby, boats): no
-  package installs, service changes, or config edits — surface the need
-  instead. SSH access for one purpose does not authorize running commands
-  on other hosts; ask first.
+- Administer remote/field hosts (salmon, gabby, boats): no package
+  installs, systemd/service changes, or host-level (`/etc`) config edits —
+  surface the need instead. This governs host *system administration*, not
+  in-session ROS operations: deployment mode's urgency contract still
+  authorizes its in-session mitigations (restart a node, tune a rate).
+  SSH access for one purpose does not authorize running commands on other
+  hosts; ask first.
 - Start unrequested background monitoring/polling loops.
 - Disable lint rules, skip tests, or suppress warnings to make a check
   pass — fix the cause; discuss before changing test or lint config.
@@ -440,9 +443,13 @@ bootstrap confirmation). `CI` is also recognized for CI environments.
 - **Merge commits, never squash** — preserve the atomic-commit history.
 - Merge via `merge_pr.sh --issue <N>` (not `--pr <N>` — the PR-keyed form
   skips worktree cleanup).
-- **Gate on green CI**: never merge while checks are red or pending. A
-  poll loop that breaks on failure must not fall through to the merge
-  command.
+- **Gate on the applicable CI verification**: for the **workspace repo**,
+  never merge while hosted checks are red or pending. For **project
+  repos**, a full-scope `ci-local` attestation satisfies the gate without
+  waiting for hosted Actions (see Merge verification below / ADR-0018) —
+  but never merge past a *red* signal from whichever verification applies.
+  Either way, a poll loop that breaks on failure must not fall through to
+  the merge command.
 - **Green CI is not review**: never merge a PR the user hasn't
   content-reviewed — doubly so for strategic documents (roadmaps, ADRs,
   instruction files).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,19 @@ setup (environment, identity, features), see your framework's adapter file:
 - Document from assumptions — verify against source code
 - Construct GitHub URLs from directory names — use `gh` CLI to look them up
 - Run bare `pip install` or use `--break-system-packages` — use `.venv` for dev tools (see ADR-0009)
+- Modify or delete raw survey data (bags, `~/data/logs` — data-of-record)
+  without explicit per-action approval. Describing a plan is not consent;
+  state the exact operation and stop for a yes.
+- Change system state on remote/field hosts (salmon, gabby, boats): no
+  package installs, service changes, or config edits — surface the need
+  instead. SSH access for one purpose does not authorize running commands
+  on other hosts; ask first.
+- Start unrequested background monitoring/polling loops.
+- Disable lint rules, skip tests, or suppress warnings to make a check
+  pass — fix the cause; discuss before changing test or lint config.
+- Put `close`/`fixes`/`resolves #N` in a PR body or commit message unless
+  that PR really should close the issue — see
+  [Issue-closing keywords](#issue-closing-keywords).
 
 ## Quality Standard
 
@@ -196,6 +209,14 @@ repo, not just the workspace repo.
 
 **Trivial fixes** (typos, minor doc corrections) don't need a dedicated issue — use the
 current task's worktree or create a quick issue for a new one.
+
+**Filing discipline**: don't file an issue for every backlog thought — a
+dev-log backlog line is enough for on-radar items; file when work is about to
+start or the item needs cross-referencing. For consolidation/cleanup work,
+default to bundling related changes into one PR (atomic commits inside)
+rather than fanning out many small issues. When creating an issue of a
+recurring type (deployment, RCA, onboarding), read a recent closed one and
+match its structure.
 
 **Sub-tasks**: When creating a new issue as a sub-task of existing work, reference
 the parent issue in the issue body (e.g., "Part of #NNN"). Use full
@@ -354,6 +375,23 @@ gh repo view --json url --jq '.url'
 When referencing any GitHub issue, PR, commit, or repository in summaries or reports,
 include a clickable markdown link on every mention.
 
+### Issue-Closing Keywords
+
+GitHub's parser auto-closes issues on `close`/`fixes`/`resolves #N` tokens in
+PR bodies and commit messages — including **negated** mentions ("does not
+close #5") and mentions describing a **sibling** PR. This has closed wrong
+issues twice. Rules:
+
+- Use the keyword only for the one issue this PR should actually close.
+- For every other mention, write "Part of #N" / "addresses #N" or link the
+  URL.
+- Work plans pasted into PR bodies inherit this hazard — scrub keyword
+  phrases from plan text before pasting.
+
+### Docs-Only PRs
+
+Docs-only PRs omit the Test plan section of the PR body.
+
 ## Build & Test
 
 `make build` handles the core setup chain automatically — on a fresh clone it
@@ -397,6 +435,21 @@ sourcing lower layers automatically.
 Set `NONINTERACTIVE=1` to suppress all interactive prompts (e.g., the first-run
 bootstrap confirmation). `CI` is also recognized for CI environments.
 
+### Merging
+
+- **Merge commits, never squash** — preserve the atomic-commit history.
+- Merge via `merge_pr.sh --issue <N>` (not `--pr <N>` — the PR-keyed form
+  skips worktree cleanup).
+- **Gate on green CI**: never merge while checks are red or pending. A
+  poll loop that breaks on failure must not fall through to the merge
+  command.
+- **Green CI is not review**: never merge a PR the user hasn't
+  content-reviewed — doubly so for strategic documents (roadmaps, ADRs,
+  instruction files).
+- Before merging, fetch and read PR review comments (human and bot) —
+  `fetch_pr_reviews.sh` — and triage them; don't merge past unread
+  feedback.
+
 ### Merge verification (ADR-0018)
 
 Project-repo PRs may merge on a **full-scope local CI attestation** instead of
@@ -416,6 +469,17 @@ repos remains a mirror/backstop — triage its post-merge failures. The
   that declare parameters/publishers/subscribers, and any `.msg`/`.srv`/`.action` files.
 - Use the verification workflow in [`.agent/knowledge/documentation_verification.md`](.agent/knowledge/documentation_verification.md).
 - Use the documentation template in [`.agent/templates/package_documentation.md`](.agent/templates/package_documentation.md).
+- **Never hand-type timestamps or measured values** into durable artifacts
+  (logs, reports, docs) — generate timestamps with
+  `date '+%Y-%m-%d %H:%M %:z'`; mark human-reported times as
+  `~HH:MM (operator-reported)`; look measured quantities up (URDF,
+  `/tf_static`, configs) instead of estimating them.
+- **Never attribute decisions or rationale to a person who didn't state
+  them** — record what was actually said; a plausible justification you
+  inferred is fabrication, not documentation.
+- **Never reference private agent-memory filenames** from repo-tracked
+  files (progress.md, plans, READMEs) — inline the relevant content
+  instead; other agents and humans can't resolve those references.
 
 ## Project-Level Guidance
 
@@ -438,6 +502,9 @@ review) that references — never forks — these workspace rules; create it fro
 - Keep repo root and `layers/*/src/` clean — no temp files, build artifacts, or logs.
 - Use `.agent/scratchpad/` for persistent temp files (unique names via `mktemp`).
 - Use `/tmp` for ephemeral files cleaned up in the same command.
+- **Scope filesystem searches to project paths** (the workspace, `~/data`) —
+  never grep/find from `$HOME`: it descends into cloud/network FUSE mounts
+  and hangs or floods results.
 
 ## Post-Task Verification
 


### PR DESCRIPTION
Promotes ~67 process rules and ~28 analysis/diagnosis practices — until now living only in one agent's private memory — into the shared instruction and knowledge corpus. Scope was settled with Roland on 2026-07-24 (all four buckets approved); **wording review before merge is the explicit gate** since this touches Ask-First instruction files. Part of the 2026-07-24 memory-promotion audit.

Closes #586

## Commits (one per bucket, plus review fixes)

1. **AGENTS.md** — new Never bullets (raw survey data, field-host sysadmin, unauthorized SSH, unrequested monitoring, lint/test circumvention, closing keywords); a "Merging" section (merge commits, `merge_pr.sh --issue`, CI gate, user content review, read comments first); "Issue-Closing Keywords" + "Docs-Only PRs" under GitHub CLI patterns; Issue-First filing discipline; Documentation Accuracy integrity bullets (no hand-typed timestamps, no invented rationale, no private-memory references); search scoping under Workspace Cleanliness.
2. **WORKFORCE_PROTOCOL.md** — dirty-worktree ownership check, handover re-check before commit, new §7 Shared-Host Etiquette (containers, GUI churn, `ROS_DOMAIN_ID`) and §8 Decision Fidelity Across Agent Chains.
3. **New knowledge docs** — `bag_analysis.md` (pipeline, time discipline, bytes-vs-bits, review products) and `diagnosis_discipline.md` (verify-before-narrating, operator observations, SIGKILL≠crash, measured-data lookup), indexed in the knowledge README.
4. **Knowledge additions** — dispatch practices in `skill_workflows.md`; workspace-wide change discipline, sensor-driver conventions, 10 Hz marine rates, runtime/lint gotchas in `ros2_development_patterns.md`; YAML `[]` gotcha in `ros2_cli_best_practices.md`; launch-arg case notes in `launch_tooling.md`; the verified gitcloudap `GIT_SSH_COMMAND` override in `field_mode_hotfix.md`.
5. **Review fixes** — see below.

## Pre-push review (Standard, two disjoint lenses)

- **Cross-pass confirmed**: the initial "never merge while checks are pending" wording collided with ADR-0018's local-attestation merge path — rescoped per repo type.
- **Lens B**: the field-host hard stop was broad enough to snag deployment-mode's authorized in-session mitigations — narrowed to host system administration with an explicit deployment-mode carve-out.
- Both lenses verified anchors, relative links, command syntax (including `merge_pr.sh --issue` cleanup behavior and the ssh `HostKeyAlias` form), and non-contradiction with PRINCIPLES.md, deployment_mode.md, and ADRs 0011/0013/0014/0015/0018.
- **Open nit for reviewer**: the timestamp/attribution integrity rules now appear in AGENTS.md, deployment_mode.md, and the new knowledge docs (consistent today). If you'd rather have one canonical home + cross-references, say so and I'll restructure.

Docs-only.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
