### PR TITLE
docs(skills): repo-qualified re-orientation context in every run-issue checkpoint

### DIFF
--- a/.agent/work-plans/issue-592/progress.md
+++ b/.agent/work-plans/issue-592/progress.md
@@ -1,0 +1,22 @@
+---
+issue: 592
+---
+
+# Issue #592 — run-issue checkpoints: require repo-qualified re-orientation context in every AskUserQuestion
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-31 11:39 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: approved
+
+**Branch**: feature/issue-592 at `718498a`
+**Mode**: pre-push
+**Depth**: Standard (reason: `.claude/skills/*/SKILL.md` governance override trigger)
+**Must-fix**: 0 | **Suggestions**: 3
+**Round**: 1 | **Ship**: recommended — no must-fix; suggestions are mechanical and applied in-branch
+
+### Findings
+- [x] (suggestion) Pin "repo slug" to the GitHub repo name, not the local directory name (dir `project11` ≠ repo `ros2_agent_workspace`) — `.claude/skills/run-issue/SKILL.md:272` (fixed in-branch)
+- [x] (suggestion) triage-reviews inline header template paraphrases the canonical format (`<phase>` vs `phase X of Y (<phase name>)`) — drift seed, cross-confirmed by all 3 specialists — `.claude/skills/triage-reviews/SKILL.md:388` (fixed in-branch: matches canonical verbatim)
+- [ ] (suggestion) No mechanical enforcement layer for the header (ADR-0004/0005 Watch): a PreToolUse hook could assert the `<repo>#<N>` prefix — backlog note, not this PR — `.claude/skills/run-issue/SKILL.md:271`

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -170,7 +170,10 @@ variant, pass both (`--type` is repeatable).
 
 ## Decision table (the spine)
 
