### PR TITLE
review-code: make Local Model Adversarial Specialist (5f) opt-in via --local

### DIFF
--- a/.agent/knowledge/inspiration_agent_workspace_digest.md
+++ b/.agent/knowledge/inspiration_agent_workspace_digest.md
@@ -89,7 +89,14 @@ of the surrounding tooling.
   in-house disjoint-lens Claude Adversarial passes (5d); `--copilot`
   adds a true second-vendor read on top when a reviewer judges it worth
   the Premium request. The old Light-tier "resource inversion" no longer
-  applies, since Light no longer auto-runs Copilot.
+  applies, since Light no longer auto-runs Copilot. The in-house Local
+  Model Adversarial pass (step 5f, Ollama via
+  `.agent/scripts/local_review.sh`,
+  [#570](https://github.com/rolker/ros2_agent_workspace/issues/570))
+  followed the same trajectory: originally default-on (quota-free
+  local inference), **now opt-in via `--local`**
+  ([#590](https://github.com/rolker/ros2_agent_workspace/issues/590))
+  — the run is the review's wall-clock long pole on current hardware.
 - **What remains unadopted**: the tmux-orchestrated multi-CLI dispatch
   in `cross_model_review.sh` and the Gemini/Codex specialists. The
   tmux session machinery adds complexity beyond the highest-leverage

--- a/.agent/knowledge/review_depth_classification.md
+++ b/.agent/knowledge/review_depth_classification.md
@@ -70,14 +70,15 @@ source path differs:
 - Claude Adversarial — one pass (Lens A: logic & correctness)
 - Copilot Adversarial — **opt-in only** (`--copilot`); off by default,
   skipped with notice if opted in but the CLI is unavailable
-- Local Model Adversarial — **default-on** (`--no-local` to opt out);
-  skipped with notice if the Ollama server/model is unavailable
+- Local Model Adversarial — **opt-in only** (`--local`); off by
+  default (wall-clock long pole on current hardware, #590), skipped
+  with notice if opted in but the Ollama server/model is unavailable
 
 **Report format**: Condensed — static analysis findings, Claude
 Adversarial findings, plus a one-line governance note ("No governance
 concerns for a change of this scope"). A Copilot Adversarial section
 appears only when `--copilot` was passed; a Local Adversarial section
-(or its skip notice) appears unless `--no-local` was passed.
+(or its skip notice) appears only when `--local` was passed.
 
 #### Standard
 
@@ -95,8 +96,9 @@ appears only when `--copilot` was passed; a Local Adversarial section
   cross-cutting), each a separate fresh-context dispatch
 - Copilot Adversarial — **opt-in only** (`--copilot`); off by default,
   skipped with notice if opted in but the CLI is unavailable
-- Local Model Adversarial — **default-on** (`--no-local` to opt out);
-  skipped with notice if the Ollama server/model is unavailable
+- Local Model Adversarial — **opt-in only** (`--local`); off by
+  default (wall-clock long pole on current hardware, #590), skipped
+  with notice if opted in but the Ollama server/model is unavailable
 
 **Report format**: Full report with all sections.
 
@@ -111,8 +113,8 @@ appears only when `--copilot` was passed; a Local Adversarial section
 
 **Specialists dispatched**:
 - Same as Standard (two disjoint-lens Claude Adversarial passes;
-  Copilot opt-in via `--copilot`; Local Model Adversarial default-on,
-  not tier-differentiated). Deep runs both Claude passes at a
+  Copilot opt-in via `--copilot`; Local Model Adversarial opt-in via
+  `--local`, not tier-differentiated). Deep runs both Claude passes at a
   longer file horizon with an explicit security/concurrency/lifecycle
   checklist, using the same fresh-context dispatch mechanism. The
   Standard→Deep difference is horizon and rigor, not which lenses run.
@@ -130,9 +132,11 @@ appears only when `--copilot` was passed; a Local Adversarial section
 > remains unadopted. When you want a third or fourth model's read on a
 > Deep PR, run that agent's review-code skill manually. A quota-free
 > local-model read (Ollama, default `qwen3.5:35b`) is wired in as
-> step 5f (`.agent/scripts/local_review.sh`, default-on, `--no-local`
-> to opt out — see
-> [#570](https://github.com/rolker/ros2_agent_workspace/issues/570));
+> step 5f (`.agent/scripts/local_review.sh`, **opt-in via `--local`**
+> — off by default since local inference is the wall-clock long pole
+> on current hardware; see
+> [#570](https://github.com/rolker/ros2_agent_workspace/issues/570) /
+> [#590](https://github.com/rolker/ros2_agent_workspace/issues/590));
 > its findings carry low-trust weighting in the silence filter.
 
 ## Override-Trigger Files

--- a/.agent/knowledge/skill_workflows.md
+++ b/.agent/knowledge/skill_workflows.md
@@ -37,8 +37,9 @@ and a second disjoint-lens Claude Adversarial pass. Copilot Adversarial
 is opt-in at every tier via `--copilot` (off by default to conserve the
 Premium quota). Local Model Adversarial (a quota-free Ollama read via
 `.agent/scripts/local_review.sh`, runtime-agnostic — needs only
-bash/curl/jq and a local Ollama server) is default-on at every tier,
-opted out via `--no-local`. `review-code` also
+bash/curl/jq and a local Ollama server) is likewise opt-in at every
+tier via `--local` (off by default — the wall-clock long pole on
+current hardware, #590). `review-code` also
 accepts a PR number / URL for post-PR review of someone else's work.
 `triage-reviews` runs after a PR has accumulated review comments
 (human + bot) and classifies each against the current code.

--- a/.agent/work-plans/issue-590/plan.md
+++ b/.agent/work-plans/issue-590/plan.md
@@ -1,0 +1,97 @@
+# Plan: Flip local review specialist 5f from default-on to opt-in
+
+## Issue
+
+https://github.com/rolker/ros2_agent_workspace/issues/590
+
+## Context
+
+The Local Model Adversarial Specialist (5f) in `/review-code` was made default-on in
+#570 (PR #571) on the theory that local Ollama inference is quota-free. In practice,
+on 8GB-VRAM hardware a ~500-line diff can exceed 600 seconds (`LOCAL_REVIEW_TIMEOUT`
+notes in `local_review.sh`), making the default-on pass the wall-clock long pole on
+every review. The fix is to flip the default: specialist 5f becomes opt-in (`--local`)
+rather than opt-out (`--no-local`). The `local_review.sh` script is unchanged — it
+remains standalone-capable and is the offline/field-mode review path.
+
+## Approach
+
+1. **Update `.claude/skills/review-code/SKILL.md`** — flip all `--no-local`/default-on
+   references to `--local`/default-off. Specific locations:
+   - Usage lines (lines 11, 13): replace `[--no-local]` with `[--local]`
+   - Flag docs (lines 45–55): rewrite flag entry to describe `--local` as opt-in;
+     carry the hardware-speed rationale so the why survives issue closure
+   - Overview specialist list (line 99–100): flip "default-on" / `--no-local`
+   - Specialists overview bullet (lines 119–120): flip to "default-off" / `--local`
+   - Step 1 argument-parsing block (lines 145–146): change `--no-local` token and
+     `NO_LOCAL=1` description; also flip the "on by default" description to
+     "off by default"; add `--no-local` as a deprecated no-op (symmetric with
+     `--no-copilot`)
+   - Usage examples (line 168): change `--no-local` example comment
+   - Tier dispatch lists (lines 344–345, 357–358): change `unless NO_LOCAL=1
+     (--no-local)` to `only if LOCAL=1 (--local)`
+   - Deep tier paragraph (line 366–368): flip default-on language
+   - Section 5f header + opening paragraph (lines 724–726): flip to default-off
+   - Report templates: replace `off (--no-local)` with `off (default)` in the
+     standard/deep template (line 875, 933); in the Light template (line 959) flip
+     the comment about omitting when opted-out and the "default-on" note (line 978)
+
+2. **Update `.agent/knowledge/review_depth_classification.md`** — 4 references:
+   - Lines 73–74: flip Light tier specialist bullet
+   - Lines 80: flip Light "unless `--no-local`" report-format note
+   - Lines 98–99: flip Standard tier specialist bullet
+   - Lines 132–134: flip the note's default-on/`--no-local` description
+
+3. **Update `.agent/knowledge/skill_workflows.md`** — 2 references (lines 40–41):
+   flip "default-on at every tier, opted out via `--no-local`" to "off by default,
+   opt-in via `--local`"
+
+4. **Update `.agent/knowledge/inspiration_agent_workspace_digest.md`** — 1 reference
+   (line 82): the Copilot section mentions "Originally default-on … opt-out via
+   `--no-copilot`" as a historical note. The parallel Local Adversarial history
+   (also originally default-on) lives in this file implicitly; add a note parallel
+   to the Copilot entry documenting the flip for #590.
+
+5. **Grep for any remaining `--no-local` in `.claude/` and `.agent/`** to catch
+   stragglers not covered above.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.claude/skills/review-code/SKILL.md` | Flip ~12 occurrences from `--no-local`/default-on to `--local`/default-off; add `--no-local` deprecated no-op; carry hardware-speed rationale in flag description |
+| `.agent/knowledge/review_depth_classification.md` | 4 occurrences flipped |
+| `.agent/knowledge/skill_workflows.md` | 2 occurrences flipped |
+| `.agent/knowledge/inspiration_agent_workspace_digest.md` | 1 historical note updated |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Opt-in is more explicit — the local pass must be actively chosen; its wall-clock cost is no longer invisible to users who never read the flag docs |
+| Capture decisions, not just implementations | Hardware-speed rationale (#590 / 8GB-VRAM constraint) must appear in the `--local` flag description so the why survives issue closure; #585 (container Ollama) may revisit the default |
+| A change includes its consequences | All four knowledge-file references updated in the same PR — no stale docs |
+| Only what's needed | Minimal targeted change; `local_review.sh` untouched |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0006 — Shared AGENTS.md | No | No changes to instruction adapter files; `--no-local` confirmed absent from adapter files in issue review |
+| 0013 — progress.md vocabulary | Yes | progress.md entries follow the vocabulary throughout |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `--no-local` flag semantics in SKILL.md | All knowledge files that document the flag | Yes — steps 2–4 |
+| Local Adversarial default | Report templates (show `off (default)` not `off (--no-local)`) | Yes — step 1 |
+| `--no-local` retired | Add as deprecated no-op (symmetric with `--no-copilot`) | Yes — step 1 |
+
+## Open Questions
+
+- [ ] No open questions — plan is review-plan-ready.
+
+## Estimated Scope
+
+Single PR. ~15 line-level edits across 4 files; no logic changes.

--- a/.agent/work-plans/issue-590/plan.md
+++ b/.agent/work-plans/issue-590/plan.md
@@ -32,14 +32,20 @@ remains standalone-capable and is the offline/field-mode review path.
      (--no-local)` to `only if LOCAL=1 (--local)`
    - Deep tier paragraph (line 366–368): flip default-on language
    - Section 5f header + opening paragraph (lines 724–726): flip to default-off
+   - Section 5f closing rationale paragraph (line 799, "default-on despite the
+     noise"): flip to opt-in wording, keeping the keep-it-exercised-for-field
+     rationale (review-plan must-fix — bare `default-on`, no flag token)
    - Report templates: replace `off (--no-local)` with `off (default)` in the
      standard/deep template (line 875, 933); in the Light template (line 959) flip
      the comment about omitting when opted-out and the "default-on" note (line 978)
 
-2. **Update `.agent/knowledge/review_depth_classification.md`** — 4 references:
+2. **Update `.agent/knowledge/review_depth_classification.md`** — 5 references
+   (review-plan must-fix: the Deep-tier bullet was missing from the original
+   enumeration):
    - Lines 73–74: flip Light tier specialist bullet
    - Lines 80: flip Light "unless `--no-local`" report-format note
    - Lines 98–99: flip Standard tier specialist bullet
+   - Line 114: flip Deep tier "Local Model Adversarial default-on" bullet
    - Lines 132–134: flip the note's default-on/`--no-local` description
 
 3. **Update `.agent/knowledge/skill_workflows.md`** — 2 references (lines 40–41):
@@ -52,8 +58,10 @@ remains standalone-capable and is the offline/field-mode review path.
    (also originally default-on) lives in this file implicitly; add a note parallel
    to the Copilot entry documenting the flip for #590.
 
-5. **Grep for any remaining `--no-local` in `.claude/` and `.agent/`** to catch
-   stragglers not covered above.
+5. **Grep for any remaining stale references in `.claude/` and `.agent/`** to
+   catch stragglers not covered above — match `no-local`, `NO_LOCAL`, and the
+   bare wordings `default-on` / `default on` (review-plan suggestion: the
+   flag-only grep would miss prose references like the 5f rationale paragraph).
 
 ## Files to Change
 

--- a/.agent/work-plans/issue-590/progress.md
+++ b/.agent/work-plans/issue-590/progress.md
@@ -1,0 +1,50 @@
+---
+issue: 590
+---
+
+# Issue #590 — Flip local review specialist 5f from default-on to opt-in
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-30 18:17 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #590
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | Opt-in is more explicit — user must actively choose the local pass; wall-clock cost is no longer invisible |
+| Enforcement over documentation | OK | No new rules; changing the default of an existing option in skill docs |
+| Capture decisions, not just implementations | Watch | Rationale (hardware speed on 8GB-VRAM hardware) is captured in the issue body; implementor should carry that rationale into the `--local` flag description in SKILL.md so the why survives issue closure |
+| A change includes its consequences | Action needed | Three knowledge files need updating alongside SKILL.md — see Actions below |
+| Only what's needed | OK | Minimal, targeted change; no new abstraction |
+| Improve incrementally | OK | Single PR, scoped to default-flip and stale-reference cleanup |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| 0006 — Shared AGENTS.md | No | No changes to AGENTS.md or adapter files; no `--no-local` references found in `.github/copilot-instructions.md` or other adapters |
+| 0013 — progress.md vocabulary | Yes | This review-issue entry; no new entry type needed |
+
+### Consequences
+
+From the consequences map, "A framework skill" → "That framework's adapter file; regenerate skills if needed":
+- Adapter files confirmed to have no direct `--no-local` references — no adapter updates needed
+- No skill list change (content change only, not a new/removed skill), so no regeneration needed
+
+References to the default-on behavior found in knowledge files (all need updating in the same PR):
+- `.agent/knowledge/skill_workflows.md` — 2 references (`default-on`, `--no-local`)
+- `.agent/knowledge/review_depth_classification.md` — 4 references (`--no-local`, `default-on` in two tier sections)
+- `.agent/knowledge/inspiration_agent_workspace_digest.md` — 1 reference (`opt-out via --no-local`)
+
+### Actions
+- [ ] Update `.claude/skills/review-code/SKILL.md`: replace `--no-local` with `--local` in usage lines, flag docs, tier tables, section 5f, and report templates; add rationale note (hardware speed constraint) to the `--local` flag description
+- [ ] Update `.agent/knowledge/review_depth_classification.md`: 4 references to `default-on` / `--no-local` need flipping to `default-off` / `--local`
+- [ ] Update `.agent/knowledge/skill_workflows.md`: 2 references
+- [ ] Update `.agent/knowledge/inspiration_agent_workspace_digest.md`: 1 reference
+- [ ] Verify no other files reference `--no-local` in a durable artifact (grep `.claude/` `.agent/` for `no-local`)

--- a/.agent/work-plans/issue-590/progress.md
+++ b/.agent/work-plans/issue-590/progress.md
@@ -74,3 +74,18 @@ References to the default-on behavior found in knowledge files (all need updatin
 - [ ] (must-fix) `SKILL.md:799` rationale paragraph ("The specialist is default-on despite the noise…") not enumerated; bare `default-on` — step-5 `--no-local`-only grep won't catch it — `.claude/skills/review-code/SKILL.md:799`
 - [ ] (must-fix) `review_depth_classification.md:114` Deep-tier bullet ("Local Model Adversarial default-on") missing from the file's enumerated locations — file has 5 refs, not 4 — `.agent/knowledge/review_depth_classification.md:114`
 - [ ] (suggestion) Broaden step-5 straggler grep to also match `default-on`/`default on` (not just `--no-local`); also covers `SKILL.md:958` bare-wording comment — `.agent/work-plans/issue-590/plan.md:55`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-30 19:01 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-590 at `e630177`
+**Mode**: pre-push
+**Depth**: Standard (reason: governance/workflow-defining files — SKILL.md + .agent/knowledge/)
+**Must-fix**: 0 | **Suggestions**: 0
+**Round**: 1 | **Ship**: recommended — docs-only flip, fully consistent, no must-fix
+
+### Findings
+- [ ] No issues found. LGTM.

--- a/.agent/work-plans/issue-590/progress.md
+++ b/.agent/work-plans/issue-590/progress.md
@@ -48,3 +48,15 @@ References to the default-on behavior found in knowledge files (all need updatin
 - [ ] Update `.agent/knowledge/skill_workflows.md`: 2 references
 - [ ] Update `.agent/knowledge/inspiration_agent_workspace_digest.md`: 1 reference
 - [ ] Verify no other files reference `--no-local` in a durable artifact (grep `.claude/` `.agent/` for `no-local`)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-30 18:20 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-590/plan.md` at `f782fdf`
+**Branch**: feature/issue-590 at `f782fdf`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-590/progress.md
+++ b/.agent/work-plans/issue-590/progress.md
@@ -60,3 +60,17 @@ References to the default-on behavior found in knowledge files (all need updatin
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-30 18:24 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-590/plan.md` at `f782fdf`
+**PR**: PR-less
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (must-fix) `SKILL.md:799` rationale paragraph ("The specialist is default-on despite the noise…") not enumerated; bare `default-on` — step-5 `--no-local`-only grep won't catch it — `.claude/skills/review-code/SKILL.md:799`
+- [ ] (must-fix) `review_depth_classification.md:114` Deep-tier bullet ("Local Model Adversarial default-on") missing from the file's enumerated locations — file has 5 refs, not 4 — `.agent/knowledge/review_depth_classification.md:114`
+- [ ] (suggestion) Broaden step-5 straggler grep to also match `default-on`/`default on` (not just `--no-local`); also covers `SKILL.md:958` bare-wording comment — `.agent/work-plans/issue-590/plan.md:55`

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -8,9 +8,9 @@ description: Lead reviewer that orchestrates specialist sub-reviews (static anal
 ## Usage
 
 ```
-/review-code [--base <branch>] [--skip-static] [--no-progress] [--issue <N>] [--copilot] [--no-local] [light|standard|deep]
+/review-code [--base <branch>] [--skip-static] [--no-progress] [--issue <N>] [--copilot] [--local] [light|standard|deep]
                                             # pre-push: diff vs default branch
-/review-code <pr-number-or-url> [--skip-static] [--copilot] [--allow-untrusted-copilot] [--no-local] [light|standard|deep]
+/review-code <pr-number-or-url> [--skip-static] [--copilot] [--allow-untrusted-copilot] [--local] [light|standard|deep]
                                             # post-PR: diff vs PR base
 ```
 
@@ -42,15 +42,20 @@ Flags:
   in-house Claude adversarial passes (5d) provide the adversarial
   coverage. (`--no-copilot` is accepted as a deprecated no-op, since
   Copilot is already off by default.)
-- **`--no-local`** (both modes) opts out of the Local Model Adversarial
-  Specialist (5f). Local review is **on by default** — it costs no API
-  quota (local Ollama inference), but on current hardware it is the
-  long-pole specialist (~7 min per run; see
-  [#570](https://github.com/rolker/ros2_agent_workspace/issues/570)).
-  Pass `--no-local` for fast iteration loops or when the machine is
-  busy with inference-heavy work. When the Ollama server or the model
-  is unavailable, the specialist skips itself with a one-line notice —
-  no flag needed.
+- **`--local`** (both modes) opts in to the Local Model Adversarial
+  Specialist (5f). Local review is **off by default**: it costs no API
+  quota (local Ollama inference), but on current hardware it is by far
+  the long-pole specialist (~7 min per run, and a ~500-line diff can
+  exceed 10 min on 8GB-VRAM-class hardware — see
+  [#570](https://github.com/rolker/ros2_agent_workspace/issues/570) /
+  [#590](https://github.com/rolker/ros2_agent_workspace/issues/590)),
+  so the wall-clock cost is paid only when chosen. Pass `--local` when
+  a quota-free cross-model read is worth the wait — e.g. a high-stakes
+  diff, or to keep the offline field-mode reviewer exercised. When
+  opted in but the Ollama server or the model is unavailable, the
+  specialist skips itself with a one-line notice. (`--no-local` is
+  accepted as a deprecated no-op, since local review is already off by
+  default.)
 - **`--allow-untrusted-copilot`** (post-PR only) overrides the
   external-PR safety gate that suppresses Copilot Adversarial when the
   PR head is from a fork or a non-collaborator author. Only meaningful
@@ -95,9 +100,10 @@ post comments or modify the PR unless the user asks.
 
 Copilot Adversarial is **opt-in at every tier** via `--copilot` — when
 passed, it runs as an additional cross-model read on top of the
-in-house Claude passes. Local Model Adversarial is the inverse:
-**on by default at every tier** (local inference is quota-free) and
-opted out with `--no-local`.
+in-house Claude passes. Local Model Adversarial is likewise
+**opt-in at every tier** via `--local` — quota-free local inference,
+but the wall-clock long pole on current hardware
+([#590](https://github.com/rolker/ros2_agent_workspace/issues/590)).
 
 **Specialists**:
 - **Static Analysis** — runs linters with ament-aligned configs on
@@ -116,13 +122,15 @@ opted out with `--no-local`.
   second-vendor read. Off by default to avoid the per-run Premium
   request; skipped with a one-line notice when `copilot` is unavailable
   even if opted in.
-- **Local Model Adversarial** — **default-on** (`--no-local` to opt
-  out) cross-model read by a locally served Ollama model (default
-  `qwen3.5:35b`) via `.agent/scripts/local_review.sh`. Quota-free but
-  low-trust: validated at ~50% precision, so its findings need
-  corroboration or spot-checking before they reach must-fix (see 5f).
-  Skips itself with a one-line notice when the server or model is
-  unavailable.
+- **Local Model Adversarial** — **opt-in** (`--local`) cross-model
+  read by a locally served Ollama model (default `qwen3.5:35b`) via
+  `.agent/scripts/local_review.sh`. Quota-free but low-trust:
+  validated at ~50% precision, so its findings need corroboration or
+  spot-checking before they reach must-fix (see 5f). Off by default —
+  the run is the review's wall-clock long pole on current hardware
+  ([#590](https://github.com/rolker/ros2_agent_workspace/issues/590)).
+  Skips itself with a one-line notice when opted in but the server or
+  model is unavailable.
 
 ## Steps
 
@@ -142,9 +150,12 @@ classification step below as a stray argument),
 post-PR only — emit an error if passed in pre-push mode, where the
 gate doesn't apply; with `COPILOT` unset it has no effect, so emit a
 one-line note "`--allow-untrusted-copilot` ignored: no effect without
-`--copilot`" rather than silently dropping it), `--no-local` (sets
-`NO_LOCAL=1`, opts out of the Local Model Adversarial Specialist in
-step 5f — on by default), `--base <branch>`
+`--copilot`" rather than silently dropping it), `--local` (sets
+`LOCAL=1`, opts in to the Local Model Adversarial Specialist in
+step 5f — off by default), `--no-local` (**recognized and
+discarded**: a deprecated no-op since local review is already off by
+default — consume the token here so it never falls through to the
+classification step below as a stray argument), `--base <branch>`
 (sets `USER_BASE`), then the optional depth keyword (`light` /
 `standard` / `deep` — positional). Classify what remains:
 
@@ -165,7 +176,7 @@ syntax applies in both modes. Examples:
 /review-code --no-progress                  # pre-push, don't write progress.md
 /review-code --issue 460                    # pre-push, override branch-name issue extraction
 /review-code --copilot                      # pre-push, opt in to Copilot Adversarial
-/review-code --no-local                     # pre-push, opt out of Local Model Adversarial
+/review-code --local                        # pre-push, opt in to Local Model Adversarial
 /review-code 42                             # post-PR, auto-classify
 /review-code 42 standard                    # post-PR, force Standard
 /review-code 42 --skip-static               # post-PR, skip static analysis
@@ -341,8 +352,8 @@ Run:
 - **5d. Claude Adversarial Specialist** — **one pass** (Lens A only)
 - **5e. Copilot Adversarial Specialist** — only if `COPILOT=1`
   (`--copilot`); skipped with notice if `copilot` unavailable
-- **5f. Local Model Adversarial Specialist** — unless `NO_LOCAL=1`
-  (`--no-local`); skipped with notice if Ollama/model unavailable
+- **5f. Local Model Adversarial Specialist** — only if `LOCAL=1`
+  (`--local`); skipped with notice if Ollama/model unavailable
 
 #### Standard tier
 
@@ -354,8 +365,8 @@ Run all of:
   lenses (Lens A + Lens B; Standard prompt)
 - **5e. Copilot Adversarial Specialist** — only if `COPILOT=1`
   (`--copilot`); skipped with notice if `copilot` unavailable
-- **5f. Local Model Adversarial Specialist** — unless `NO_LOCAL=1`
-  (`--no-local`); skipped with notice if Ollama/model unavailable
+- **5f. Local Model Adversarial Specialist** — only if `LOCAL=1`
+  (`--local`); skipped with notice if Ollama/model unavailable
 
 #### Deep tier
 
@@ -363,9 +374,10 @@ Same as Standard, but the two **5d. Claude Adversarial** passes run with
 the Deep prompt (broader file horizon plus an explicit security /
 concurrency / lifecycle checklist). If opted in with `--copilot`,
 **5e. Copilot Adversarial** also runs with the Deep prompt as a third,
-cross-model read. **5f. Local Model Adversarial** runs as at other
-tiers (its prompt is not tier-differentiated — the diff is the whole
-horizon a local model can reliably handle).
+cross-model read. If opted in with `--local`, **5f. Local Model
+Adversarial** runs as at other tiers (its prompt is not
+tier-differentiated — the diff is the whole horizon a local model can
+reliably handle).
 
 ---
 
@@ -721,10 +733,10 @@ specialists.
 
 #### 5f. Local Model Adversarial Specialist
 
-**Activates by default at every tier**; opted out with `--no-local`
-(`NO_LOCAL=1`). When `NO_LOCAL=1`, skip the entire specialist and omit
-it from the report (like un-opted-in Copilot, absence is the requested
-state).
+**Opt-in at every tier** via `--local` (`LOCAL=1`); off by default
+([#590](https://github.com/rolker/ros2_agent_workspace/issues/590)).
+When `LOCAL` is unset, skip the entire specialist and omit it from the
+report (like un-opted-in Copilot, absence is the default state).
 
 A quota-free cross-model pass served by a **local Ollama model**
 (default `qwen3.5:35b`), dispatched through
@@ -796,10 +808,13 @@ speculative. Treat this source accordingly in step 6:
   or environments the code visibly does not target — those are its
   documented failure modes.
 
-The specialist is default-on despite the noise because the two real
-catches came at zero quota cost, and the same helper is the offline
-field-mode reviewer — keeping it exercised on every dev review keeps
-it trustworthy in the field.
+The specialist is opt-in
+([#590](https://github.com/rolker/ros2_agent_workspace/issues/590)):
+the real catches come at zero quota cost, but on current hardware the
+run is the review's wall-clock long pole, so that cost is paid only
+when a reviewer chooses it. The same helper remains the offline
+field-mode reviewer — opt in on a dev review periodically to keep it
+exercised and trustworthy in the field.
 
 ### 6. Apply silence filter
 
@@ -872,7 +887,7 @@ review indefinitely:
 **Static analysis**: <run | skipped (--skip-static)>
 **Claude Adversarial**: <1 pass (Lens A) | 2 passes (Lens A + Lens B)>
 **Copilot Adversarial**: <off (default) | run (--copilot) | skipped (<reason>, --copilot)>
-**Local Adversarial**: <run (<model>) | skipped (<reason>) | off (--no-local)>
+**Local Adversarial**: <off (default) | run (<model>, --local) | skipped (<reason>, --local)>
 **Context**: <status of review-context.yaml — fresh / stale / not found / N/A>
 
 ### Must-Fix
@@ -930,7 +945,7 @@ Existing Review Comments sections. Use:
 **Static analysis**: skipped (--skip-static)         <!-- include only when SKIP_STATIC=true -->
 **Claude Adversarial**: 1 pass (Lens A)
 **Copilot Adversarial**: <off (default) | run (--copilot) | skipped (<reason>, --copilot)>
-**Local Adversarial**: <run (<model>) | skipped (<reason>) | off (--no-local)>
+**Local Adversarial**: <off (default) | run (<model>, --local) | skipped (<reason>, --local)>
 
 ### Static Analysis
 
@@ -955,8 +970,8 @@ Existing Review Comments sections. Use:
 |---|------|------|---------|
 | 1 | `path` | 23 | Description (cross-model confirmed by <specialist> / uncorroborated — spot-checked) |
 
-<!-- Local Adversarial skipped: <reason>   (when default-on but Ollama/model unavailable or errored) -->
-<!-- Omitted entirely when opted out with --no-local. -->
+<!-- Local Adversarial skipped: <reason>   (when opted in but Ollama/model unavailable or errored) -->
+<!-- Omitted entirely by default, when --local was not passed. -->
 
 No governance concerns for a change of this scope.
 ```
@@ -975,7 +990,7 @@ since Claude Adversarial is now unconditional at Light.)
 **Review depth**: <tier> (reason: <signal>)
 **Static analysis**: skipped (--skip-static)         <!-- include only when SKIP_STATIC=true -->
 **Copilot Adversarial**: <run (--copilot) | skipped (<reason>, --copilot)>  <!-- include only when COPILOT=1; shows that an opted-in cross-model pass ran-clean vs. was skipped -->
-**Local Adversarial**: <run (<model>) | skipped (<reason>)>  <!-- omit only when --no-local; shows the default-on local pass ran-clean vs. was skipped -->
+**Local Adversarial**: <run (<model>) | skipped (<reason>)>  <!-- include only when LOCAL=1; shows that an opted-in local pass ran-clean vs. was skipped -->
 No issues found. LGTM.
 ```
 


### PR DESCRIPTION
## Summary

Flips the Local Model Adversarial Specialist (5f) in `/review-code` from default-on/opt-out (`--no-local`) to **default-off/opt-in (`--local`)**. On current hardware the local Ollama run (`qwen3.5:35b`) is the review's wall-clock long pole (~7+ min; a ~500-line diff can exceed 10 min on 8GB-VRAM-class hardware), so the cost is now paid only when a reviewer chooses it.

- `.claude/skills/review-code/SKILL.md` — usage lines, flag docs (hardware-speed rationale carried in the `--local` description), overview, argument parsing (`--local` sets `LOCAL=1`; `--no-local` becomes a recognized-and-discarded deprecated no-op, same pattern as `--no-copilot`), tier dispatch lists, section 5f including its closing rationale paragraph, and all report templates (`off (default)` wording).
- `.agent/knowledge/review_depth_classification.md` — all 5 tier/note references flipped.
- `.agent/knowledge/skill_workflows.md` — review-code summary flipped.
- `.agent/knowledge/inspiration_agent_workspace_digest.md` — historical note added parallel to the Copilot default-flip entry.
- `local_review.sh` is **unchanged** — it remains the standalone offline/field-mode review path.
- Plan synced with the review-plan findings (missed 5f rationale paragraph, 5th `review_depth_classification.md` reference, broadened straggler grep).

#585 (container-reachable Ollama) may revisit the default if local inference gets fast enough.

Closes #590

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