-Read the **last** progress.md entry; act per its type + verdict:
+Read the **last** progress.md entry; act per its type + verdict. Every row
+whose Checkpoint column fires asks via `AskUserQuestion` — and every such call
+must carry the repo-qualified re-orientation header defined in
+[Checkpoints](#checkpoints) below, no exceptions:
 
 | Last entry | Condition | Next action | Checkpoint |
 |---|---|---|---|
@@ -252,18 +255,25 @@ Use `AskUserQuestion` — **never block silently**. Mandatory checkpoints:
 4. **Before any push, PR creation, or merge** — local-first: the user confirms
    that work publishes.
 
-**Every checkpoint dialog must stand on its own.** An operator returning to a
-checkpoint — possibly after attending to another issue running concurrently —
-should be able to adjudicate it from the dialog alone, without scrolling back
-for the context that triggered it. Two requirements make that true, and **both
-apply to all four checkpoints above**:
+**Every checkpoint dialog must stand on its own.** The operator runs multiple
+agent sessions concurrently and jumps between them answering prompts and
+questions — that is the *normal* operating mode, not an occasional
+return-after-hours. Every checkpoint lands in front of someone who was just
+thinking about a different repo, so it must be adjudicable from the dialog
+alone, without scrolling back for the context that triggered it. Two
+requirements make that true, and **both apply to every `AskUserQuestion` this
+orchestrator asks** — all four checkpoints above, every round, including
+sessions resumed mid-lifecycle (re-read this section on resume; do not skip
+the header because "the operator was just here"):
 
 - **Re-orientation header** — every `AskUserQuestion` call must open its
   `question` text with a one-line header:
-  `Issue #N: <title> — phase X of Y; <one-line state>`. Put it in the
-  **`question` field, not the `header` field** — the `header` chip is capped at
-  ~12 chars and cannot hold it. This reloads the operator's context the moment
-  attention returns.
+  `<repo>#<N> (PR #M): <issue title> — phase X of Y (<phase name>); <one-line state>`.
+  The **repo slug is mandatory** — issue and PR numbers collide across project
+  repos, so a bare `#24` is ambiguous by construction; include `(PR #M)`
+  whenever a PR exists. Put it in the **`question` field, not the `header`
+  field** — the `header` chip is capped at ~12 chars and cannot hold it. This
+  reloads the operator's context the moment attention returns.
 - **Finding-embedding** — when a checkpoint is triggered by a review entry's
   findings or open questions (`## Issue Review` open-question actions → checkpoint
   1; `## Plan Review` → checkpoint 2; `## Integrated Review` → checkpoint 3; and
@@ -276,9 +286,10 @@ apply to all four checkpoints above**:
 Worked example — checkpoint 3, triggered by an `## Integrated Review` must-fix:
 
 ```
-question: "Issue #466: Recover from GPS dropout — phase 6 of 7; Integrated
-           Review found 1 must-fix. [HIGH] stale fix published when RTK age
-           > 2s (nav_node.cpp:212). How should I proceed?"
+question: "project11_navigation#466 (PR #467): Recover from GPS dropout —
+           phase 6 of 7 (triage-reviews); Integrated Review found 1 must-fix.
+           [HIGH] stale fix published when RTK age > 2s (nav_node.cpp:212).
+           How should I proceed?"
 options:
   - label:       "Fix via address-findings"
     description: "Dispatch address-findings to gate publishing on RTK age —

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -271,7 +271,9 @@ the header because "the operator was just here"):
   `<repo>#<N> (PR #M): <issue title> — phase X of Y (<phase name>); <one-line state>`.
   The **repo slug is mandatory** — issue and PR numbers collide across project
   repos, so a bare `#24` is ambiguous by construction; include `(PR #M)`
-  whenever a PR exists. Put it in the **`question` field, not the `header`
+  whenever a PR exists. The slug is the **GitHub repo name** (`gh repo view
+  --json name`), not the local directory name — they can differ (e.g., dir
+  `project11` = repo `ros2_agent_workspace`). Put it in the **`question` field, not the `header`
   field** — the `header` chip is capped at ~12 chars and cannot hold it. This
   reloads the operator's context the moment attention returns.
 - **Finding-embedding** — when a checkpoint is triggered by a review entry's

--- a/.claude/skills/run-issue/SKILL.md
+++ b/.claude/skills/run-issue/SKILL.md
@@ -272,8 +272,8 @@ the header because "the operator was just here"):
   The **repo slug is mandatory** — issue and PR numbers collide across project
   repos, so a bare `#24` is ambiguous by construction; include `(PR #M)`
   whenever a PR exists. The slug is the **GitHub repo name** (`gh repo view
-  --json name`), not the local directory name — they can differ (e.g., dir
-  `project11` = repo `ros2_agent_workspace`). Put it in the **`question` field, not the `header`
+  --json name --jq .name`), not the local directory name — they can differ
+  (e.g., dir `project11` = repo `ros2_agent_workspace`). Put it in the **`question` field, not the `header`
   field** — the `header` chip is capped at ~12 chars and cannot hold it. This
   reloads the operator's context the moment attention returns.
 - **Finding-embedding** — when a checkpoint is triggered by a review entry's

--- a/.claude/skills/triage-reviews/SKILL.md
+++ b/.claude/skills/triage-reviews/SKILL.md
@@ -382,6 +382,14 @@ orchestrator (`/run-issue`,
 last `## Integrated Review` entry and drives the next phase, pausing at user
 checkpoints.
 
+**Checkpoint context:** whoever asks the resulting fix-vs-defer question (the
+`/run-issue` host, or a hand-driven session) must open the `AskUserQuestion`
+`question` text with the full re-orientation header —
+`<repo>#<N> (PR #M): <issue title> — <phase>; <one-line state>` — per
+run-issue § Checkpoints. The operator juggles concurrent sessions across
+repos; a question like "how should we handle the four open findings on
+PR #25?" is unanswerable without the repo, issue, and work context.
+
 ## Guidelines
 
 - **Triage, don't fix** — output the classified plan in the conversation. The user

--- a/.claude/skills/triage-reviews/SKILL.md
+++ b/.claude/skills/triage-reviews/SKILL.md
@@ -385,8 +385,8 @@ checkpoints.
 **Checkpoint context:** whoever asks the resulting fix-vs-defer question (the
 `/run-issue` host, or a hand-driven session) must open the `AskUserQuestion`
 `question` text with the full re-orientation header —
-`<repo>#<N> (PR #M): <issue title> — <phase>; <one-line state>` — per
-run-issue § Checkpoints. The operator juggles concurrent sessions across
+`<repo>#<N> (PR #M): <issue title> — phase X of Y (<phase name>); <one-line state>`
+— per run-issue § Checkpoints (the single source for the format). The operator juggles concurrent sessions across
 repos; a question like "how should we handle the four open findings on
 PR #25?" is unanswerable without the repo, issue, and work context.
 


### PR DESCRIPTION
## Summary

Checkpoint dialogs from `/run-issue` were landing without the context needed
to adjudicate them ("How should we handle the four open findings on PR #25?"
— which repo? which issue? what work?). The operator runs multiple agent
sessions concurrently and tab-jumps between them, so **every**
`AskUserQuestion` must stand on its own.

- **run-issue § Checkpoints**: the required re-orientation header is now
  repo-qualified — `<repo>#<N> (PR #M): <issue title> — phase X of Y
  (<phase name>); <one-line state>`. The repo slug (GitHub repo name, not
  the local directory name) is mandatory: issue/PR numbers collide across
  project repos. Rationale reframed around concurrent-session tab-switching
  as the normal operating mode; point-of-use reminder added at the decision
  table; worked example updated.
- **triage-reviews**: defense-in-depth "Checkpoint context" paragraph
  quoting the canonical header verbatim — covers hand-driven sessions that
  never load run-issue.

## Review

Pre-push `/review-code --no-local`, Standard tier (skill-file governance
trigger). Round 1: 0 must-fix, 3 suggestions — 2 applied in-branch
(slug = GitHub repo name; single-source the format), 1 noted as backlog
(a PreToolUse hook asserting the `<repo>#<N>` prefix — mechanical
enforcement layer per ADR-0004/0005). Ship: recommended. See
`.agent/work-plans/issue-592/progress.md`.

Closes #592

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
